### PR TITLE
Refactor files that have provided URLs

### DIFF
--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -81,7 +81,7 @@ pycross_lock_file(
         ":python_linux_x86_64",
     ],
     remote_wheels = {
-        "https://files.pythonhosted.org/packages/3.7/x/xmltodict/xmltodict-0.12.0-py2.py3-none-any.whl": "8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051",
+        "https://files.pythonhosted.org/packages/94/db/fd0326e331726f07ff7f40675cd86aa804bfd2e5016c727fa761c934990e/xmltodict-0.13.0-py2.py3-none-any.whl": "aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852",
     },
     local_wheels = [
         "//wheels",

--- a/example/example_lock.bzl
+++ b/example/example_lock.bzl
@@ -1855,13 +1855,13 @@ def repositories():
     )
 
     maybe(
-        pypi_file,
+        http_file,
         name = "example_lock_wheel_xmltodict_0.13.0_py2.py3_none_any",
-        package_name = "xmltodict",
-        package_version = "0.13.0",
-        filename = "xmltodict-0.13.0-py2.py3-none-any.whl",
+        urls = [
+            "https://files.pythonhosted.org/packages/94/db/fd0326e331726f07ff7f40675cd86aa804bfd2e5016c727fa761c934990e/xmltodict-0.13.0-py2.py3-none-any.whl"
+        ],
         sha256 = "aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852",
-        index = "https://pypi.org",
+        downloaded_file_path = "xmltodict-0.13.0-py2.py3-none-any.whl",
     )
 
     maybe(

--- a/pycross/private/tools/bzl_lock_generator.py
+++ b/pycross/private/tools/bzl_lock_generator.py
@@ -500,7 +500,10 @@ class PackageTarget:
 
 class UrlRepoTarget:
     def __init__(self, name: str, file: PackageFile):
-        assert(file.urls, "UrlWheelRepoTarget requires a PackageFile with one or more URLs")
+        assert (
+            file.urls,
+            "UrlWheelRepoTarget requires a PackageFile with one or more URLs",
+        )
         self.name = name
         self.file = file
 
@@ -634,9 +637,7 @@ def main():
     for remote_wheel in args.remote_wheel or []:
         url, sha256 = remote_wheel
         filename = url_wheel_name(url)
-        remote_wheels[filename] = PackageFile(
-            name=filename, sha256=sha256, urls=(url,)
-        )
+        remote_wheels[filename] = PackageFile(name=filename, sha256=sha256, urls=(url,))
 
     naming = Naming(
         repo_prefix=args.repo_prefix,
@@ -766,9 +767,7 @@ def main():
                 repos.append(UrlRepoTarget(name, file))
             else:
                 repos.append(
-                    PypiFileRepoTarget(
-                        name, package_target.package, file, pypi_index
-                    )
+                    PypiFileRepoTarget(name, package_target.package, file, pypi_index)
                 )
 
     repos.sort(key=lambda ft: ft.name)

--- a/pycross/private/tools/lock_model.py
+++ b/pycross/private/tools/lock_model.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import Optional
+from typing import Tuple
+
 import json
 from dataclasses import dataclass
 from json import JSONEncoder
@@ -24,6 +27,7 @@ class _VersionHandlingEncoder(JSONEncoder):
 class PackageFile:
     name: str
     sha256: str
+    urls: Optional[Tuple[str]] = None
 
     def __post_init__(self):
         assert self.name, "The name field must be specified."
@@ -32,6 +36,10 @@ class PackageFile:
     @property
     def is_wheel(self) -> bool:
         return is_wheel(self.name)
+
+    @property
+    def is_sdist(self) -> bool:
+        return not self.is_wheel
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Adds an optional urls list to PackageFile and removes the UrlFile
wrapper. If a PackageFile has urls - whether wheel or sdist - http_file
will be used to fetch it rather than pypi_file.
