### PR TITLE
Correctly add transitive deps when building a wheel

### DIFF
--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -377,6 +377,17 @@ def build_wheel(
         cmd = list(cmd)
         cmd.insert(1, "-I")
 
+        if debug:
+            try:
+                site = subprocess.check_output(
+                    [cmd[0], "-I", "-m", "site"], cwd=cwd, env=env, stderr=subprocess.STDOUT
+                )
+                print("===== BUILD SITE =====", file=sys.stdout)
+                print(site.decode(), file=sys.stdout)
+            except subprocess.CalledProcessError as cpe:
+                print("Warning: failed to collect site output", file=sys.stderr)
+                print(cpe.output.decode(), file=sys.stderr)
+
         try:
             output = subprocess.check_output(
                 cmd, cwd=cwd, env=env, stderr=subprocess.STDOUT
@@ -387,7 +398,7 @@ def build_wheel(
             raise
 
         if debug:
-            print(output.decode(), file=sys.stderr)
+            print(output.decode(), file=sys.stdout)
 
     builder = ProjectBuilder(
         srcdir=sdist_dir,

--- a/pycross/private/wheel_build.bzl
+++ b/pycross/private/wheel_build.bzl
@@ -84,7 +84,6 @@ def _pycross_wheel_build_impl(ctx):
             ctx.attr.target_environment[PycrossTargetEnvironmentInfo].file.path,
         ])
 
-
     imports = depset(
         transitive = [d[PyInfo].imports for d in ctx.attr.deps],
     )
@@ -137,6 +136,8 @@ def _pycross_wheel_build_impl(ctx):
         cc_sysconfig_data,
     ] + ctx.files.deps
 
+    transitive_sources = [dep[PyInfo].transitive_sources for dep in ctx.attr.deps if PyInfo in dep]
+
     if ctx.attr.target_environment:
         deps.append(ctx.attr.target_environment[PycrossTargetEnvironmentInfo].file)
 
@@ -150,7 +151,7 @@ def _pycross_wheel_build_impl(ctx):
     env.update(ctx.configuration.default_shell_env)
 
     ctx.actions.run(
-        inputs = depset(deps, transitive = toolchain_deps),
+        inputs = depset(deps, transitive = toolchain_deps + transitive_sources),
         outputs = [out_wheel, out_name],
         executable = ctx.executable._tool,
         use_default_shell_env = False,

--- a/pycross/private/wheel_library.bzl
+++ b/pycross/private/wheel_library.bzl
@@ -74,7 +74,7 @@ def _pycross_wheel_library_impl(ctx):
     )
     transitive_sources = depset(
         direct = [out],
-        transitive = [d[PyInfo].transitive_sources for d in ctx.attr.deps],
+        transitive = [dep[PyInfo].transitive_sources for dep in ctx.attr.deps if PyInfo in dep],
     )
     runfiles = ctx.runfiles(files = [out])
     for d in ctx.attr.deps:

--- a/pycross/private/wheel_library.bzl
+++ b/pycross/private/wheel_library.bzl
@@ -90,6 +90,7 @@ def _pycross_wheel_library_impl(ctx):
             has_py3_only_sources = has_py3_only_sources,
             imports = imports,
             transitive_sources = transitive_sources,
+            uses_shared_libraries = True,  # Docs say this is unused
         ),
     ]
 


### PR DESCRIPTION
Previously we were including transitive packages (`PyInfo.imports`) in the list of build dependencies, but they weren't being added to the Bazel sandbox.

Also, if debug mode is enabled (`RULES_PYCROSS_DEBUG=1`), we run `python -m site` prior to the build to show the site configuration.