### PR TITLE
Make pycross_wheel_build compatible with --experimental_sibling_repository_layout

### DIFF
--- a/examples/pdm/.bazelrc
+++ b/examples/pdm/.bazelrc
@@ -2,6 +2,7 @@
 build --incompatible_enable_cc_toolchain_resolution
 build --incompatible_strict_action_env
 build --nolegacy_external_runfiles
+build --experimental_sibling_repository_layout
 
 # This causes pycross_wheel_build to print output and retain its temp directory
 build --action_env=RULES_PYCROSS_DEBUG=1


### PR DESCRIPTION
With `--experimental_sibling_repository_layout` enabled, our assumptions about build dependency import paths were broken.