### PR TITLE
Experimental wheel cross-compilation

### DIFF
--- a/examples/crossenv/.bazelrc
+++ b/examples/crossenv/.bazelrc
@@ -1,0 +1,7 @@
+#build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build --incompatible_enable_cc_toolchain_resolution
+build --incompatible_strict_action_env
+build --nolegacy_external_runfiles
+
+# This causes pycross_wheel_build to print output and retain its temp directory
+build --action_env=RULES_PYCROSS_DEBUG=1

--- a/examples/crossenv/.bazelversion
+++ b/examples/crossenv/.bazelversion
@@ -1,4 +1,4 @@
-5.3.2
+6.0.0rc4
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/examples/crossenv/BUILD.bazel
+++ b/examples/crossenv/BUILD.bazel
@@ -74,6 +74,66 @@ pycross_target_environment(
     visibility = ["//visibility:public"],
 )
 
+pycross_hermetic_toolchain(
+    name = "pycross_darwin_linux",
+    exec_interpreter = "@python3_9_x86_64-apple-darwin//:py3_runtime",
+    target_environment = ":python_linux_x86_64",
+    target_interpreter = "@python3_9_x86_64-unknown-linux-gnu//:py3_runtime",
+)
+
+toolchain(
+    name = "pycross_darwin_linux_tc",
+    exec_compatible_with = _darwin_x86_64,
+    target_compatible_with = _linux_x86_64,
+    toolchain = ":pycross_darwin_linux",
+    toolchain_type = "@jvolkman_rules_pycross//pycross:toolchain_type",
+)
+
+pycross_hermetic_toolchain(
+    name = "pycross_darwin_darwin",
+    exec_interpreter = "@python3_9_x86_64-apple-darwin//:py3_runtime",
+    target_environment = ":python_darwin_x86_64",
+    target_interpreter = "@python3_9_x86_64-apple-darwin//:py3_runtime",
+)
+
+toolchain(
+    name = "pycross_darwin_darwin_tc",
+    exec_compatible_with = _darwin_x86_64,
+    target_compatible_with = _darwin_x86_64,
+    toolchain = ":pycross_darwin_darwin",
+    toolchain_type = "@jvolkman_rules_pycross//pycross:toolchain_type",
+)
+
+pycross_hermetic_toolchain(
+    name = "pycross_linux_linux",
+    exec_interpreter = "@python3_9_x86_64-unknown-linux-gnu//:py3_runtime",
+    target_environment = ":python_linux_x86_64",
+    target_interpreter = "@python3_9_x86_64-unknown-linux-gnu//:py3_runtime",
+)
+
+toolchain(
+    name = "pycross_linux_linux_tc",
+    exec_compatible_with = _linux_x86_64,
+    target_compatible_with = _linux_x86_64,
+    toolchain = ":pycross_linux_linux",
+    toolchain_type = "@jvolkman_rules_pycross//pycross:toolchain_type",
+)
+
+pycross_hermetic_toolchain(
+    name = "pycross_linux_darwin",
+    exec_interpreter = "@python3_9_x86_64-unknown-linux-gnu//:py3_runtime",
+    target_environment = ":python_darwin_x86_64",
+    target_interpreter = "@python3_9_x86_64-apple-darwin//:py3_runtime",
+)
+
+toolchain(
+    name = "pycross_linux_darwin_tc",
+    exec_compatible_with = _linux_x86_64,
+    target_compatible_with = _darwin_x86_64,
+    toolchain = ":pycross_linux_darwin",
+    toolchain_type = "@jvolkman_rules_pycross//pycross:toolchain_type",
+)
+
 pycross_poetry_lock_model(
     name = "example_lock_model",
     poetry_lock_file = "poetry.lock",

--- a/examples/crossenv/README.md
+++ b/examples/crossenv/README.md
@@ -1,0 +1,9 @@
+# Example
+
+This example makes use of *very* experimental support for Python cross-compilation.
+It's likely to fail in most cases, but can build simple wheels with native code.
+
+For example: if running on MacOS, you can build a Linux wheel like:
+```
+bazel build //deps:setproctitle --platforms //:linux_x86_64
+```

--- a/examples/crossenv/WORKSPACE
+++ b/examples/crossenv/WORKSPACE
@@ -1,0 +1,93 @@
+workspace(
+    name = "jvolkman_rules_pycross_example",
+)
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_python",
+    sha256 = "8c8fe44ef0a9afc256d1e75ad5f448bb59b81aba149b8958f02f7b3a98f5d9b4",
+    strip_prefix = "rules_python-0.13.0",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.13.0.tar.gz",
+)
+
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+
+python_register_toolchains(
+    name = "python3_9",
+    # Available versions are listed in @rules_python//python:versions.bzl.
+    # We recommend using the same version your team is already standardized on.
+    python_version = "3.9",
+)
+
+load("@python3_9//:defs.bzl", "interpreter")
+
+local_repository(
+    name = "jvolkman_rules_pycross",
+    path = "../..",
+)
+
+load("@jvolkman_rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
+
+rules_pycross_dependencies(python_interpreter_target = interpreter)
+
+load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_lock_repo")
+
+pycross_lock_repo(
+    name = "example_lock_repo",
+    lock_file = "//:example_lock.bzl",
+)
+
+load("@example_lock_repo//:requirements.bzl", "install_deps")
+
+install_deps()
+
+# Setup a CC toolchain using bazel-zig-cc
+# https://git.sr.ht/~motiejus/bazel-zig-cc
+BAZEL_ZIG_CC_VERSION = "v0.7.3"
+
+http_archive(
+    name = "bazel-zig-cc",
+    sha256 = "cd2629843fe4ba20cf29e1d73cc02559afba640f884e519b6a194a35627cbbf3",
+    strip_prefix = "bazel-zig-cc-{}".format(BAZEL_ZIG_CC_VERSION),
+    urls = ["https://git.sr.ht/~motiejus/bazel-zig-cc/archive/{}.tar.gz".format(BAZEL_ZIG_CC_VERSION)],
+)
+
+load(
+    "@bazel-zig-cc//toolchain:defs.bzl",
+    "URL_FORMAT_JAKSTYS",
+    "URL_FORMAT_NIGHTLY",
+    zig_toolchains = "toolchains",
+)
+
+zig_version = "0.10.0-dev.2156+458943e32"
+
+zig_host_platform_sha256 = {
+    "linux-aarch64": "43e55632c61833a598aff3dcb134a7967c19eddc6abd28273bb60585bbbf34af",
+    "linux-x86_64": "c22f4453ac45256d865defad05bfe0e42c6b73f15dc007e87fdae42f44933485",
+    "macos-aarch64": "f786a0d6674f9ec267eb1715de1b6265faedfdfdc7d4d05dedc534644e12224d",
+    "macos-x86_64": "7dffe1c995da9145872ae806d770cd2acc38993d3d32aabdece7107177853730",
+}
+
+zig_toolchains(
+    host_platform_sha256 = zig_host_platform_sha256,
+    url_formats = [
+        URL_FORMAT_NIGHTLY,
+        URL_FORMAT_JAKSTYS,
+    ],
+    version = zig_version,
+)
+
+register_toolchains(
+    "@zig_sdk//toolchain:linux_amd64_gnu.2.19",
+    "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
+    "@zig_sdk//toolchain:darwin_amd64",
+    "@zig_sdk//toolchain:darwin_arm64",
+)
+
+register_toolchains(
+    "//:pycross_darwin_linux_tc",
+    "//:pycross_darwin_darwin_tc",
+    "//:pycross_linux_linux_tc",
+    "//:pycross_linux_darwin_tc",
+)

--- a/examples/crossenv/deps/BUILD.bazel
+++ b/examples/crossenv/deps/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build")
+load("//:example_lock.bzl", "targets")
+
+package(default_visibility = ["//visibility:public"])
+
+# Specified here as an override.
+pycross_wheel_build(
+    name = "overridden_future_0.18.2",
+    sdist = "@example_lock_sdist_future_0.18.2//file",
+    deps = [
+        "//deps:setuptools",
+        "//deps:wheel",
+    ],
+    tags = ["manual"],
+)
+
+targets()

--- a/examples/crossenv/example_lock.bzl
+++ b/examples/crossenv/example_lock.bzl
@@ -1,0 +1,2098 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library", "pypi_file")
+
+PINS = {
+    "appnope": "appnope_0.1.3",
+    "asttokens": "asttokens_2.0.8",
+    "attrs": "attrs_22.1.0",
+    "aws_sam_translator": "aws_sam_translator_1.51.0",
+    "aws_xray_sdk": "aws_xray_sdk_2.10.0",
+    "backcall": "backcall_0.2.0",
+    "boto3": "boto3_1.24.73",
+    "botocore": "botocore_1.27.73",
+    "certifi": "certifi_2022.9.14",
+    "cffi": "cffi_1.15.1",
+    "cfn_lint": "cfn_lint_0.65.0",
+    "charset_normalizer": "charset_normalizer_2.1.1",
+    "click": "click_8.1.3",
+    "cognitojwt": "cognitojwt_1.4.1",
+    "cryptography": "cryptography_38.0.1",
+    "cython": "cython_0.29.32",
+    "decorator": "decorator_5.1.1",
+    "docker": "docker_6.0.0",
+    "ecdsa": "ecdsa_0.18.0",
+    "executing": "executing_1.0.0",
+    "flask": "flask_2.2.2",
+    "flask_cors": "flask_cors_3.0.10",
+    "future": "future_0.18.2",
+    "graphql_core": "graphql_core_3.2.1",
+    "greenlet": "greenlet_1.1.3",
+    "idna": "idna_3.4",
+    "importlib_metadata": "importlib_metadata_4.12.0",
+    "ipython": "ipython_8.5.0",
+    "itsdangerous": "itsdangerous_2.1.2",
+    "jaraco_classes": "jaraco_classes_3.2.2",
+    "jedi": "jedi_0.18.1",
+    "jeepney": "jeepney_0.8.0",
+    "jinja2": "jinja2_3.1.2",
+    "jmespath": "jmespath_1.0.1",
+    "jschema_to_python": "jschema_to_python_1.2.3",
+    "jsondiff": "jsondiff_2.0.0",
+    "jsonpatch": "jsonpatch_1.32",
+    "jsonpickle": "jsonpickle_2.2.0",
+    "jsonpointer": "jsonpointer_2.3",
+    "jsonschema": "jsonschema_3.2.0",
+    "junit_xml": "junit_xml_1.9",
+    "keyring": "keyring_23.9.1",
+    "markupsafe": "markupsafe_2.1.1",
+    "matplotlib_inline": "matplotlib_inline_0.1.6",
+    "more_itertools": "more_itertools_8.14.0",
+    "moto": "moto_3.1.1",
+    "networkx": "networkx_2.8.6",
+    "numpy": "numpy_1.22.3",
+    "opencv_python": "opencv_python_4.6.0.66",
+    "packaging": "packaging_21.3",
+    "parso": "parso_0.8.3",
+    "pbr": "pbr_5.10.0",
+    "pexpect": "pexpect_4.8.0",
+    "pickleshare": "pickleshare_0.7.5",
+    "prompt_toolkit": "prompt_toolkit_3.0.31",
+    "ptyprocess": "ptyprocess_0.7.0",
+    "pure_eval": "pure_eval_0.2.2",
+    "pyasn1": "pyasn1_0.4.8",
+    "pycparser": "pycparser_2.21",
+    "pygments": "pygments_2.13.0",
+    "pyparsing": "pyparsing_3.0.9",
+    "pyrsistent": "pyrsistent_0.18.1",
+    "python_dateutil": "python_dateutil_2.8.2",
+    "python_jose": "python_jose_3.1.0",
+    "pytz": "pytz_2022.2.1",
+    "pyyaml": "pyyaml_6.0",
+    "requests": "requests_2.28.1",
+    "responses": "responses_0.21.0",
+    "rsa": "rsa_4.9",
+    "s3transfer": "s3transfer_0.6.0",
+    "sarif_om": "sarif_om_1.0.4",
+    "secretstorage": "secretstorage_3.3.3",
+    "setproctitle": "setproctitle_1.2.2",
+    "setuptools": "setuptools_59.2.0",
+    "six": "six_1.16.0",
+    "sqlalchemy": "sqlalchemy_1.4.41",
+    "sqlalchemy_utils": "sqlalchemy_utils_0.38.2",
+    "sshpubkeys": "sshpubkeys_3.3.1",
+    "stack_data": "stack_data_0.5.0",
+    "traitlets": "traitlets_5.4.0",
+    "tree_sitter": "tree_sitter_0.20.0",
+    "urllib3": "urllib3_1.26.12",
+    "wcwidth": "wcwidth_0.2.5",
+    "websocket_client": "websocket_client_1.4.1",
+    "werkzeug": "werkzeug_2.2.2",
+    "wheel": "wheel_0.37.0",
+    "wrapt": "wrapt_1.14.1",
+    "xmltodict": "xmltodict_0.13.0",
+    "zipp": "zipp_3.8.1",
+}
+
+def targets():
+    for pin_name, pin_target in PINS.items():
+        native.alias(
+            name = pin_name,
+            actual = ":" + pin_target,
+        )
+
+    native.config_setting(
+        name = "_env_python_darwin_arm64",
+        constraint_values = [
+            "@platforms//os:osx",
+            "@platforms//cpu:arm64",
+        ],
+    )
+
+    native.config_setting(
+        name = "_env_python_darwin_x86_64",
+        constraint_values = [
+            "@platforms//os:osx",
+            "@platforms//cpu:x86_64",
+        ],
+    )
+
+    native.config_setting(
+        name = "_env_python_linux_x86_64",
+        constraint_values = [
+            "@platforms//os:linux",
+            "@platforms//cpu:x86_64",
+        ],
+    )
+
+    _target = select({
+        ":_env_python_darwin_arm64": "@//:python_darwin_arm64",
+        ":_env_python_darwin_x86_64": "@//:python_darwin_x86_64",
+        ":_env_python_linux_x86_64": "@//:python_linux_x86_64",
+    })
+
+    pycross_wheel_library(
+        name = "appnope_0.1.3",
+        wheel = "@example_lock_wheel_appnope_0.1.3_py2.py3_none_any//file",
+    )
+
+    _asttokens_2_0_8_deps = [
+        ":six_1.16.0",
+    ]
+
+    pycross_wheel_library(
+        name = "asttokens_2.0.8",
+        deps = _asttokens_2_0_8_deps,
+        wheel = "@example_lock_wheel_asttokens_2.0.8_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "attrs_22.1.0",
+        wheel = "@example_lock_wheel_attrs_22.1.0_py2.py3_none_any//file",
+    )
+
+    _aws_sam_translator_1_51_0_deps = [
+        ":boto3_1.24.73",
+        ":jsonschema_3.2.0",
+    ]
+
+    pycross_wheel_library(
+        name = "aws_sam_translator_1.51.0",
+        deps = _aws_sam_translator_1_51_0_deps,
+        wheel = "@example_lock_wheel_aws_sam_translator_1.51.0_py3_none_any//file",
+    )
+
+    _aws_xray_sdk_2_10_0_deps = [
+        ":botocore_1.27.73",
+        ":wrapt_1.14.1",
+    ]
+
+    pycross_wheel_library(
+        name = "aws_xray_sdk_2.10.0",
+        deps = _aws_xray_sdk_2_10_0_deps,
+        wheel = "@example_lock_wheel_aws_xray_sdk_2.10.0_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "backcall_0.2.0",
+        wheel = "@example_lock_wheel_backcall_0.2.0_py2.py3_none_any//file",
+    )
+
+    _boto3_1_24_73_deps = [
+        ":botocore_1.27.73",
+        ":jmespath_1.0.1",
+        ":s3transfer_0.6.0",
+    ]
+
+    pycross_wheel_library(
+        name = "boto3_1.24.73",
+        deps = _boto3_1_24_73_deps,
+        wheel = "@example_lock_wheel_boto3_1.24.73_py3_none_any//file",
+    )
+
+    _botocore_1_27_73_deps = [
+        ":jmespath_1.0.1",
+        ":python_dateutil_2.8.2",
+        ":urllib3_1.26.12",
+    ]
+
+    pycross_wheel_library(
+        name = "botocore_1.27.73",
+        deps = _botocore_1_27_73_deps,
+        wheel = "@example_lock_wheel_botocore_1.27.73_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "certifi_2022.9.14",
+        wheel = "@example_lock_wheel_certifi_2022.9.14_py3_none_any//file",
+    )
+
+    _cffi_1_15_1_deps = [
+        ":pycparser_2.21",
+    ]
+
+    pycross_wheel_library(
+        name = "cffi_1.15.1",
+        deps = _cffi_1_15_1_deps,
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_cffi_1.15.1_cp39_cp39_macosx_11_0_arm64//file",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_cffi_1.15.1_cp39_cp39_macosx_10_9_x86_64//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_cffi_1.15.1_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+        }),
+    )
+
+    _cfn_lint_0_65_0_deps = [
+        ":aws_sam_translator_1.51.0",
+        ":jschema_to_python_1.2.3",
+        ":jsonpatch_1.32",
+        ":jsonschema_3.2.0",
+        ":junit_xml_1.9",
+        ":networkx_2.8.6",
+        ":pyyaml_6.0",
+        ":sarif_om_1.0.4",
+    ]
+
+    pycross_wheel_library(
+        name = "cfn_lint_0.65.0",
+        deps = _cfn_lint_0_65_0_deps,
+        wheel = "@example_lock_wheel_cfn_lint_0.65.0_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "charset_normalizer_2.1.1",
+        wheel = "@example_lock_wheel_charset_normalizer_2.1.1_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "click_8.1.3",
+        wheel = "@example_lock_wheel_click_8.1.3_py3_none_any//file",
+    )
+
+    _cognitojwt_1_4_1_deps = [
+        ":python_jose_3.1.0",
+    ]
+
+    pycross_wheel_library(
+        name = "cognitojwt_1.4.1",
+        deps = _cognitojwt_1_4_1_deps,
+        wheel = "@example_lock_wheel_cognitojwt_1.4.1_py3_none_any//file",
+    )
+
+    _cryptography_38_0_1_deps = [
+        ":cffi_1.15.1",
+    ]
+
+    pycross_wheel_library(
+        name = "cryptography_38.0.1",
+        deps = _cryptography_38_0_1_deps,
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_cryptography_38.0.1_cp36_abi3_macosx_10_10_universal2//file",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_cryptography_38.0.1_cp36_abi3_macosx_10_10_x86_64//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_cryptography_38.0.1_cp36_abi3_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+        }),
+    )
+
+    pycross_wheel_library(
+        name = "cython_0.29.32",
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_cython_0.29.32_py2.py3_none_any//file",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_cython_0.29.32_py2.py3_none_any//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_cython_0.29.32_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64//file",
+        }),
+    )
+
+    pycross_wheel_library(
+        name = "decorator_5.1.1",
+        wheel = "@example_lock_wheel_decorator_5.1.1_py3_none_any//file",
+    )
+
+    _docker_6_0_0_deps = [
+        ":packaging_21.3",
+        ":requests_2.28.1",
+        ":urllib3_1.26.12",
+        ":websocket_client_1.4.1",
+    ]
+
+    pycross_wheel_library(
+        name = "docker_6.0.0",
+        deps = _docker_6_0_0_deps,
+        wheel = "@example_lock_wheel_docker_6.0.0_py3_none_any//file",
+    )
+
+    _ecdsa_0_18_0_deps = [
+        ":six_1.16.0",
+    ]
+
+    pycross_wheel_library(
+        name = "ecdsa_0.18.0",
+        deps = _ecdsa_0_18_0_deps,
+        wheel = "@example_lock_wheel_ecdsa_0.18.0_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "executing_1.0.0",
+        wheel = "@example_lock_wheel_executing_1.0.0_py2.py3_none_any//file",
+    )
+
+    _flask_2_2_2_deps = [
+        ":click_8.1.3",
+        ":importlib_metadata_4.12.0",
+        ":itsdangerous_2.1.2",
+        ":jinja2_3.1.2",
+        ":werkzeug_2.2.2",
+    ]
+
+    pycross_wheel_library(
+        name = "flask_2.2.2",
+        deps = _flask_2_2_2_deps,
+        wheel = "@example_lock_wheel_flask_2.2.2_py3_none_any//file",
+    )
+
+    _flask_cors_3_0_10_deps = [
+        ":flask_2.2.2",
+        ":six_1.16.0",
+    ]
+
+    pycross_wheel_library(
+        name = "flask_cors_3.0.10",
+        deps = _flask_cors_3_0_10_deps,
+        wheel = "@example_lock_wheel_flask_cors_3.0.10_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "future_0.18.2",
+        wheel = "@//deps:overridden_future_0.18.2",
+    )
+
+    pycross_wheel_library(
+        name = "graphql_core_3.2.1",
+        wheel = "@example_lock_wheel_graphql_core_3.2.1_py3_none_any//file",
+    )
+
+    _greenlet_1_1_3_build_deps = [
+        ":setuptools_59.2.0",
+        ":wheel_0.37.0",
+    ]
+
+    pycross_wheel_build(
+        name = "_build_greenlet_1.1.3",
+        sdist = "@example_lock_sdist_greenlet_1.1.3//file",
+        target_environment = _target,
+        deps = _greenlet_1_1_3_build_deps,
+        tags = ["manual"],
+    )
+
+    pycross_wheel_library(
+        name = "greenlet_1.1.3",
+        wheel = select({
+            ":_env_python_darwin_arm64": ":_build_greenlet_1.1.3",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_greenlet_1.1.3_cp39_cp39_macosx_10_15_x86_64//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_greenlet_1.1.3_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+        }),
+    )
+
+    pycross_wheel_library(
+        name = "idna_3.4",
+        wheel = "@example_lock_wheel_idna_3.4_py3_none_any//file",
+    )
+
+    _importlib_metadata_4_12_0_deps = [
+        ":zipp_3.8.1",
+    ]
+
+    pycross_wheel_library(
+        name = "importlib_metadata_4.12.0",
+        deps = _importlib_metadata_4_12_0_deps,
+        wheel = "@example_lock_wheel_importlib_metadata_4.12.0_py3_none_any//file",
+    )
+
+    _ipython_8_5_0_deps = [
+        ":backcall_0.2.0",
+        ":decorator_5.1.1",
+        ":jedi_0.18.1",
+        ":matplotlib_inline_0.1.6",
+        ":pexpect_4.8.0",
+        ":pickleshare_0.7.5",
+        ":prompt_toolkit_3.0.31",
+        ":pygments_2.13.0",
+        ":stack_data_0.5.0",
+        ":traitlets_5.4.0",
+    ] + select({
+        ":_env_python_darwin_arm64": [
+            ":appnope_0.1.3",
+        ],
+        ":_env_python_darwin_x86_64": [
+            ":appnope_0.1.3",
+        ],
+        "//conditions:default": [],
+    })
+
+    pycross_wheel_library(
+        name = "ipython_8.5.0",
+        deps = _ipython_8_5_0_deps,
+        wheel = "@example_lock_wheel_ipython_8.5.0_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "itsdangerous_2.1.2",
+        wheel = "@example_lock_wheel_itsdangerous_2.1.2_py3_none_any//file",
+    )
+
+    _jaraco_classes_3_2_2_deps = [
+        ":more_itertools_8.14.0",
+    ]
+
+    pycross_wheel_library(
+        name = "jaraco_classes_3.2.2",
+        deps = _jaraco_classes_3_2_2_deps,
+        wheel = "@example_lock_wheel_jaraco.classes_3.2.2_py3_none_any//file",
+    )
+
+    _jedi_0_18_1_deps = [
+        ":parso_0.8.3",
+    ]
+
+    pycross_wheel_library(
+        name = "jedi_0.18.1",
+        deps = _jedi_0_18_1_deps,
+        wheel = "@example_lock_wheel_jedi_0.18.1_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "jeepney_0.8.0",
+        wheel = "@example_lock_wheel_jeepney_0.8.0_py3_none_any//file",
+    )
+
+    _jinja2_3_1_2_deps = [
+        ":markupsafe_2.1.1",
+    ]
+
+    pycross_wheel_library(
+        name = "jinja2_3.1.2",
+        deps = _jinja2_3_1_2_deps,
+        wheel = "@example_lock_wheel_jinja2_3.1.2_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "jmespath_1.0.1",
+        wheel = "@example_lock_wheel_jmespath_1.0.1_py3_none_any//file",
+    )
+
+    _jschema_to_python_1_2_3_deps = [
+        ":attrs_22.1.0",
+        ":jsonpickle_2.2.0",
+        ":pbr_5.10.0",
+    ]
+
+    pycross_wheel_library(
+        name = "jschema_to_python_1.2.3",
+        deps = _jschema_to_python_1_2_3_deps,
+        wheel = "@example_lock_wheel_jschema_to_python_1.2.3_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "jsondiff_2.0.0",
+        wheel = "@example_lock_wheel_jsondiff_2.0.0_py3_none_any//file",
+    )
+
+    _jsonpatch_1_32_deps = [
+        ":jsonpointer_2.3",
+    ]
+
+    pycross_wheel_library(
+        name = "jsonpatch_1.32",
+        deps = _jsonpatch_1_32_deps,
+        wheel = "@example_lock_wheel_jsonpatch_1.32_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "jsonpickle_2.2.0",
+        wheel = "@example_lock_wheel_jsonpickle_2.2.0_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "jsonpointer_2.3",
+        wheel = "@example_lock_wheel_jsonpointer_2.3_py2.py3_none_any//file",
+    )
+
+    _jsonschema_3_2_0_deps = [
+        ":attrs_22.1.0",
+        ":pyrsistent_0.18.1",
+        ":setuptools_59.2.0",
+        ":six_1.16.0",
+    ]
+
+    pycross_wheel_library(
+        name = "jsonschema_3.2.0",
+        deps = _jsonschema_3_2_0_deps,
+        wheel = "@example_lock_wheel_jsonschema_3.2.0_py2.py3_none_any//file",
+    )
+
+    _junit_xml_1_9_deps = [
+        ":six_1.16.0",
+    ]
+
+    pycross_wheel_library(
+        name = "junit_xml_1.9",
+        deps = _junit_xml_1_9_deps,
+        wheel = "@example_lock_wheel_junit_xml_1.9_py2.py3_none_any//file",
+    )
+
+    _keyring_23_9_1_deps = [
+        ":importlib_metadata_4.12.0",
+        ":jaraco_classes_3.2.2",
+    ] + select({
+        ":_env_python_linux_x86_64": [
+            ":jeepney_0.8.0",
+            ":secretstorage_3.3.3",
+        ],
+        "//conditions:default": [],
+    })
+
+    pycross_wheel_library(
+        name = "keyring_23.9.1",
+        deps = _keyring_23_9_1_deps,
+        wheel = "@example_lock_wheel_keyring_23.9.1_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "markupsafe_2.1.1",
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_markupsafe_2.1.1_cp39_cp39_macosx_10_9_universal2//file",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_markupsafe_2.1.1_cp39_cp39_macosx_10_9_x86_64//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_markupsafe_2.1.1_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+        }),
+    )
+
+    _matplotlib_inline_0_1_6_deps = [
+        ":traitlets_5.4.0",
+    ]
+
+    pycross_wheel_library(
+        name = "matplotlib_inline_0.1.6",
+        deps = _matplotlib_inline_0_1_6_deps,
+        wheel = "@example_lock_wheel_matplotlib_inline_0.1.6_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "more_itertools_8.14.0",
+        wheel = "@example_lock_wheel_more_itertools_8.14.0_py3_none_any//file",
+    )
+
+    _moto_3_1_1_deps = [
+        ":aws_xray_sdk_2.10.0",
+        ":boto3_1.24.73",
+        ":botocore_1.27.73",
+        ":cfn_lint_0.65.0",
+        ":cryptography_38.0.1",
+        ":docker_6.0.0",
+        ":ecdsa_0.18.0",
+        ":flask_2.2.2",
+        ":flask_cors_3.0.10",
+        ":graphql_core_3.2.1",
+        ":idna_3.4",
+        ":jinja2_3.1.2",
+        ":jsondiff_2.0.0",
+        ":markupsafe_2.1.1",
+        ":python_dateutil_2.8.2",
+        ":python_jose_3.1.0",
+        ":pytz_2022.2.1",
+        ":pyyaml_6.0",
+        ":requests_2.28.1",
+        ":responses_0.21.0",
+        ":setuptools_59.2.0",
+        ":sshpubkeys_3.3.1",
+        ":werkzeug_2.2.2",
+        ":xmltodict_0.13.0",
+    ]
+
+    pycross_wheel_library(
+        name = "moto_3.1.1",
+        deps = _moto_3_1_1_deps,
+        wheel = "@example_lock_wheel_moto_3.1.1_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "networkx_2.8.6",
+        wheel = "@example_lock_wheel_networkx_2.8.6_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "numpy_1.22.3",
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_numpy_1.22.3_cp39_cp39_macosx_11_0_arm64//file",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_numpy_1.22.3_cp39_cp39_macosx_10_14_x86_64//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_numpy_1.22.3_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+        }),
+    )
+
+    _opencv_python_4_6_0_66_deps = select({
+        ":_env_python_darwin_arm64": [
+            ":numpy_1.22.3",
+        ],
+        ":_env_python_darwin_x86_64": [
+            ":numpy_1.22.3",
+        ],
+        ":_env_python_linux_x86_64": [
+            ":numpy_1.22.3",
+        ],
+        "//conditions:default": [],
+    })
+
+    pycross_wheel_library(
+        name = "opencv_python_4.6.0.66",
+        deps = _opencv_python_4_6_0_66_deps,
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_opencv_python_4.6.0.66_cp37_abi3_macosx_11_0_arm64//file",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_opencv_python_4.6.0.66_cp36_abi3_macosx_10_15_x86_64//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_opencv_python_4.6.0.66_cp36_abi3_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+        }),
+    )
+
+    _packaging_21_3_deps = [
+        ":pyparsing_3.0.9",
+    ]
+
+    pycross_wheel_library(
+        name = "packaging_21.3",
+        deps = _packaging_21_3_deps,
+        wheel = "@example_lock_wheel_packaging_21.3_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "parso_0.8.3",
+        wheel = "@example_lock_wheel_parso_0.8.3_py2.py3_none_any//file",
+    )
+
+    _pbr_5_10_0_build_deps = [
+        ":setuptools_59.2.0",
+        ":wheel_0.37.0",
+    ]
+
+    pycross_wheel_build(
+        name = "_build_pbr_5.10.0",
+        sdist = "@example_lock_sdist_pbr_5.10.0//file",
+        target_environment = _target,
+        deps = _pbr_5_10_0_build_deps,
+        tags = ["manual"],
+    )
+
+    pycross_wheel_library(
+        name = "pbr_5.10.0",
+        wheel = ":_build_pbr_5.10.0",
+    )
+
+    _pexpect_4_8_0_deps = [
+        ":ptyprocess_0.7.0",
+    ]
+
+    pycross_wheel_library(
+        name = "pexpect_4.8.0",
+        deps = _pexpect_4_8_0_deps,
+        wheel = "@example_lock_wheel_pexpect_4.8.0_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "pickleshare_0.7.5",
+        wheel = "@example_lock_wheel_pickleshare_0.7.5_py2.py3_none_any//file",
+    )
+
+    _prompt_toolkit_3_0_31_deps = [
+        ":wcwidth_0.2.5",
+    ]
+
+    pycross_wheel_library(
+        name = "prompt_toolkit_3.0.31",
+        deps = _prompt_toolkit_3_0_31_deps,
+        wheel = "@example_lock_wheel_prompt_toolkit_3.0.31_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "ptyprocess_0.7.0",
+        wheel = "@example_lock_wheel_ptyprocess_0.7.0_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "pure_eval_0.2.2",
+        wheel = "@example_lock_wheel_pure_eval_0.2.2_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "pyasn1_0.4.8",
+        wheel = "@example_lock_wheel_pyasn1_0.4.8_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "pycparser_2.21",
+        wheel = "@example_lock_wheel_pycparser_2.21_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "pygments_2.13.0",
+        wheel = "@example_lock_wheel_pygments_2.13.0_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "pyparsing_3.0.9",
+        wheel = "@example_lock_wheel_pyparsing_3.0.9_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "pyrsistent_0.18.1",
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_pyrsistent_0.18.1_cp39_cp39_macosx_10_9_universal2//file",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_pyrsistent_0.18.1_cp39_cp39_macosx_10_9_universal2//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_pyrsistent_0.18.1_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+        }),
+    )
+
+    _python_dateutil_2_8_2_deps = [
+        ":six_1.16.0",
+    ]
+
+    pycross_wheel_library(
+        name = "python_dateutil_2.8.2",
+        deps = _python_dateutil_2_8_2_deps,
+        wheel = "@example_lock_wheel_python_dateutil_2.8.2_py2.py3_none_any//file",
+    )
+
+    _python_jose_3_1_0_deps = [
+        ":cryptography_38.0.1",
+        ":ecdsa_0.18.0",
+        ":pyasn1_0.4.8",
+        ":rsa_4.9",
+        ":six_1.16.0",
+    ]
+
+    pycross_wheel_library(
+        name = "python_jose_3.1.0",
+        deps = _python_jose_3_1_0_deps,
+        wheel = "@example_lock_wheel_python_jose_3.1.0_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "pytz_2022.2.1",
+        wheel = "@example_lock_wheel_pytz_2022.2.1_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "pyyaml_6.0",
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_pyyaml_6.0_cp39_cp39_macosx_11_0_arm64//file",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_pyyaml_6.0_cp39_cp39_macosx_10_9_x86_64//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_pyyaml_6.0_cp39_cp39_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
+        }),
+    )
+
+    _requests_2_28_1_deps = [
+        ":certifi_2022.9.14",
+        ":charset_normalizer_2.1.1",
+        ":idna_3.4",
+        ":urllib3_1.26.12",
+    ]
+
+    pycross_wheel_library(
+        name = "requests_2.28.1",
+        deps = _requests_2_28_1_deps,
+        wheel = "@example_lock_wheel_requests_2.28.1_py3_none_any//file",
+    )
+
+    _responses_0_21_0_deps = [
+        ":requests_2.28.1",
+        ":urllib3_1.26.12",
+    ]
+
+    pycross_wheel_library(
+        name = "responses_0.21.0",
+        deps = _responses_0_21_0_deps,
+        wheel = "@example_lock_wheel_responses_0.21.0_py3_none_any//file",
+    )
+
+    _rsa_4_9_deps = [
+        ":pyasn1_0.4.8",
+    ]
+
+    pycross_wheel_library(
+        name = "rsa_4.9",
+        deps = _rsa_4_9_deps,
+        wheel = "@example_lock_wheel_rsa_4.9_py3_none_any//file",
+    )
+
+    _s3transfer_0_6_0_deps = [
+        ":botocore_1.27.73",
+    ]
+
+    pycross_wheel_library(
+        name = "s3transfer_0.6.0",
+        deps = _s3transfer_0_6_0_deps,
+        wheel = "@example_lock_wheel_s3transfer_0.6.0_py3_none_any//file",
+    )
+
+    _sarif_om_1_0_4_deps = [
+        ":attrs_22.1.0",
+        ":pbr_5.10.0",
+    ]
+
+    pycross_wheel_library(
+        name = "sarif_om_1.0.4",
+        deps = _sarif_om_1_0_4_deps,
+        wheel = "@example_lock_wheel_sarif_om_1.0.4_py3_none_any//file",
+    )
+
+    _secretstorage_3_3_3_deps = [
+        ":cryptography_38.0.1",
+        ":jeepney_0.8.0",
+    ]
+
+    pycross_wheel_library(
+        name = "secretstorage_3.3.3",
+        deps = _secretstorage_3_3_3_deps,
+        wheel = "@example_lock_wheel_secretstorage_3.3.3_py3_none_any//file",
+    )
+
+    _setproctitle_1_2_2_build_deps = [
+        ":setuptools_59.2.0",
+        ":wheel_0.37.0",
+    ]
+
+    pycross_wheel_build(
+        name = "_build_setproctitle_1.2.2",
+        sdist = "@example_lock_sdist_setproctitle_1.2.2//file",
+        target_environment = _target,
+        deps = _setproctitle_1_2_2_build_deps,
+        tags = ["manual"],
+    )
+
+    pycross_wheel_library(
+        name = "setproctitle_1.2.2",
+        wheel = ":_build_setproctitle_1.2.2",
+    )
+
+    pycross_wheel_library(
+        name = "setuptools_59.2.0",
+        wheel = "@example_lock_wheel_setuptools_59.2.0_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "six_1.16.0",
+        wheel = "@example_lock_wheel_six_1.16.0_py2.py3_none_any//file",
+    )
+
+    _sqlalchemy_1_4_41_deps = [
+        ":greenlet_1.1.3",
+    ]
+
+    _sqlalchemy_1_4_41_build_deps = [
+        ":setuptools_59.2.0",
+        ":wheel_0.37.0",
+    ]
+
+    pycross_wheel_build(
+        name = "_build_sqlalchemy_1.4.41",
+        sdist = "@example_lock_sdist_sqlalchemy_1.4.41//file",
+        target_environment = _target,
+        deps = _sqlalchemy_1_4_41_deps + _sqlalchemy_1_4_41_build_deps,
+        tags = ["manual"],
+    )
+
+    pycross_wheel_library(
+        name = "sqlalchemy_1.4.41",
+        deps = _sqlalchemy_1_4_41_deps,
+        wheel = select({
+            ":_env_python_darwin_arm64": ":_build_sqlalchemy_1.4.41",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_sqlalchemy_1.4.41_cp39_cp39_macosx_10_15_x86_64//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_sqlalchemy_1.4.41_cp39_cp39_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+        }),
+    )
+
+    _sqlalchemy_utils_0_38_2_deps = [
+        ":six_1.16.0",
+        ":sqlalchemy_1.4.41",
+    ]
+
+    pycross_wheel_library(
+        name = "sqlalchemy_utils_0.38.2",
+        deps = _sqlalchemy_utils_0_38_2_deps,
+        wheel = "@example_lock_wheel_sqlalchemy_utils_0.38.2_py3_none_any//file",
+    )
+
+    _sshpubkeys_3_3_1_deps = [
+        ":cryptography_38.0.1",
+        ":ecdsa_0.18.0",
+    ]
+
+    pycross_wheel_library(
+        name = "sshpubkeys_3.3.1",
+        deps = _sshpubkeys_3_3_1_deps,
+        wheel = "@example_lock_wheel_sshpubkeys_3.3.1_py2.py3_none_any//file",
+    )
+
+    _stack_data_0_5_0_deps = [
+        ":asttokens_2.0.8",
+        ":executing_1.0.0",
+        ":pure_eval_0.2.2",
+    ]
+
+    pycross_wheel_library(
+        name = "stack_data_0.5.0",
+        deps = _stack_data_0_5_0_deps,
+        wheel = "@example_lock_wheel_stack_data_0.5.0_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "traitlets_5.4.0",
+        wheel = "@example_lock_wheel_traitlets_5.4.0_py3_none_any//file",
+    )
+
+    _tree_sitter_0_20_0_build_deps = [
+        ":setuptools_59.2.0",
+        ":wheel_0.37.0",
+    ]
+
+    pycross_wheel_build(
+        name = "_build_tree_sitter_0.20.0",
+        sdist = "@example_lock_sdist_tree_sitter_0.20.0//file",
+        target_environment = _target,
+        deps = _tree_sitter_0_20_0_build_deps,
+        tags = ["manual"],
+    )
+
+    pycross_wheel_library(
+        name = "tree_sitter_0.20.0",
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_tree_sitter_0.20.0_cp39_cp39_macosx_12_0_arm64//file",
+            ":_env_python_darwin_x86_64": ":_build_tree_sitter_0.20.0",
+            ":_env_python_linux_x86_64": ":_build_tree_sitter_0.20.0",
+        }),
+    )
+
+    pycross_wheel_library(
+        name = "urllib3_1.26.12",
+        wheel = "@example_lock_wheel_urllib3_1.26.12_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "wcwidth_0.2.5",
+        wheel = "@example_lock_wheel_wcwidth_0.2.5_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "websocket_client_1.4.1",
+        wheel = "@example_lock_wheel_websocket_client_1.4.1_py3_none_any//file",
+    )
+
+    _werkzeug_2_2_2_deps = [
+        ":markupsafe_2.1.1",
+    ]
+
+    pycross_wheel_library(
+        name = "werkzeug_2.2.2",
+        deps = _werkzeug_2_2_2_deps,
+        wheel = "@example_lock_wheel_werkzeug_2.2.2_py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "wheel_0.37.0",
+        wheel = "@example_lock_wheel_wheel_0.37.0_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "wrapt_1.14.1",
+        wheel = select({
+            ":_env_python_darwin_arm64": "@example_lock_wheel_wrapt_1.14.1_cp39_cp39_macosx_11_0_arm64//file",
+            ":_env_python_darwin_x86_64": "@example_lock_wheel_wrapt_1.14.1_cp39_cp39_macosx_10_9_x86_64//file",
+            ":_env_python_linux_x86_64": "@example_lock_wheel_wrapt_1.14.1_cp39_cp39_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+        }),
+    )
+
+    pycross_wheel_library(
+        name = "xmltodict_0.13.0",
+        wheel = "@example_lock_wheel_xmltodict_0.13.0_py2.py3_none_any//file",
+    )
+
+    pycross_wheel_library(
+        name = "zipp_3.8.1",
+        wheel = "@example_lock_wheel_zipp_3.8.1_py3_none_any//file",
+    )
+
+def repositories():
+    maybe(
+        pypi_file,
+        name = "example_lock_sdist_future_0.18.2",
+        package_name = "future",
+        package_version = "0.18.2",
+        filename = "future-0.18.2.tar.gz",
+        sha256 = "b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_sdist_greenlet_1.1.3",
+        package_name = "greenlet",
+        package_version = "1.1.3",
+        filename = "greenlet-1.1.3.tar.gz",
+        sha256 = "bcb6c6dd1d6be6d38d6db283747d07fda089ff8c559a835236560a4410340455",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_sdist_pbr_5.10.0",
+        package_name = "pbr",
+        package_version = "5.10.0",
+        filename = "pbr-5.10.0.tar.gz",
+        sha256 = "cfcc4ff8e698256fc17ea3ff796478b050852585aa5bae79ecd05b2ab7b39b9a",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_sdist_setproctitle_1.2.2",
+        package_name = "setproctitle",
+        package_version = "1.2.2",
+        filename = "setproctitle-1.2.2.tar.gz",
+        sha256 = "7dfb472c8852403d34007e01d6e3c68c57eb66433fb8a5c77b13b89a160d97df",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_sdist_sqlalchemy_1.4.41",
+        package_name = "sqlalchemy",
+        package_version = "1.4.41",
+        filename = "SQLAlchemy-1.4.41.tar.gz",
+        sha256 = "0292f70d1797e3c54e862e6f30ae474014648bc9c723e14a2fda730adb0a9791",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_sdist_tree_sitter_0.20.0",
+        package_name = "tree-sitter",
+        package_version = "0.20.0",
+        filename = "tree_sitter-0.20.0.tar.gz",
+        sha256 = "1940f64be1e8c9c3c0e34a2258f1e4c324207534d5b1eefc5ab2960a9d98f668",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_appnope_0.1.3_py2.py3_none_any",
+        package_name = "appnope",
+        package_version = "0.1.3",
+        filename = "appnope-0.1.3-py2.py3-none-any.whl",
+        sha256 = "265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_asttokens_2.0.8_py2.py3_none_any",
+        package_name = "asttokens",
+        package_version = "2.0.8",
+        filename = "asttokens-2.0.8-py2.py3-none-any.whl",
+        sha256 = "e3305297c744ae53ffa032c45dc347286165e4ffce6875dc662b205db0623d86",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_attrs_22.1.0_py2.py3_none_any",
+        package_name = "attrs",
+        package_version = "22.1.0",
+        filename = "attrs-22.1.0-py2.py3-none-any.whl",
+        sha256 = "86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_aws_sam_translator_1.51.0_py3_none_any",
+        package_name = "aws-sam-translator",
+        package_version = "1.51.0",
+        filename = "aws_sam_translator-1.51.0-py3-none-any.whl",
+        sha256 = "f0f09f95fcc0c5e699603b9b1daa86307b94920b0823c423ed2ff1eb1cac497f",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_aws_xray_sdk_2.10.0_py2.py3_none_any",
+        package_name = "aws-xray-sdk",
+        package_version = "2.10.0",
+        filename = "aws_xray_sdk-2.10.0-py2.py3-none-any.whl",
+        sha256 = "7551e81a796e1a5471ebe84844c40e8edf7c218db33506d046fec61f7495eda4",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_backcall_0.2.0_py2.py3_none_any",
+        package_name = "backcall",
+        package_version = "0.2.0",
+        filename = "backcall-0.2.0-py2.py3-none-any.whl",
+        sha256 = "fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_boto3_1.24.73_py3_none_any",
+        package_name = "boto3",
+        package_version = "1.24.73",
+        filename = "boto3-1.24.73-py3-none-any.whl",
+        sha256 = "f7ca88a76c8e31c19fef3bad2dee3c2ee0e77a0bced151fa3922cf021d55755e",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_botocore_1.27.73_py3_none_any",
+        package_name = "botocore",
+        package_version = "1.27.73",
+        filename = "botocore-1.27.73-py3-none-any.whl",
+        sha256 = "0b94d1e7b1435f8ff108c74a09fe03ec88aadbfafe97e940ea415dc86ba305a3",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_certifi_2022.9.14_py3_none_any",
+        package_name = "certifi",
+        package_version = "2022.9.14",
+        filename = "certifi-2022.9.14-py3-none-any.whl",
+        sha256 = "e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cffi_1.15.1_cp39_cp39_macosx_10_9_x86_64",
+        package_name = "cffi",
+        package_version = "1.15.1",
+        filename = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl",
+        sha256 = "54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cffi_1.15.1_cp39_cp39_macosx_11_0_arm64",
+        package_name = "cffi",
+        package_version = "1.15.1",
+        filename = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl",
+        sha256 = "fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cffi_1.15.1_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64",
+        package_name = "cffi",
+        package_version = "1.15.1",
+        filename = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cfn_lint_0.65.0_py3_none_any",
+        package_name = "cfn-lint",
+        package_version = "0.65.0",
+        filename = "cfn_lint-0.65.0-py3-none-any.whl",
+        sha256 = "b5992f52a86e6ef0a150fabbb4d131bbf626eddd4154ca708193c1d233a7efca",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_charset_normalizer_2.1.1_py3_none_any",
+        package_name = "charset-normalizer",
+        package_version = "2.1.1",
+        filename = "charset_normalizer-2.1.1-py3-none-any.whl",
+        sha256 = "83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_click_8.1.3_py3_none_any",
+        package_name = "click",
+        package_version = "8.1.3",
+        filename = "click-8.1.3-py3-none-any.whl",
+        sha256 = "bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cognitojwt_1.4.1_py3_none_any",
+        package_name = "cognitojwt",
+        package_version = "1.4.1",
+        filename = "cognitojwt-1.4.1-py3-none-any.whl",
+        sha256 = "8ee189f82289d140dc750c91e8772436b64b94d071507ace42efc22c525f42ce",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cryptography_38.0.1_cp36_abi3_macosx_10_10_universal2",
+        package_name = "cryptography",
+        package_version = "38.0.1",
+        filename = "cryptography-38.0.1-cp36-abi3-macosx_10_10_universal2.whl",
+        sha256 = "10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cryptography_38.0.1_cp36_abi3_macosx_10_10_x86_64",
+        package_name = "cryptography",
+        package_version = "38.0.1",
+        filename = "cryptography-38.0.1-cp36-abi3-macosx_10_10_x86_64.whl",
+        sha256 = "3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cryptography_38.0.1_cp36_abi3_manylinux_2_17_x86_64.manylinux2014_x86_64",
+        package_name = "cryptography",
+        package_version = "38.0.1",
+        filename = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cython_0.29.32_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64",
+        package_name = "cython",
+        package_version = "0.29.32",
+        filename = "Cython-0.29.32-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl",
+        sha256 = "f3fd44cc362eee8ae569025f070d56208908916794b6ab21e139cea56470a2b3",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_cython_0.29.32_py2.py3_none_any",
+        package_name = "cython",
+        package_version = "0.29.32",
+        filename = "Cython-0.29.32-py2.py3-none-any.whl",
+        sha256 = "eeb475eb6f0ccf6c039035eb4f0f928eb53ead88777e0a760eccb140ad90930b",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_decorator_5.1.1_py3_none_any",
+        package_name = "decorator",
+        package_version = "5.1.1",
+        filename = "decorator-5.1.1-py3-none-any.whl",
+        sha256 = "b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_docker_6.0.0_py3_none_any",
+        package_name = "docker",
+        package_version = "6.0.0",
+        filename = "docker-6.0.0-py3-none-any.whl",
+        sha256 = "6e06ee8eca46cd88733df09b6b80c24a1a556bc5cb1e1ae54b2c239886d245cf",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_ecdsa_0.18.0_py2.py3_none_any",
+        package_name = "ecdsa",
+        package_version = "0.18.0",
+        filename = "ecdsa-0.18.0-py2.py3-none-any.whl",
+        sha256 = "80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_executing_1.0.0_py2.py3_none_any",
+        package_name = "executing",
+        package_version = "1.0.0",
+        filename = "executing-1.0.0-py2.py3-none-any.whl",
+        sha256 = "550d581b497228b572235e633599133eeee67073c65914ca346100ad56775349",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_flask_2.2.2_py3_none_any",
+        package_name = "flask",
+        package_version = "2.2.2",
+        filename = "Flask-2.2.2-py3-none-any.whl",
+        sha256 = "b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_flask_cors_3.0.10_py2.py3_none_any",
+        package_name = "flask-cors",
+        package_version = "3.0.10",
+        filename = "Flask_Cors-3.0.10-py2.py3-none-any.whl",
+        sha256 = "74efc975af1194fc7891ff5cd85b0f7478be4f7f59fe158102e91abb72bb4438",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_graphql_core_3.2.1_py3_none_any",
+        package_name = "graphql-core",
+        package_version = "3.2.1",
+        filename = "graphql_core-3.2.1-py3-none-any.whl",
+        sha256 = "f83c658e4968998eed1923a2e3e3eddd347e005ac0315fbb7ca4d70ea9156323",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_greenlet_1.1.3_cp39_cp39_macosx_10_15_x86_64",
+        package_name = "greenlet",
+        package_version = "1.1.3",
+        filename = "greenlet-1.1.3-cp39-cp39-macosx_10_15_x86_64.whl",
+        sha256 = "cbc1eb55342cbac8f7ec159088d54e2cfdd5ddf61c87b8bbe682d113789331b2",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_greenlet_1.1.3_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64",
+        package_name = "greenlet",
+        package_version = "1.1.3",
+        filename = "greenlet-1.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "2fb0aa7f6996879551fd67461d5d3ab0c3c0245da98be90c89fcb7a18d437403",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_idna_3.4_py3_none_any",
+        package_name = "idna",
+        package_version = "3.4",
+        filename = "idna-3.4-py3-none-any.whl",
+        sha256 = "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_importlib_metadata_4.12.0_py3_none_any",
+        package_name = "importlib-metadata",
+        package_version = "4.12.0",
+        filename = "importlib_metadata-4.12.0-py3-none-any.whl",
+        sha256 = "7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_ipython_8.5.0_py3_none_any",
+        package_name = "ipython",
+        package_version = "8.5.0",
+        filename = "ipython-8.5.0-py3-none-any.whl",
+        sha256 = "6f090e29ab8ef8643e521763a4f1f39dc3914db643122b1e9d3328ff2e43ada2",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_itsdangerous_2.1.2_py3_none_any",
+        package_name = "itsdangerous",
+        package_version = "2.1.2",
+        filename = "itsdangerous-2.1.2-py3-none-any.whl",
+        sha256 = "2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jaraco.classes_3.2.2_py3_none_any",
+        package_name = "jaraco-classes",
+        package_version = "3.2.2",
+        filename = "jaraco.classes-3.2.2-py3-none-any.whl",
+        sha256 = "e6ef6fd3fcf4579a7a019d87d1e56a883f4e4c35cfe925f86731abc58804e647",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jedi_0.18.1_py2.py3_none_any",
+        package_name = "jedi",
+        package_version = "0.18.1",
+        filename = "jedi-0.18.1-py2.py3-none-any.whl",
+        sha256 = "637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jeepney_0.8.0_py3_none_any",
+        package_name = "jeepney",
+        package_version = "0.8.0",
+        filename = "jeepney-0.8.0-py3-none-any.whl",
+        sha256 = "c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jinja2_3.1.2_py3_none_any",
+        package_name = "jinja2",
+        package_version = "3.1.2",
+        filename = "Jinja2-3.1.2-py3-none-any.whl",
+        sha256 = "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jmespath_1.0.1_py3_none_any",
+        package_name = "jmespath",
+        package_version = "1.0.1",
+        filename = "jmespath-1.0.1-py3-none-any.whl",
+        sha256 = "02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jschema_to_python_1.2.3_py3_none_any",
+        package_name = "jschema-to-python",
+        package_version = "1.2.3",
+        filename = "jschema_to_python-1.2.3-py3-none-any.whl",
+        sha256 = "8a703ca7604d42d74b2815eecf99a33359a8dccbb80806cce386d5e2dd992b05",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jsondiff_2.0.0_py3_none_any",
+        package_name = "jsondiff",
+        package_version = "2.0.0",
+        filename = "jsondiff-2.0.0-py3-none-any.whl",
+        sha256 = "689841d66273fc88fc79f7d33f4c074774f4f214b6466e3aff0e5adaf889d1e0",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jsonpatch_1.32_py2.py3_none_any",
+        package_name = "jsonpatch",
+        package_version = "1.32",
+        filename = "jsonpatch-1.32-py2.py3-none-any.whl",
+        sha256 = "26ac385719ac9f54df8a2f0827bb8253aa3ea8ab7b3368457bcdb8c14595a397",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jsonpickle_2.2.0_py2.py3_none_any",
+        package_name = "jsonpickle",
+        package_version = "2.2.0",
+        filename = "jsonpickle-2.2.0-py2.py3-none-any.whl",
+        sha256 = "de7f2613818aa4f234138ca11243d6359ff83ae528b2185efdd474f62bcf9ae1",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jsonpointer_2.3_py2.py3_none_any",
+        package_name = "jsonpointer",
+        package_version = "2.3",
+        filename = "jsonpointer-2.3-py2.py3-none-any.whl",
+        sha256 = "51801e558539b4e9cd268638c078c6c5746c9ac96bc38152d443400e4f3793e9",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_jsonschema_3.2.0_py2.py3_none_any",
+        package_name = "jsonschema",
+        package_version = "3.2.0",
+        filename = "jsonschema-3.2.0-py2.py3-none-any.whl",
+        sha256 = "4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_junit_xml_1.9_py2.py3_none_any",
+        package_name = "junit-xml",
+        package_version = "1.9",
+        filename = "junit_xml-1.9-py2.py3-none-any.whl",
+        sha256 = "ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_keyring_23.9.1_py3_none_any",
+        package_name = "keyring",
+        package_version = "23.9.1",
+        filename = "keyring-23.9.1-py3-none-any.whl",
+        sha256 = "3565b9e4ea004c96e158d2d332a49f466733d565bb24157a60fd2e49f41a0fd1",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_markupsafe_2.1.1_cp39_cp39_macosx_10_9_universal2",
+        package_name = "markupsafe",
+        package_version = "2.1.1",
+        filename = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl",
+        sha256 = "e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_markupsafe_2.1.1_cp39_cp39_macosx_10_9_x86_64",
+        package_name = "markupsafe",
+        package_version = "2.1.1",
+        filename = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl",
+        sha256 = "b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_markupsafe_2.1.1_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64",
+        package_name = "markupsafe",
+        package_version = "2.1.1",
+        filename = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_matplotlib_inline_0.1.6_py3_none_any",
+        package_name = "matplotlib-inline",
+        package_version = "0.1.6",
+        filename = "matplotlib_inline-0.1.6-py3-none-any.whl",
+        sha256 = "f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_more_itertools_8.14.0_py3_none_any",
+        package_name = "more-itertools",
+        package_version = "8.14.0",
+        filename = "more_itertools-8.14.0-py3-none-any.whl",
+        sha256 = "1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_moto_3.1.1_py2.py3_none_any",
+        package_name = "moto",
+        package_version = "3.1.1",
+        filename = "moto-3.1.1-py2.py3-none-any.whl",
+        sha256 = "462495563847134ea8ef4135a229731a598a8e7b6b10a74f8d745815aa20a25b",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_networkx_2.8.6_py3_none_any",
+        package_name = "networkx",
+        package_version = "2.8.6",
+        filename = "networkx-2.8.6-py3-none-any.whl",
+        sha256 = "2a30822761f34d56b9a370d96a4bf4827a535f5591a4078a453425caeba0c5bb",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_numpy_1.22.3_cp39_cp39_macosx_10_14_x86_64",
+        package_name = "numpy",
+        package_version = "1.22.3",
+        filename = "numpy-1.22.3-cp39-cp39-macosx_10_14_x86_64.whl",
+        sha256 = "2c10a93606e0b4b95c9b04b77dc349b398fdfbda382d2a39ba5a822f669a0123",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_numpy_1.22.3_cp39_cp39_macosx_11_0_arm64",
+        package_name = "numpy",
+        package_version = "1.22.3",
+        filename = "numpy-1.22.3-cp39-cp39-macosx_11_0_arm64.whl",
+        sha256 = "fade0d4f4d292b6f39951b6836d7a3c7ef5b2347f3c420cd9820a1d90d794802",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_numpy_1.22.3_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64",
+        package_name = "numpy",
+        package_version = "1.22.3",
+        filename = "numpy-1.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "97098b95aa4e418529099c26558eeb8486e66bd1e53a6b606d684d0c3616b168",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_opencv_python_4.6.0.66_cp36_abi3_macosx_10_15_x86_64",
+        package_name = "opencv-python",
+        package_version = "4.6.0.66",
+        filename = "opencv_python-4.6.0.66-cp36-abi3-macosx_10_15_x86_64.whl",
+        sha256 = "e6e448b62afc95c5b58f97e87ef84699e6607fe5c58730a03301c52496005cae",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_opencv_python_4.6.0.66_cp36_abi3_manylinux_2_17_x86_64.manylinux2014_x86_64",
+        package_name = "opencv-python",
+        package_version = "4.6.0.66",
+        filename = "opencv_python-4.6.0.66-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "dbdc84a9b4ea2cbae33861652d25093944b9959279200b7ae0badd32439f74de",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_opencv_python_4.6.0.66_cp37_abi3_macosx_11_0_arm64",
+        package_name = "opencv-python",
+        package_version = "4.6.0.66",
+        filename = "opencv_python-4.6.0.66-cp37-abi3-macosx_11_0_arm64.whl",
+        sha256 = "6e32af22e3202748bd233ed8f538741876191863882eba44e332d1a34993165b",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_packaging_21.3_py3_none_any",
+        package_name = "packaging",
+        package_version = "21.3",
+        filename = "packaging-21.3-py3-none-any.whl",
+        sha256 = "ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_parso_0.8.3_py2.py3_none_any",
+        package_name = "parso",
+        package_version = "0.8.3",
+        filename = "parso-0.8.3-py2.py3-none-any.whl",
+        sha256 = "c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pexpect_4.8.0_py2.py3_none_any",
+        package_name = "pexpect",
+        package_version = "4.8.0",
+        filename = "pexpect-4.8.0-py2.py3-none-any.whl",
+        sha256 = "0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pickleshare_0.7.5_py2.py3_none_any",
+        package_name = "pickleshare",
+        package_version = "0.7.5",
+        filename = "pickleshare-0.7.5-py2.py3-none-any.whl",
+        sha256 = "9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_prompt_toolkit_3.0.31_py3_none_any",
+        package_name = "prompt-toolkit",
+        package_version = "3.0.31",
+        filename = "prompt_toolkit-3.0.31-py3-none-any.whl",
+        sha256 = "9696f386133df0fc8ca5af4895afe5d78f5fcfe5258111c2a79a1c3e41ffa96d",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_ptyprocess_0.7.0_py2.py3_none_any",
+        package_name = "ptyprocess",
+        package_version = "0.7.0",
+        filename = "ptyprocess-0.7.0-py2.py3-none-any.whl",
+        sha256 = "4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pure_eval_0.2.2_py3_none_any",
+        package_name = "pure-eval",
+        package_version = "0.2.2",
+        filename = "pure_eval-0.2.2-py3-none-any.whl",
+        sha256 = "01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pyasn1_0.4.8_py2.py3_none_any",
+        package_name = "pyasn1",
+        package_version = "0.4.8",
+        filename = "pyasn1-0.4.8-py2.py3-none-any.whl",
+        sha256 = "39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pycparser_2.21_py2.py3_none_any",
+        package_name = "pycparser",
+        package_version = "2.21",
+        filename = "pycparser-2.21-py2.py3-none-any.whl",
+        sha256 = "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pygments_2.13.0_py3_none_any",
+        package_name = "pygments",
+        package_version = "2.13.0",
+        filename = "Pygments-2.13.0-py3-none-any.whl",
+        sha256 = "f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pyparsing_3.0.9_py3_none_any",
+        package_name = "pyparsing",
+        package_version = "3.0.9",
+        filename = "pyparsing-3.0.9-py3-none-any.whl",
+        sha256 = "5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pyrsistent_0.18.1_cp39_cp39_macosx_10_9_universal2",
+        package_name = "pyrsistent",
+        package_version = "0.18.1",
+        filename = "pyrsistent-0.18.1-cp39-cp39-macosx_10_9_universal2.whl",
+        sha256 = "f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pyrsistent_0.18.1_cp39_cp39_manylinux_2_17_x86_64.manylinux2014_x86_64",
+        package_name = "pyrsistent",
+        package_version = "0.18.1",
+        filename = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_python_dateutil_2.8.2_py2.py3_none_any",
+        package_name = "python-dateutil",
+        package_version = "2.8.2",
+        filename = "python_dateutil-2.8.2-py2.py3-none-any.whl",
+        sha256 = "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_python_jose_3.1.0_py2.py3_none_any",
+        package_name = "python-jose",
+        package_version = "3.1.0",
+        filename = "python_jose-3.1.0-py2.py3-none-any.whl",
+        sha256 = "1ac4caf4bfebd5a70cf5bd82702ed850db69b0b6e1d0ae7368e5f99ac01c9571",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pytz_2022.2.1_py2.py3_none_any",
+        package_name = "pytz",
+        package_version = "2022.2.1",
+        filename = "pytz-2022.2.1-py2.py3-none-any.whl",
+        sha256 = "220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pyyaml_6.0_cp39_cp39_macosx_10_9_x86_64",
+        package_name = "pyyaml",
+        package_version = "6.0",
+        filename = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl",
+        sha256 = "055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pyyaml_6.0_cp39_cp39_macosx_11_0_arm64",
+        package_name = "pyyaml",
+        package_version = "6.0",
+        filename = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl",
+        sha256 = "e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_pyyaml_6.0_cp39_cp39_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64",
+        package_name = "pyyaml",
+        package_version = "6.0",
+        filename = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+        sha256 = "40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_requests_2.28.1_py3_none_any",
+        package_name = "requests",
+        package_version = "2.28.1",
+        filename = "requests-2.28.1-py3-none-any.whl",
+        sha256 = "8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_responses_0.21.0_py3_none_any",
+        package_name = "responses",
+        package_version = "0.21.0",
+        filename = "responses-0.21.0-py3-none-any.whl",
+        sha256 = "2dcc863ba63963c0c3d9ee3fa9507cbe36b7d7b0fccb4f0bdfd9e96c539b1487",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_rsa_4.9_py3_none_any",
+        package_name = "rsa",
+        package_version = "4.9",
+        filename = "rsa-4.9-py3-none-any.whl",
+        sha256 = "90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_s3transfer_0.6.0_py3_none_any",
+        package_name = "s3transfer",
+        package_version = "0.6.0",
+        filename = "s3transfer-0.6.0-py3-none-any.whl",
+        sha256 = "06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_sarif_om_1.0.4_py3_none_any",
+        package_name = "sarif-om",
+        package_version = "1.0.4",
+        filename = "sarif_om-1.0.4-py3-none-any.whl",
+        sha256 = "539ef47a662329b1c8502388ad92457425e95dc0aaaf995fe46f4984c4771911",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_secretstorage_3.3.3_py3_none_any",
+        package_name = "secretstorage",
+        package_version = "3.3.3",
+        filename = "SecretStorage-3.3.3-py3-none-any.whl",
+        sha256 = "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_setuptools_59.2.0_py3_none_any",
+        package_name = "setuptools",
+        package_version = "59.2.0",
+        filename = "setuptools-59.2.0-py3-none-any.whl",
+        sha256 = "4adde3d1e1c89bde1c643c64d89cdd94cbfd8c75252ee459d4500bccb9c7d05d",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_six_1.16.0_py2.py3_none_any",
+        package_name = "six",
+        package_version = "1.16.0",
+        filename = "six-1.16.0-py2.py3-none-any.whl",
+        sha256 = "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_sqlalchemy_1.4.41_cp39_cp39_macosx_10_15_x86_64",
+        package_name = "sqlalchemy",
+        package_version = "1.4.41",
+        filename = "SQLAlchemy-1.4.41-cp39-cp39-macosx_10_15_x86_64.whl",
+        sha256 = "199a73c31ac8ea59937cc0bf3dfc04392e81afe2ec8a74f26f489d268867846c",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_sqlalchemy_1.4.41_cp39_cp39_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64",
+        package_name = "sqlalchemy",
+        package_version = "1.4.41",
+        filename = "SQLAlchemy-1.4.41-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "2307495d9e0ea00d0c726be97a5b96615035854972cc538f6e7eaed23a35886c",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_sqlalchemy_utils_0.38.2_py3_none_any",
+        package_name = "sqlalchemy-utils",
+        package_version = "0.38.2",
+        filename = "SQLAlchemy_Utils-0.38.2-py3-none-any.whl",
+        sha256 = "622235b1598f97300e4d08820ab024f5219c9a6309937a8b908093f487b4ba54",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_sshpubkeys_3.3.1_py2.py3_none_any",
+        package_name = "sshpubkeys",
+        package_version = "3.3.1",
+        filename = "sshpubkeys-3.3.1-py2.py3-none-any.whl",
+        sha256 = "946f76b8fe86704b0e7c56a00d80294e39bc2305999844f079a217885060b1ac",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_stack_data_0.5.0_py3_none_any",
+        package_name = "stack-data",
+        package_version = "0.5.0",
+        filename = "stack_data-0.5.0-py3-none-any.whl",
+        sha256 = "66d2ebd3d7f29047612ead465b6cae5371006a71f45037c7e2507d01367bce3b",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_traitlets_5.4.0_py3_none_any",
+        package_name = "traitlets",
+        package_version = "5.4.0",
+        filename = "traitlets-5.4.0-py3-none-any.whl",
+        sha256 = "93663cc8236093d48150e2af5e2ed30fc7904a11a6195e21bab0408af4e6d6c8",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_tree_sitter_0.20.0_cp39_cp39_macosx_12_0_arm64",
+        package_name = "tree-sitter",
+        package_version = "0.20.0",
+        filename = "tree_sitter-0.20.0-cp39-cp39-macosx_12_0_arm64.whl",
+        sha256 = "51a609a7c1bd9d9e75d92ee128c12c7852ae70a482900fbbccf3d13a79e0378c",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_urllib3_1.26.12_py2.py3_none_any",
+        package_name = "urllib3",
+        package_version = "1.26.12",
+        filename = "urllib3-1.26.12-py2.py3-none-any.whl",
+        sha256 = "b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_wcwidth_0.2.5_py2.py3_none_any",
+        package_name = "wcwidth",
+        package_version = "0.2.5",
+        filename = "wcwidth-0.2.5-py2.py3-none-any.whl",
+        sha256 = "beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_websocket_client_1.4.1_py3_none_any",
+        package_name = "websocket-client",
+        package_version = "1.4.1",
+        filename = "websocket_client-1.4.1-py3-none-any.whl",
+        sha256 = "398909eb7e261f44b8f4bd474785b6ec5f5b499d4953342fe9755e01ef624090",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_werkzeug_2.2.2_py3_none_any",
+        package_name = "werkzeug",
+        package_version = "2.2.2",
+        filename = "Werkzeug-2.2.2-py3-none-any.whl",
+        sha256 = "f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_wheel_0.37.0_py2.py3_none_any",
+        package_name = "wheel",
+        package_version = "0.37.0",
+        filename = "wheel-0.37.0-py2.py3-none-any.whl",
+        sha256 = "21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_wrapt_1.14.1_cp39_cp39_macosx_10_9_x86_64",
+        package_name = "wrapt",
+        package_version = "1.14.1",
+        filename = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl",
+        sha256 = "3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_wrapt_1.14.1_cp39_cp39_macosx_11_0_arm64",
+        package_name = "wrapt",
+        package_version = "1.14.1",
+        filename = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl",
+        sha256 = "988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_wrapt_1.14.1_cp39_cp39_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64",
+        package_name = "wrapt",
+        package_version = "1.14.1",
+        filename = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+        index = "https://pypi.org",
+    )
+
+    maybe(
+        http_file,
+        name = "example_lock_wheel_xmltodict_0.13.0_py2.py3_none_any",
+        urls = [
+            "https://files.pythonhosted.org/packages/94/db/fd0326e331726f07ff7f40675cd86aa804bfd2e5016c727fa761c934990e/xmltodict-0.13.0-py2.py3-none-any.whl"
+        ],
+        sha256 = "aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852",
+        downloaded_file_path = "xmltodict-0.13.0-py2.py3-none-any.whl",
+    )
+
+    maybe(
+        pypi_file,
+        name = "example_lock_wheel_zipp_3.8.1_py3_none_any",
+        package_name = "zipp",
+        package_version = "3.8.1",
+        filename = "zipp-3.8.1-py3-none-any.whl",
+        sha256 = "47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009",
+        index = "https://pypi.org",
+    )
+

--- a/examples/crossenv/poetry.lock
+++ b/examples/crossenv/poetry.lock
@@ -1,0 +1,1981 @@
+[[package]]
+name = "appnope"
+version = "0.1.3"
+description = "Disable App Nap on macOS >= 10.9"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "asttokens"
+version = "2.0.8"
+description = "Annotate AST trees with source code positions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+test = ["astroid (<=2.5.3)", "pytest"]
+
+[[package]]
+name = "attrs"
+version = "22.1.0"
+description = "Classes Without Boilerplate"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+
+[[package]]
+name = "aws-sam-translator"
+version = "1.51.0"
+description = "AWS SAM Translator is a library that transform SAM templates into AWS CloudFormation templates"
+category = "main"
+optional = false
+python-versions = ">=3.7, <=4.0, !=4.0"
+
+[package.dependencies]
+boto3 = ">=1.19.5,<2.0.0"
+jsonschema = ">=3.2,<4.0"
+
+[package.extras]
+dev = ["black (==20.8b1)", "boto3 (>=1.23,<2)", "boto3-stubs[appconfig,serverlessrepo] (>=1.19.5,<2.0.0)", "click (>=7.1,<8.0)", "coverage (>=5.3,<6.0)", "dateparser (>=0.7,<1.0)", "docopt (>=0.6.2,<0.7.0)", "flake8 (>=3.8.4,<3.9.0)", "mypy (==0.971)", "parameterized (>=0.7.4,<0.8.0)", "pylint (>=2.9.0,<2.10.0)", "pytest (>=6.2.5,<6.3.0)", "pytest-cov (>=2.10.1,<2.11.0)", "pytest-env (>=0.6.2,<0.7.0)", "pytest-xdist (>=2.5,<3.0)", "pyyaml (>=5.4,<6.0)", "requests (>=2.24.0,<2.25.0)", "tenacity (>=7.0.0,<7.1.0)", "tox (>=3.24,<4.0)", "types-PyYAML (>=5.4,<6.0)", "types-jsonschema (>=3.2,<4.0)"]
+
+[[package]]
+name = "aws-xray-sdk"
+version = "2.10.0"
+description = "The AWS X-Ray SDK for Python (the SDK) enables Python developers to record and emit information from within their applications to the AWS X-Ray service."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+botocore = ">=1.11.3"
+wrapt = "*"
+
+[[package]]
+name = "backcall"
+version = "0.2.0"
+description = "Specifications for callback functions passed in to an API"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "boto3"
+version = "1.24.73"
+description = "The AWS SDK for Python"
+category = "main"
+optional = false
+python-versions = ">= 3.7"
+
+[package.dependencies]
+botocore = ">=1.27.73,<1.28.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.6.0,<0.7.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.27.73"
+description = "Low-level, data-driven core of boto 3."
+category = "main"
+optional = false
+python-versions = ">= 3.7"
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<1.27"
+
+[package.extras]
+crt = ["awscrt (==0.14.0)"]
+
+[[package]]
+name = "certifi"
+version = "2022.9.14"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "cffi"
+version = "1.15.1"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
+name = "cfn-lint"
+version = "0.65.0"
+description = "Checks CloudFormation templates for practices and behaviour that could potentially be improved"
+category = "main"
+optional = false
+python-versions = ">=3.7, <=4.0, !=4.0"
+
+[package.dependencies]
+aws-sam-translator = ">=1.50.0"
+jschema-to-python = ">=1.2.3,<1.3.0"
+jsonpatch = "*"
+jsonschema = ">=3.0,<5"
+junit-xml = ">=1.9,<2.0"
+networkx = ">=2.4,<3.0"
+pyyaml = ">5.4"
+sarif-om = ">=1.0.4,<1.1.0"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.1.1"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "cognitojwt"
+version = "1.4.1"
+description = "Decode and verify Amazon Cognito JWT tokens"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+python-jose = {version = "*", extras = ["cryptography"]}
+
+[package.extras]
+async = ["aiofile", "aiohttp", "async-lru"]
+sync = ["requests"]
+test = ["aiohttp", "async-lru", "attrs (==19.1.0)", "pytest (==5.4.0)", "pytest-asyncio (==0.12.0)", "requests"]
+
+[[package]]
+name = "colorama"
+version = "0.4.5"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "cryptography"
+version = "38.0.1"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = ">=1.12"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
+docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
+sdist = ["setuptools-rust (>=0.11.4)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
+
+[[package]]
+name = "Cython"
+version = "0.29.32"
+description = "The Cython compiler for writing C extensions for the Python language."
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "docker"
+version = "6.0.0"
+description = "A Python library for the Docker Engine API."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+packaging = ">=14.0"
+pywin32 = {version = ">=304", markers = "sys_platform == \"win32\""}
+requests = ">=2.26.0"
+urllib3 = ">=1.26.0"
+websocket-client = ">=0.32.0"
+
+[package.extras]
+ssh = ["paramiko (>=2.4.3)"]
+
+[[package]]
+name = "ecdsa"
+version = "0.18.0"
+description = "ECDSA cryptographic signature library (pure python)"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[package.extras]
+gmpy = ["gmpy"]
+gmpy2 = ["gmpy2"]
+
+[[package]]
+name = "executing"
+version = "1.0.0"
+description = "Get the currently executing AST node of a frame, and other information"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "Flask"
+version = "2.2.2"
+description = "A simple framework for building complex web applications."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=8.0"
+importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
+itsdangerous = ">=2.0"
+Jinja2 = ">=3.0"
+Werkzeug = ">=2.2.2"
+
+[package.extras]
+async = ["asgiref (>=3.2)"]
+dotenv = ["python-dotenv"]
+
+[[package]]
+name = "Flask-Cors"
+version = "3.0.10"
+description = "A Flask extension adding a decorator for CORS support"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Flask = ">=0.9"
+Six = "*"
+
+[[package]]
+name = "future"
+version = "0.18.2"
+description = "Clean single-source support for Python 3 and 2"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "graphql-core"
+version = "3.2.1"
+description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
+category = "main"
+optional = false
+python-versions = ">=3.6,<4"
+
+[[package]]
+name = "greenlet"
+version = "1.1.3"
+description = "Lightweight in-process concurrent programming"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+
+[package.extras]
+docs = ["Sphinx"]
+
+[[package]]
+name = "idna"
+version = "3.4"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "importlib-metadata"
+version = "4.12.0"
+description = "Read metadata from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
+perf = ["ipython"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+
+[[package]]
+name = "ipython"
+version = "8.5.0"
+description = "IPython: Productive Interactive Computing"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+appnope = {version = "*", markers = "sys_platform == \"darwin\""}
+backcall = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+decorator = "*"
+jedi = ">=0.16"
+matplotlib-inline = "*"
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
+pickleshare = "*"
+prompt-toolkit = ">3.0.1,<3.1.0"
+pygments = ">=2.4.0"
+stack-data = "*"
+traitlets = ">=5"
+
+[package.extras]
+all = ["Sphinx (>=1.3)", "black", "curio", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.19)", "pandas", "pytest (<7.1)", "pytest-asyncio", "qtconsole", "testpath", "trio"]
+black = ["black"]
+doc = ["Sphinx (>=1.3)"]
+kernel = ["ipykernel"]
+nbconvert = ["nbconvert"]
+nbformat = ["nbformat"]
+notebook = ["ipywidgets", "notebook"]
+parallel = ["ipyparallel"]
+qtconsole = ["qtconsole"]
+test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
+test_extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
+
+[[package]]
+name = "itsdangerous"
+version = "2.1.2"
+description = "Safely pass data to untrusted environments and back."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "jaraco.classes"
+version = "3.2.2"
+description = "Utility functions for Python class constructs"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
+[[package]]
+name = "jedi"
+version = "0.18.1"
+description = "An autocompletion tool for Python that can be used for text editors."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+parso = ">=0.8.0,<0.9.0"
+
+[package.extras]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
+
+[[package]]
+name = "jeepney"
+version = "0.8.0"
+description = "Low-level, pure Python DBus protocol wrapper."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["async-timeout", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
+trio = ["async_generator", "trio"]
+
+[[package]]
+name = "Jinja2"
+version = "3.1.2"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "jschema-to-python"
+version = "1.2.3"
+description = "Generate source code for Python classes from a JSON schema."
+category = "main"
+optional = false
+python-versions = ">= 2.7"
+
+[package.dependencies]
+attrs = "*"
+jsonpickle = "*"
+pbr = "*"
+
+[[package]]
+name = "jsondiff"
+version = "2.0.0"
+description = "Diff JSON and JSON-like structures in Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "jsonpatch"
+version = "1.32"
+description = "Apply JSON-Patches (RFC 6902)"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+jsonpointer = ">=1.9"
+
+[[package]]
+name = "jsonpickle"
+version = "2.2.0"
+description = "Python library for serializing any arbitrary object graph into JSON"
+category = "main"
+optional = false
+python-versions = ">=2.7"
+
+[package.extras]
+docs = ["jaraco.packaging (>=3.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["ecdsa", "enum34", "feedparser", "jsonlib", "numpy", "pandas", "pymongo", "pytest (>=3.5,!=3.7.3)", "pytest-black-multipy", "pytest-checkdocs (>=1.2.3)", "pytest-cov", "pytest-flake8 (<1.1.0)", "pytest-flake8 (>=1.1.1)", "scikit-learn", "sqlalchemy"]
+"testing.libs" = ["simplejson", "ujson", "yajl"]
+
+[[package]]
+name = "jsonpointer"
+version = "2.3"
+description = "Identify specific nodes in a JSON document (RFC 6901)"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "jsonschema"
+version = "3.2.0"
+description = "An implementation of JSON Schema validation for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+attrs = ">=17.4.0"
+pyrsistent = ">=0.14.0"
+setuptools = "*"
+six = ">=1.11.0"
+
+[package.extras]
+format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
+format_nongpl = ["idna", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "webcolors"]
+
+[[package]]
+name = "junit-xml"
+version = "1.9"
+description = "Creates JUnit XML test result documents that can be read by tools such as Jenkins"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
+name = "keyring"
+version = "23.9.1"
+description = "Store and access your passwords safely."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+importlib-metadata = {version = ">=3.6", markers = "python_version < \"3.10\""}
+"jaraco.classes" = "*"
+jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
+pywin32-ctypes = {version = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1", markers = "sys_platform == \"win32\""}
+SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
+
+[package.extras]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
+[[package]]
+name = "MarkupSafe"
+version = "2.1.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.1.6"
+description = "Inline Matplotlib backend for Jupyter"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+traitlets = "*"
+
+[[package]]
+name = "more-itertools"
+version = "8.14.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "moto"
+version = "3.1.1"
+description = "A library that allows your python tests to easily mock out the boto library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+aws-xray-sdk = {version = ">=0.93,<0.96 || >0.96", optional = true, markers = "extra == \"all\""}
+boto3 = ">=1.9.201"
+botocore = ">=1.12.201"
+cfn-lint = {version = ">=0.4.0", optional = true, markers = "extra == \"all\""}
+cryptography = ">=3.3.1"
+docker = {version = ">=2.5.1", optional = true, markers = "extra == \"all\""}
+ecdsa = {version = "!=0.15", optional = true, markers = "extra == \"all\""}
+flask = {version = "*", optional = true, markers = "extra == \"server\""}
+flask-cors = {version = "*", optional = true, markers = "extra == \"server\""}
+graphql-core = {version = "*", optional = true, markers = "extra == \"all\""}
+idna = {version = ">=2.5,<4", optional = true, markers = "extra == \"all\""}
+Jinja2 = ">=2.10.1"
+jsondiff = {version = ">=1.1.2", optional = true, markers = "extra == \"all\""}
+MarkupSafe = "!=2.0.0a1"
+python-dateutil = ">=2.1,<3.0.0"
+python-jose = {version = ">=3.1.0,<4.0.0", extras = ["cryptography"], optional = true, markers = "extra == \"all\""}
+pytz = "*"
+PyYAML = {version = ">=5.1", optional = true, markers = "extra == \"all\""}
+requests = ">=2.5"
+responses = ">=0.9.0"
+setuptools = {version = "*", optional = true, markers = "extra == \"all\""}
+sshpubkeys = {version = ">=3.1.0", optional = true, markers = "extra == \"all\""}
+werkzeug = "*"
+xmltodict = "*"
+
+[package.extras]
+all = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.4.0)", "docker (>=2.5.1)", "ecdsa (!=0.15)", "graphql-core", "idna (>=2.5,<4)", "jsondiff (>=1.1.2)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+apigateway = ["PyYAML (>=5.1)", "ecdsa (!=0.15)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
+apigatewayv2 = ["PyYAML (>=5.1)"]
+appsync = ["graphql-core"]
+awslambda = ["docker (>=2.5.1)"]
+batch = ["docker (>=2.5.1)"]
+cloudformation = ["PyYAML (>=5.1)", "cfn-lint (>=0.4.0)", "docker (>=2.5.1)"]
+cognitoidp = ["ecdsa (!=0.15)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
+ds = ["sshpubkeys (>=3.1.0)"]
+dynamodb = ["docker (>=2.5.1)"]
+dynamodb2 = ["docker (>=2.5.1)"]
+dynamodbstreams = ["docker (>=2.5.1)"]
+ec2 = ["sshpubkeys (>=3.1.0)"]
+efs = ["sshpubkeys (>=3.1.0)"]
+iotdata = ["jsondiff (>=1.1.2)"]
+route53resolver = ["sshpubkeys (>=3.1.0)"]
+s3 = ["PyYAML (>=5.1)"]
+server = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.4.0)", "docker (>=2.5.1)", "ecdsa (!=0.15)", "flask", "flask-cors", "graphql-core", "idna (>=2.5,<4)", "jsondiff (>=1.1.2)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+ssm = ["PyYAML (>=5.1)", "dataclasses"]
+xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
+
+[[package]]
+name = "networkx"
+version = "2.8.6"
+description = "Python package for creating and manipulating graphs and networks"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.extras]
+default = ["matplotlib (>=3.4)", "numpy (>=1.19)", "pandas (>=1.3)", "scipy (>=1.8)"]
+developer = ["mypy (>=0.961)", "pre-commit (>=2.20)"]
+doc = ["nb2plots (>=0.6)", "numpydoc (>=1.4)", "pillow (>=9.1)", "pydata-sphinx-theme (>=0.9)", "sphinx (>=5)", "sphinx-gallery (>=0.10)", "texext (>=0.6.6)"]
+extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.9)", "sympy (>=1.10)"]
+test = ["codecov (>=2.1)", "pytest (>=7.1)", "pytest-cov (>=3.0)"]
+
+[[package]]
+name = "numpy"
+version = "1.22.3"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[[package]]
+name = "opencv-python"
+version = "4.6.0.66"
+description = "Wrapper package for OpenCV python bindings."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.21.2", markers = "python_version >= \"3.10\" or python_version >= \"3.6\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
+    {version = ">=1.19.3", markers = "python_version >= \"3.6\" and platform_system == \"Linux\" and platform_machine == \"aarch64\" or python_version >= \"3.9\""},
+    {version = ">=1.14.5", markers = "python_version >= \"3.7\""},
+    {version = ">=1.17.3", markers = "python_version >= \"3.8\""},
+]
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "parso"
+version = "0.8.3"
+description = "A Python Parser"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["docopt", "pytest (<6.0.0)"]
+
+[[package]]
+name = "pbr"
+version = "5.10.0"
+description = "Python Build Reasonableness"
+category = "main"
+optional = false
+python-versions = ">=2.6"
+
+[[package]]
+name = "pexpect"
+version = "4.8.0"
+description = "Pexpect allows easy control of interactive console applications."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+ptyprocess = ">=0.5"
+
+[[package]]
+name = "pickleshare"
+version = "0.7.5"
+description = "Tiny 'shelve'-like database with concurrency support"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.31"
+description = "Library for building powerful interactive command lines in Python"
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pure-eval"
+version = "0.2.2"
+description = "Safely evaluate AST nodes without side effects"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+tests = ["pytest"]
+
+[[package]]
+name = "pyasn1"
+version = "0.4.8"
+description = "ASN.1 types and codecs"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "Pygments"
+version = "2.13.0"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+plugins = ["importlib-metadata"]
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "main"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pyrsistent"
+version = "0.18.1"
+description = "Persistent/Functional/Immutable data structures"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "python-jose"
+version = "3.1.0"
+description = "JOSE implementation in Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+cryptography = {version = "*", optional = true, markers = "extra == \"cryptography\""}
+ecdsa = "<1.0"
+pyasn1 = "*"
+rsa = "*"
+six = "<2.0"
+
+[package.extras]
+cryptography = ["cryptography"]
+pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
+pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
+
+[[package]]
+name = "pytz"
+version = "2022.2.1"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pywin32"
+version = "304"
+description = "Python for Window Extensions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "PyYAML"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "requests"
+version = "2.28.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "responses"
+version = "0.21.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+requests = ">=2.0,<3.0"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-localserver", "types-mock", "types-requests"]
+
+[[package]]
+name = "rsa"
+version = "4.9"
+description = "Pure-Python RSA implementation"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4"
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "s3transfer"
+version = "0.6.0"
+description = "An Amazon S3 Transfer Manager"
+category = "main"
+optional = false
+python-versions = ">= 3.7"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+
+[[package]]
+name = "sarif-om"
+version = "1.0.4"
+description = "Classes implementing the SARIF 2.1.0 object model."
+category = "main"
+optional = false
+python-versions = ">= 2.7"
+
+[package.dependencies]
+attrs = "*"
+pbr = "*"
+
+[[package]]
+name = "SecretStorage"
+version = "3.3.3"
+description = "Python bindings to FreeDesktop.org Secret Service API"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cryptography = ">=2.0"
+jeepney = ">=0.6"
+
+[[package]]
+name = "setproctitle"
+version = "1.2.2"
+description = "A Python module to customize the process title"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+test = ["pytest (>=6.1,<6.2)"]
+
+[[package]]
+name = "setuptools"
+version = "59.2.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-inline-tabs", "sphinxcontrib-towncrier"]
+testing = ["flake8-2020", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "paver", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy", "pytest-virtualenv (>=1.2.7)", "pytest-xdist", "sphinx", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "SQLAlchemy"
+version = "1.4.41"
+description = "Database Abstraction Library"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+
+[package.dependencies]
+greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
+
+[package.extras]
+aiomysql = ["aiomysql", "greenlet (!=0.4.17)"]
+aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing_extensions (!=3.10.0.1)"]
+asyncio = ["greenlet (!=0.4.17)"]
+asyncmy = ["asyncmy (>=0.2.3,!=0.2.4)", "greenlet (!=0.4.17)"]
+mariadb_connector = ["mariadb (>=1.0.1,!=1.1.2)"]
+mssql = ["pyodbc"]
+mssql_pymssql = ["pymssql"]
+mssql_pyodbc = ["pyodbc"]
+mypy = ["mypy (>=0.910)", "sqlalchemy2-stubs"]
+mysql = ["mysqlclient (>=1.4.0)", "mysqlclient (>=1.4.0,<2)"]
+mysql_connector = ["mysql-connector-python"]
+oracle = ["cx_oracle (>=7)", "cx_oracle (>=7,<8)"]
+postgresql = ["psycopg2 (>=2.7)"]
+postgresql_asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
+postgresql_pg8000 = ["pg8000 (>=1.16.6,!=1.29.0)"]
+postgresql_psycopg2binary = ["psycopg2-binary"]
+postgresql_psycopg2cffi = ["psycopg2cffi"]
+pymysql = ["pymysql", "pymysql (<1)"]
+sqlcipher = ["sqlcipher3_binary"]
+
+[[package]]
+name = "SQLAlchemy-Utils"
+version = "0.38.2"
+description = "Various utility functions for SQLAlchemy."
+category = "main"
+optional = false
+python-versions = "~=3.4"
+
+[package.dependencies]
+six = "*"
+SQLAlchemy = ">=1.0"
+
+[package.extras]
+arrow = ["arrow (>=0.3.4)"]
+babel = ["Babel (>=1.3)"]
+color = ["colour (>=0.0.4)"]
+encrypted = ["cryptography (>=0.6)"]
+intervals = ["intervals (>=0.7.1)"]
+password = ["passlib (>=1.6,<2.0)"]
+pendulum = ["pendulum (>=2.0.5)"]
+phone = ["phonenumbers (>=5.9.2)"]
+test = ["Jinja2 (>=2.3)", "Pygments (>=1.2)", "backports.zoneinfo", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "isort (>=4.2.2)", "mock (==2.0.0)", "pg8000 (>=1.12.4)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (>=2.7.1)", "python-dateutil (>=2.6)", "pytz (>=2014.2)"]
+test_all = ["Babel (>=1.3)", "Jinja2 (>=2.3)", "Pygments (>=1.2)", "arrow (>=0.3.4)", "backports.zoneinfo", "colour (>=0.0.4)", "cryptography (>=0.6)", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "furl (>=0.4.1)", "intervals (>=0.7.1)", "isort (>=4.2.2)", "mock (==2.0.0)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "pg8000 (>=1.12.4)", "phonenumbers (>=5.9.2)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (>=2.7.1)", "python-dateutil", "python-dateutil (>=2.6)", "pytz (>=2014.2)"]
+timezone = ["python-dateutil"]
+url = ["furl (>=0.4.1)"]
+
+[[package]]
+name = "sshpubkeys"
+version = "3.3.1"
+description = "SSH public key parser"
+category = "main"
+optional = false
+python-versions = ">=3"
+
+[package.dependencies]
+cryptography = ">=2.1.4"
+ecdsa = ">=0.13"
+
+[package.extras]
+dev = ["twine", "wheel", "yapf"]
+
+[[package]]
+name = "stack-data"
+version = "0.5.0"
+description = "Extract data from python stack frames and tracebacks for informative displays"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+asttokens = "*"
+executing = "*"
+pure-eval = "*"
+
+[package.extras]
+tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
+
+[[package]]
+name = "traitlets"
+version = "5.4.0"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pre-commit", "pytest"]
+
+[[package]]
+name = "tree-sitter"
+version = "0.20.0"
+description = "Python bindings to the Tree-sitter parsing library"
+category = "main"
+optional = false
+python-versions = ">=3.3"
+
+[[package]]
+name = "urllib3"
+version = "1.26.12"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "websocket-client"
+version = "1.4.1"
+description = "WebSocket client for Python with low level API options"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
+optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
+
+[[package]]
+name = "Werkzeug"
+version = "2.2.2"
+description = "The comprehensive WSGI web application library."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+MarkupSafe = ">=2.1.1"
+
+[package.extras]
+watchdog = ["watchdog"]
+
+[[package]]
+name = "wheel"
+version = "0.37.0"
+description = "A built-package format for Python"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.extras]
+test = ["pytest (>=3.0.0)", "pytest-cov"]
+
+[[package]]
+name = "wrapt"
+version = "1.14.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "xmltodict"
+version = "0.13.0"
+description = "Makes working with XML feel like you are working with JSON"
+category = "main"
+optional = false
+python-versions = ">=3.4"
+
+[[package]]
+name = "zipp"
+version = "3.8.1"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "~=3.9"
+content-hash = "b00ff4411221f1d8cf7293978de9fce46f0b25484fded3058e4a002e1494a040"
+
+[metadata.files]
+appnope = [
+    {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
+    {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
+]
+asttokens = [
+    {file = "asttokens-2.0.8-py2.py3-none-any.whl", hash = "sha256:e3305297c744ae53ffa032c45dc347286165e4ffce6875dc662b205db0623d86"},
+    {file = "asttokens-2.0.8.tar.gz", hash = "sha256:c61e16246ecfb2cde2958406b4c8ebc043c9e6d73aaa83c941673b35e5d3a76b"},
+]
+attrs = [
+    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
+    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+]
+aws-sam-translator = [
+    {file = "aws-sam-translator-1.51.0.tar.gz", hash = "sha256:4c39d78dd92a8d4b46b5b02dc74e6f0ef8713109ebc8910aec234c3b18649ffb"},
+    {file = "aws_sam_translator-1.51.0-py2-none-any.whl", hash = "sha256:6f990c6a8f0e0f660aa49b073af9fc82bef2935c1b8c4552d71cff87eb2f8233"},
+    {file = "aws_sam_translator-1.51.0-py3-none-any.whl", hash = "sha256:f0f09f95fcc0c5e699603b9b1daa86307b94920b0823c423ed2ff1eb1cac497f"},
+]
+aws-xray-sdk = [
+    {file = "aws-xray-sdk-2.10.0.tar.gz", hash = "sha256:9b14924fd0628cf92936055864655354003f0b1acc3e1c3ffde6403d0799dd7a"},
+    {file = "aws_xray_sdk-2.10.0-py2.py3-none-any.whl", hash = "sha256:7551e81a796e1a5471ebe84844c40e8edf7c218db33506d046fec61f7495eda4"},
+]
+backcall = [
+    {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
+    {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
+boto3 = [
+    {file = "boto3-1.24.73-py3-none-any.whl", hash = "sha256:f7ca88a76c8e31c19fef3bad2dee3c2ee0e77a0bced151fa3922cf021d55755e"},
+    {file = "boto3-1.24.73.tar.gz", hash = "sha256:a8911d55f1497dc55d69d2029c3a5120887af4846ef6b9fe3ef0c777dc1b394e"},
+]
+botocore = [
+    {file = "botocore-1.27.73-py3-none-any.whl", hash = "sha256:0b94d1e7b1435f8ff108c74a09fe03ec88aadbfafe97e940ea415dc86ba305a3"},
+    {file = "botocore-1.27.73.tar.gz", hash = "sha256:e281e45e84d2728207d63499a37cea1dc1dde6093167ab238370ece67f6e7316"},
+]
+certifi = [
+    {file = "certifi-2022.9.14-py3-none-any.whl", hash = "sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516"},
+    {file = "certifi-2022.9.14.tar.gz", hash = "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5"},
+]
+cffi = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
+]
+cfn-lint = [
+    {file = "cfn-lint-0.65.0.tar.gz", hash = "sha256:a83c6844463d79dfaa2f7747dfc98282af901502a7db4c66cb7200262e3cc1d0"},
+    {file = "cfn_lint-0.65.0-py3-none-any.whl", hash = "sha256:b5992f52a86e6ef0a150fabbb4d131bbf626eddd4154ca708193c1d233a7efca"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
+    {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+cognitojwt = [
+    {file = "cognitojwt-1.4.1-py3-none-any.whl", hash = "sha256:8ee189f82289d140dc750c91e8772436b64b94d071507ace42efc22c525f42ce"},
+    {file = "cognitojwt-1.4.1.tar.gz", hash = "sha256:a9f751942517ecf85da9f14674749390aad268e4b0155ef7d133aa50800aa15a"},
+]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+cryptography = [
+    {file = "cryptography-38.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f"},
+    {file = "cryptography-38.0.1-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:3b72c360427889b40f36dc214630e688c2fe03e16c162ef0aa41da7ab1455153"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:194044c6b89a2f9f169df475cc167f6157eb9151cc69af8a2a163481d45cc407"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:16fa61e7481f4b77ef53991075de29fc5bacb582a1244046d2e8b4bb72ef66d0"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d4ef6cc305394ed669d4d9eebf10d3a101059bdcf2669c366ec1d14e4fb227bd"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3261725c0ef84e7592597606f6583385fed2a5ec3909f43bc475ade9729a41d6"},
+    {file = "cryptography-38.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:0297ffc478bdd237f5ca3a7dc96fc0d315670bfa099c04dc3a4a2172008a405a"},
+    {file = "cryptography-38.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:89ed49784ba88c221756ff4d4755dbc03b3c8d2c5103f6d6b4f83a0fb1e85294"},
+    {file = "cryptography-38.0.1-cp36-abi3-win32.whl", hash = "sha256:ac7e48f7e7261207d750fa7e55eac2d45f720027d5703cd9007e9b37bbb59ac0"},
+    {file = "cryptography-38.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:ad7353f6ddf285aeadfaf79e5a6829110106ff8189391704c1d8801aa0bae45a"},
+    {file = "cryptography-38.0.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:896dd3a66959d3a5ddcfc140a53391f69ff1e8f25d93f0e2e7830c6de90ceb9d"},
+    {file = "cryptography-38.0.1-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d3971e2749a723e9084dd507584e2a2761f78ad2c638aa31e80bc7a15c9db4f9"},
+    {file = "cryptography-38.0.1-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:79473cf8a5cbc471979bd9378c9f425384980fcf2ab6534b18ed7d0d9843987d"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:d9e69ae01f99abe6ad646947bba8941e896cb3aa805be2597a0400e0764b5818"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5067ee7f2bce36b11d0e334abcd1ccf8c541fc0bbdaf57cdd511fdee53e879b6"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:3e3a2599e640927089f932295a9a247fc40a5bdf69b0484532f530471a382750"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c2e5856248a416767322c8668ef1845ad46ee62629266f84a8f007a317141013"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:64760ba5331e3f1794d0bcaabc0d0c39e8c60bf67d09c93dc0e54189dfd7cfe5"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b6c9b706316d7b5a137c35e14f4103e2115b088c412140fdbd5f87c73284df61"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0163a849b6f315bf52815e238bc2b2346604413fa7c1601eea84bcddb5fb9ac"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d1a5bd52d684e49a36582193e0b89ff267704cd4025abefb9e26803adeb3e5fb"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:765fa194a0f3372d83005ab83ab35d7c5526c4e22951e46059b8ac678b44fa5a"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b"},
+    {file = "cryptography-38.0.1.tar.gz", hash = "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7"},
+]
+Cython = [
+    {file = "Cython-0.29.32-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:39afb4679b8c6bf7ccb15b24025568f4f9b4d7f9bf3cbd981021f542acecd75b"},
+    {file = "Cython-0.29.32-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:dbee03b8d42dca924e6aa057b836a064c769ddfd2a4c2919e65da2c8a362d528"},
+    {file = "Cython-0.29.32-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ba622326f2862f9c1f99ca8d47ade49871241920a352c917e16861e25b0e5c3"},
+    {file = "Cython-0.29.32-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e6ffa08aa1c111a1ebcbd1cf4afaaec120bc0bbdec3f2545f8bb7d3e8e77a1cd"},
+    {file = "Cython-0.29.32-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:97335b2cd4acebf30d14e2855d882de83ad838491a09be2011745579ac975833"},
+    {file = "Cython-0.29.32-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:06be83490c906b6429b4389e13487a26254ccaad2eef6f3d4ee21d8d3a4aaa2b"},
+    {file = "Cython-0.29.32-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:eefd2b9a5f38ded8d859fe96cc28d7d06e098dc3f677e7adbafda4dcdd4a461c"},
+    {file = "Cython-0.29.32-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5514f3b4122cb22317122a48e175a7194e18e1803ca555c4c959d7dfe68eaf98"},
+    {file = "Cython-0.29.32-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:656dc5ff1d269de4d11ee8542f2ffd15ab466c447c1f10e5b8aba6f561967276"},
+    {file = "Cython-0.29.32-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:cdf10af3e2e3279dc09fdc5f95deaa624850a53913f30350ceee824dc14fc1a6"},
+    {file = "Cython-0.29.32-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:3875c2b2ea752816a4d7ae59d45bb546e7c4c79093c83e3ba7f4d9051dd02928"},
+    {file = "Cython-0.29.32-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:79e3bab19cf1b021b613567c22eb18b76c0c547b9bc3903881a07bfd9e7e64cf"},
+    {file = "Cython-0.29.32-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0595aee62809ba353cebc5c7978e0e443760c3e882e2c7672c73ffe46383673"},
+    {file = "Cython-0.29.32-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0ea8267fc373a2c5064ad77d8ff7bf0ea8b88f7407098ff51829381f8ec1d5d9"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:c8e8025f496b5acb6ba95da2fb3e9dacffc97d9a92711aacfdd42f9c5927e094"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:afbce249133a830f121b917f8c9404a44f2950e0e4f5d1e68f043da4c2e9f457"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:513e9707407608ac0d306c8b09d55a28be23ea4152cbd356ceaec0f32ef08d65"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e83228e0994497900af954adcac27f64c9a57cd70a9ec768ab0cb2c01fd15cf1"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ea1dcc07bfb37367b639415333cfbfe4a93c3be340edf1db10964bc27d42ed64"},
+    {file = "Cython-0.29.32-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8669cadeb26d9a58a5e6b8ce34d2c8986cc3b5c0bfa77eda6ceb471596cb2ec3"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:ed087eeb88a8cf96c60fb76c5c3b5fb87188adee5e179f89ec9ad9a43c0c54b3"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:3f85eb2343d20d91a4ea9cf14e5748092b376a64b7e07fc224e85b2753e9070b"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:63b79d9e1f7c4d1f498ab1322156a0d7dc1b6004bf981a8abda3f66800e140cd"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e1958e0227a4a6a2c06fd6e35b7469de50adf174102454db397cec6e1403cce3"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:856d2fec682b3f31583719cb6925c6cdbb9aa30f03122bcc45c65c8b6f515754"},
+    {file = "Cython-0.29.32-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:479690d2892ca56d34812fe6ab8f58e4b2e0129140f3d94518f15993c40553da"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:67fdd2f652f8d4840042e2d2d91e15636ba2bcdcd92e7e5ffbc68e6ef633a754"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:4a4b03ab483271f69221c3210f7cde0dcc456749ecf8243b95bc7a701e5677e0"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:40eff7aa26e91cf108fd740ffd4daf49f39b2fdffadabc7292b4b7dc5df879f0"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0bbc27abdf6aebfa1bce34cd92bd403070356f28b0ecb3198ff8a182791d58b9"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cddc47ec746a08603037731f5d10aebf770ced08666100bd2cdcaf06a85d4d1b"},
+    {file = "Cython-0.29.32-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:eca3065a1279456e81c615211d025ea11bfe4e19f0c5650b859868ca04b3fcbd"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:d968ffc403d92addf20b68924d95428d523436adfd25cf505d427ed7ba3bee8b"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:f3fd44cc362eee8ae569025f070d56208908916794b6ab21e139cea56470a2b3"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:b6da3063c5c476f5311fd76854abae6c315f1513ef7d7904deed2e774623bbb9"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:061e25151c38f2361bc790d3bcf7f9d9828a0b6a4d5afa56fbed3bd33fb2373a"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f9944013588a3543fca795fffb0a070a31a243aa4f2d212f118aa95e69485831"},
+    {file = "Cython-0.29.32-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:07d173d3289415bb496e72cb0ddd609961be08fe2968c39094d5712ffb78672b"},
+    {file = "Cython-0.29.32-py2.py3-none-any.whl", hash = "sha256:eeb475eb6f0ccf6c039035eb4f0f928eb53ead88777e0a760eccb140ad90930b"},
+    {file = "Cython-0.29.32.tar.gz", hash = "sha256:8733cf4758b79304f2a4e39ebfac5e92341bce47bcceb26c1254398b2f8c1af7"},
+]
+decorator = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+docker = [
+    {file = "docker-6.0.0-py3-none-any.whl", hash = "sha256:6e06ee8eca46cd88733df09b6b80c24a1a556bc5cb1e1ae54b2c239886d245cf"},
+    {file = "docker-6.0.0.tar.gz", hash = "sha256:19e330470af40167d293b0352578c1fa22d74b34d3edf5d4ff90ebc203bbb2f1"},
+]
+ecdsa = [
+    {file = "ecdsa-0.18.0-py2.py3-none-any.whl", hash = "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"},
+    {file = "ecdsa-0.18.0.tar.gz", hash = "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49"},
+]
+executing = [
+    {file = "executing-1.0.0-py2.py3-none-any.whl", hash = "sha256:550d581b497228b572235e633599133eeee67073c65914ca346100ad56775349"},
+    {file = "executing-1.0.0.tar.gz", hash = "sha256:98daefa9d1916a4f0d944880d5aeaf079e05585689bebd9ff9b32e31dd5e1017"},
+]
+Flask = [
+    {file = "Flask-2.2.2-py3-none-any.whl", hash = "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"},
+    {file = "Flask-2.2.2.tar.gz", hash = "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b"},
+]
+Flask-Cors = [
+    {file = "Flask-Cors-3.0.10.tar.gz", hash = "sha256:b60839393f3b84a0f3746f6cdca56c1ad7426aa738b70d6c61375857823181de"},
+    {file = "Flask_Cors-3.0.10-py2.py3-none-any.whl", hash = "sha256:74efc975af1194fc7891ff5cd85b0f7478be4f7f59fe158102e91abb72bb4438"},
+]
+future = [
+    {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
+graphql-core = [
+    {file = "graphql-core-3.2.1.tar.gz", hash = "sha256:9d1bf141427b7d54be944587c8349df791ce60ade2e3cccaf9c56368c133c201"},
+    {file = "graphql_core-3.2.1-py3-none-any.whl", hash = "sha256:f83c658e4968998eed1923a2e3e3eddd347e005ac0315fbb7ca4d70ea9156323"},
+]
+greenlet = [
+    {file = "greenlet-1.1.3-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:8c287ae7ac921dfde88b1c125bd9590b7ec3c900c2d3db5197f1286e144e712b"},
+    {file = "greenlet-1.1.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:870a48007872d12e95a996fca3c03a64290d3ea2e61076aa35d3b253cf34cd32"},
+    {file = "greenlet-1.1.3-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:7c5227963409551ae4a6938beb70d56bf1918c554a287d3da6853526212fbe0a"},
+    {file = "greenlet-1.1.3-cp27-cp27m-win32.whl", hash = "sha256:9fae214f6c43cd47f7bef98c56919b9222481e833be2915f6857a1e9e8a15318"},
+    {file = "greenlet-1.1.3-cp27-cp27m-win_amd64.whl", hash = "sha256:de431765bd5fe62119e0bc6bc6e7b17ac53017ae1782acf88fcf6b7eae475a49"},
+    {file = "greenlet-1.1.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:510c3b15587afce9800198b4b142202b323bf4b4b5f9d6c79cb9a35e5e3c30d2"},
+    {file = "greenlet-1.1.3-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:9951dcbd37850da32b2cb6e391f621c1ee456191c6ae5528af4a34afe357c30e"},
+    {file = "greenlet-1.1.3-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:07c58e169bbe1e87b8bbf15a5c1b779a7616df9fd3e61cadc9d691740015b4f8"},
+    {file = "greenlet-1.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df02fdec0c533301497acb0bc0f27f479a3a63dcdc3a099ae33a902857f07477"},
+    {file = "greenlet-1.1.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9c88e134d51d5e82315a7c32b914a58751b7353eb5268dbd02eabf020b4c4700"},
+    {file = "greenlet-1.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b41d19c0cfe5c259fe6c539fd75051cd39a5d33d05482f885faf43f7f5e7d26"},
+    {file = "greenlet-1.1.3-cp310-cp310-win_amd64.whl", hash = "sha256:6f5d4b2280ceea76c55c893827961ed0a6eadd5a584a7c4e6e6dd7bc10dfdd96"},
+    {file = "greenlet-1.1.3-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:184416e481295832350a4bf731ba619a92f5689bf5d0fa4341e98b98b1265bd7"},
+    {file = "greenlet-1.1.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd0404d154084a371e6d2bafc787201612a1359c2dee688ae334f9118aa0bf47"},
+    {file = "greenlet-1.1.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7a43bbfa9b6cfdfaeefbd91038dde65ea2c421dc387ed171613df340650874f2"},
+    {file = "greenlet-1.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce5b64dfe8d0cca407d88b0ee619d80d4215a2612c1af8c98a92180e7109f4b5"},
+    {file = "greenlet-1.1.3-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:903fa5716b8fbb21019268b44f73f3748c41d1a30d71b4a49c84b642c2fed5fa"},
+    {file = "greenlet-1.1.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:0118817c9341ef2b0f75f5af79ac377e4da6ff637e5ee4ac91802c0e379dadb4"},
+    {file = "greenlet-1.1.3-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:466ce0928e33421ee84ae04c4ac6f253a3a3e6b8d600a79bd43fd4403e0a7a76"},
+    {file = "greenlet-1.1.3-cp35-cp35m-win32.whl", hash = "sha256:65ad1a7a463a2a6f863661329a944a5802c7129f7ad33583dcc11069c17e622c"},
+    {file = "greenlet-1.1.3-cp35-cp35m-win_amd64.whl", hash = "sha256:7532a46505470be30cbf1dbadb20379fb481244f1ca54207d7df3bf0bbab6a20"},
+    {file = "greenlet-1.1.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:caff52cb5cd7626872d9696aee5b794abe172804beb7db52eed1fd5824b63910"},
+    {file = "greenlet-1.1.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:db41f3845eb579b544c962864cce2c2a0257fe30f0f1e18e51b1e8cbb4e0ac6d"},
+    {file = "greenlet-1.1.3-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:e8533f5111704d75de3139bf0b8136d3a6c1642c55c067866fa0a51c2155ee33"},
+    {file = "greenlet-1.1.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9537e4baf0db67f382eb29255a03154fcd4984638303ff9baaa738b10371fa57"},
+    {file = "greenlet-1.1.3-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8bfd36f368efe0ab2a6aa3db7f14598aac454b06849fb633b762ddbede1db90"},
+    {file = "greenlet-1.1.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0877a9a2129a2c56a2eae2da016743db7d9d6a05d5e1c198f1b7808c602a30e"},
+    {file = "greenlet-1.1.3-cp36-cp36m-win32.whl", hash = "sha256:88b04e12c9b041a1e0bcb886fec709c488192638a9a7a3677513ac6ba81d8e79"},
+    {file = "greenlet-1.1.3-cp36-cp36m-win_amd64.whl", hash = "sha256:4f166b4aca8d7d489e82d74627a7069ab34211ef5ebb57c300ec4b9337b60fc0"},
+    {file = "greenlet-1.1.3-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:cd16a89efe3a003029c87ff19e9fba635864e064da646bc749fc1908a4af18f3"},
+    {file = "greenlet-1.1.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5b756e6730ea59b2745072e28ad27f4c837084688e6a6b3633c8b1e509e6ae0e"},
+    {file = "greenlet-1.1.3-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:9b2f7d0408ddeb8ea1fd43d3db79a8cefaccadd2a812f021333b338ed6b10aba"},
+    {file = "greenlet-1.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44b4817c34c9272c65550b788913620f1fdc80362b209bc9d7dd2f40d8793080"},
+    {file = "greenlet-1.1.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d58a5a71c4c37354f9e0c24c9c8321f0185f6945ef027460b809f4bb474bfe41"},
+    {file = "greenlet-1.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dd51d2650e70c6c4af37f454737bf4a11e568945b27f74b471e8e2a9fd21268"},
+    {file = "greenlet-1.1.3-cp37-cp37m-win32.whl", hash = "sha256:048d2bed76c2aa6de7af500ae0ea51dd2267aec0e0f2a436981159053d0bc7cc"},
+    {file = "greenlet-1.1.3-cp37-cp37m-win_amd64.whl", hash = "sha256:77e41db75f9958f2083e03e9dd39da12247b3430c92267df3af77c83d8ff9eed"},
+    {file = "greenlet-1.1.3-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:1626185d938d7381631e48e6f7713e8d4b964be246073e1a1d15c2f061ac9f08"},
+    {file = "greenlet-1.1.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:1ec2779774d8e42ed0440cf8bc55540175187e8e934f2be25199bf4ed948cd9e"},
+    {file = "greenlet-1.1.3-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:f2f908239b7098799b8845e5936c2ccb91d8c2323be02e82f8dcb4a80dcf4a25"},
+    {file = "greenlet-1.1.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b181e9aa6cb2f5ec0cacc8cee6e5a3093416c841ba32c185c30c160487f0380"},
+    {file = "greenlet-1.1.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2cf45e339cabea16c07586306a31cfcc5a3b5e1626d365714d283732afed6809"},
+    {file = "greenlet-1.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6200a11f003ec26815f7e3d2ded01b43a3810be3528dd760d2f1fa777490c3cd"},
+    {file = "greenlet-1.1.3-cp38-cp38-win32.whl", hash = "sha256:db5b25265010a1b3dca6a174a443a0ed4c4ab12d5e2883a11c97d6e6d59b12f9"},
+    {file = "greenlet-1.1.3-cp38-cp38-win_amd64.whl", hash = "sha256:095a980288fe05adf3d002fbb180c99bdcf0f930e220aa66fcd56e7914a38202"},
+    {file = "greenlet-1.1.3-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:cbc1eb55342cbac8f7ec159088d54e2cfdd5ddf61c87b8bbe682d113789331b2"},
+    {file = "greenlet-1.1.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:694ffa7144fa5cc526c8f4512665003a39fa09ef00d19bbca5c8d3406db72fbe"},
+    {file = "greenlet-1.1.3-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:aa741c1a8a8cc25eb3a3a01a62bdb5095a773d8c6a86470bde7f607a447e7905"},
+    {file = "greenlet-1.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3a669f11289a8995d24fbfc0e63f8289dd03c9aaa0cc8f1eab31d18ca61a382"},
+    {file = "greenlet-1.1.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76a53bfa10b367ee734b95988bd82a9a5f0038a25030f9f23bbbc005010ca600"},
+    {file = "greenlet-1.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fb0aa7f6996879551fd67461d5d3ab0c3c0245da98be90c89fcb7a18d437403"},
+    {file = "greenlet-1.1.3-cp39-cp39-win32.whl", hash = "sha256:5fbe1ab72b998ca77ceabbae63a9b2e2dc2d963f4299b9b278252ddba142d3f1"},
+    {file = "greenlet-1.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:ffe73f9e7aea404722058405ff24041e59d31ca23d1da0895af48050a07b6932"},
+    {file = "greenlet-1.1.3.tar.gz", hash = "sha256:bcb6c6dd1d6be6d38d6db283747d07fda089ff8c559a835236560a4410340455"},
+]
+idna = [
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
+    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
+]
+ipython = [
+    {file = "ipython-8.5.0-py3-none-any.whl", hash = "sha256:6f090e29ab8ef8643e521763a4f1f39dc3914db643122b1e9d3328ff2e43ada2"},
+    {file = "ipython-8.5.0.tar.gz", hash = "sha256:097bdf5cd87576fd066179c9f7f208004f7a6864ee1b20f37d346c0bcb099f84"},
+]
+itsdangerous = [
+    {file = "itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44"},
+    {file = "itsdangerous-2.1.2.tar.gz", hash = "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"},
+]
+"jaraco.classes" = [
+    {file = "jaraco.classes-3.2.2-py3-none-any.whl", hash = "sha256:e6ef6fd3fcf4579a7a019d87d1e56a883f4e4c35cfe925f86731abc58804e647"},
+    {file = "jaraco.classes-3.2.2.tar.gz", hash = "sha256:6745f113b0b588239ceb49532aa09c3ebb947433ce311ef2f8e3ad64ebb74594"},
+]
+jedi = [
+    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
+    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
+]
+jeepney = [
+    {file = "jeepney-0.8.0-py3-none-any.whl", hash = "sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755"},
+    {file = "jeepney-0.8.0.tar.gz", hash = "sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806"},
+]
+Jinja2 = [
+    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
+    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+]
+jmespath = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
+jschema-to-python = [
+    {file = "jschema_to_python-1.2.3-py3-none-any.whl", hash = "sha256:8a703ca7604d42d74b2815eecf99a33359a8dccbb80806cce386d5e2dd992b05"},
+    {file = "jschema_to_python-1.2.3.tar.gz", hash = "sha256:76ff14fe5d304708ccad1284e4b11f96a658949a31ee7faed9e0995279549b91"},
+]
+jsondiff = [
+    {file = "jsondiff-2.0.0-py3-none-any.whl", hash = "sha256:689841d66273fc88fc79f7d33f4c074774f4f214b6466e3aff0e5adaf889d1e0"},
+    {file = "jsondiff-2.0.0.tar.gz", hash = "sha256:2795844ef075ec8a2b8d385c4d59f5ea48b08e7180fce3cb2787be0db00b1fb4"},
+]
+jsonpatch = [
+    {file = "jsonpatch-1.32-py2.py3-none-any.whl", hash = "sha256:26ac385719ac9f54df8a2f0827bb8253aa3ea8ab7b3368457bcdb8c14595a397"},
+    {file = "jsonpatch-1.32.tar.gz", hash = "sha256:b6ddfe6c3db30d81a96aaeceb6baf916094ffa23d7dd5fa2c13e13f8b6e600c2"},
+]
+jsonpickle = [
+    {file = "jsonpickle-2.2.0-py2.py3-none-any.whl", hash = "sha256:de7f2613818aa4f234138ca11243d6359ff83ae528b2185efdd474f62bcf9ae1"},
+    {file = "jsonpickle-2.2.0.tar.gz", hash = "sha256:7b272918b0554182e53dc340ddd62d9b7f902fec7e7b05620c04f3ccef479a0e"},
+]
+jsonpointer = [
+    {file = "jsonpointer-2.3-py2.py3-none-any.whl", hash = "sha256:51801e558539b4e9cd268638c078c6c5746c9ac96bc38152d443400e4f3793e9"},
+    {file = "jsonpointer-2.3.tar.gz", hash = "sha256:97cba51526c829282218feb99dab1b1e6bdf8efd1c43dc9d57be093c0d69c99a"},
+]
+jsonschema = [
+    {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
+    {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
+]
+junit-xml = [
+    {file = "junit_xml-1.9-py2.py3-none-any.whl", hash = "sha256:ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732"},
+]
+keyring = [
+    {file = "keyring-23.9.1-py3-none-any.whl", hash = "sha256:3565b9e4ea004c96e158d2d332a49f466733d565bb24157a60fd2e49f41a0fd1"},
+    {file = "keyring-23.9.1.tar.gz", hash = "sha256:39e4f6572238d2615a82fcaa485e608b84b503cf080dc924c43bbbacb11c1c18"},
+]
+MarkupSafe = [
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win32.whl", hash = "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win32.whl", hash = "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win32.whl", hash = "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win32.whl", hash = "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
+    {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
+]
+matplotlib-inline = [
+    {file = "matplotlib-inline-0.1.6.tar.gz", hash = "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"},
+    {file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311"},
+]
+more-itertools = [
+    {file = "more-itertools-8.14.0.tar.gz", hash = "sha256:c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750"},
+    {file = "more_itertools-8.14.0-py3-none-any.whl", hash = "sha256:1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2"},
+]
+moto = [
+    {file = "moto-3.1.1-py2.py3-none-any.whl", hash = "sha256:462495563847134ea8ef4135a229731a598a8e7b6b10a74f8d745815aa20a25b"},
+    {file = "moto-3.1.1.tar.gz", hash = "sha256:9b5446b3d1f7505d32616209ae09f02123ebc583387f7c182f11e4175754034f"},
+]
+networkx = [
+    {file = "networkx-2.8.6-py3-none-any.whl", hash = "sha256:2a30822761f34d56b9a370d96a4bf4827a535f5591a4078a453425caeba0c5bb"},
+    {file = "networkx-2.8.6.tar.gz", hash = "sha256:bd2b7730300860cbd2dafe8e5af89ff5c9a65c3975b352799d87a6238b4301a6"},
+]
+numpy = [
+    {file = "numpy-1.22.3-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:92bfa69cfbdf7dfc3040978ad09a48091143cffb778ec3b03fa170c494118d75"},
+    {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4"},
+    {file = "numpy-1.22.3-cp310-cp310-win32.whl", hash = "sha256:f950f8845b480cffe522913d35567e29dd381b0dc7e4ce6a4a9f9156417d2430"},
+    {file = "numpy-1.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:568dfd16224abddafb1cbcce2ff14f522abe037268514dd7e42c6776a1c3f8e5"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ca688e1b9b95d80250bca34b11a05e389b1420d00e87a0d12dc45f131f704a1"},
+    {file = "numpy-1.22.3-cp38-cp38-win32.whl", hash = "sha256:e7927a589df200c5e23c57970bafbd0cd322459aa7b1ff73b7c2e84d6e3eae62"},
+    {file = "numpy-1.22.3-cp38-cp38-win_amd64.whl", hash = "sha256:07a8c89a04997625236c5ecb7afe35a02af3896c8aa01890a849913a2309c676"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:2c10a93606e0b4b95c9b04b77dc349b398fdfbda382d2a39ba5a822f669a0123"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fade0d4f4d292b6f39951b6836d7a3c7ef5b2347f3c420cd9820a1d90d794802"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bfb1bb598e8229c2d5d48db1860bcf4311337864ea3efdbe1171fb0c5da515d"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97098b95aa4e418529099c26558eeb8486e66bd1e53a6b606d684d0c3616b168"},
+    {file = "numpy-1.22.3-cp39-cp39-win32.whl", hash = "sha256:fdf3c08bce27132395d3c3ba1503cac12e17282358cb4bddc25cc46b0aca07aa"},
+    {file = "numpy-1.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:639b54cdf6aa4f82fe37ebf70401bbb74b8508fddcf4797f9fe59615b8c5813a"},
+    {file = "numpy-1.22.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c34ea7e9d13a70bf2ab64a2532fe149a9aced424cd05a2c4ba662fd989e3e45f"},
+    {file = "numpy-1.22.3.zip", hash = "sha256:dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18"},
+]
+opencv-python = [
+    {file = "opencv-python-4.6.0.66.tar.gz", hash = "sha256:c5bfae41ad4031e66bb10ec4a0a2ffd3e514d092652781e8b1ac98d1b59f1158"},
+    {file = "opencv_python-4.6.0.66-cp36-abi3-macosx_10_15_x86_64.whl", hash = "sha256:e6e448b62afc95c5b58f97e87ef84699e6607fe5c58730a03301c52496005cae"},
+    {file = "opencv_python-4.6.0.66-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5af8ba35a4fcb8913ffb86e92403e9a656a4bff4a645d196987468f0f8947875"},
+    {file = "opencv_python-4.6.0.66-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbdc84a9b4ea2cbae33861652d25093944b9959279200b7ae0badd32439f74de"},
+    {file = "opencv_python-4.6.0.66-cp36-abi3-win32.whl", hash = "sha256:f482e78de6e7b0b060ff994ffd859bddc3f7f382bb2019ef157b0ea8ca8712f5"},
+    {file = "opencv_python-4.6.0.66-cp36-abi3-win_amd64.whl", hash = "sha256:0dc82a3d8630c099d2f3ac1b1aabee164e8188db54a786abb7a4e27eba309440"},
+    {file = "opencv_python-4.6.0.66-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:6e32af22e3202748bd233ed8f538741876191863882eba44e332d1a34993165b"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+parso = [
+    {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
+    {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
+]
+pbr = [
+    {file = "pbr-5.10.0-py2.py3-none-any.whl", hash = "sha256:da3e18aac0a3c003e9eea1a81bd23e5a3a75d745670dcf736317b7d966887fdf"},
+    {file = "pbr-5.10.0.tar.gz", hash = "sha256:cfcc4ff8e698256fc17ea3ff796478b050852585aa5bae79ecd05b2ab7b39b9a"},
+]
+pexpect = [
+    {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
+    {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
+]
+pickleshare = [
+    {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
+    {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
+]
+prompt-toolkit = [
+    {file = "prompt_toolkit-3.0.31-py3-none-any.whl", hash = "sha256:9696f386133df0fc8ca5af4895afe5d78f5fcfe5258111c2a79a1c3e41ffa96d"},
+    {file = "prompt_toolkit-3.0.31.tar.gz", hash = "sha256:9ada952c9d1787f52ff6d5f3484d0b4df8952787c087edf6a1f7c2cb1ea88148"},
+]
+ptyprocess = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
+]
+pure-eval = [
+    {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
+    {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
+]
+pyasn1 = [
+    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
+    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
+    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
+    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
+    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
+    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+Pygments = [
+    {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
+    {file = "Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pyrsistent = [
+    {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win32.whl", hash = "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win_amd64.whl", hash = "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win32.whl", hash = "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win32.whl", hash = "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win32.whl", hash = "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07"},
+    {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+python-jose = [
+    {file = "python-jose-3.1.0.tar.gz", hash = "sha256:8484b7fdb6962e9d242cce7680469ecf92bda95d10bbcbbeb560cacdff3abfce"},
+    {file = "python_jose-3.1.0-py2.py3-none-any.whl", hash = "sha256:1ac4caf4bfebd5a70cf5bd82702ed850db69b0b6e1d0ae7368e5f99ac01c9571"},
+]
+pytz = [
+    {file = "pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
+    {file = "pytz-2022.2.1.tar.gz", hash = "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"},
+]
+pywin32 = [
+    {file = "pywin32-304-cp310-cp310-win32.whl", hash = "sha256:3c7bacf5e24298c86314f03fa20e16558a4e4138fc34615d7de4070c23e65af3"},
+    {file = "pywin32-304-cp310-cp310-win_amd64.whl", hash = "sha256:4f32145913a2447736dad62495199a8e280a77a0ca662daa2332acf849f0be48"},
+    {file = "pywin32-304-cp310-cp310-win_arm64.whl", hash = "sha256:d3ee45adff48e0551d1aa60d2ec066fec006083b791f5c3527c40cd8aefac71f"},
+    {file = "pywin32-304-cp311-cp311-win32.whl", hash = "sha256:30c53d6ce44c12a316a06c153ea74152d3b1342610f1b99d40ba2795e5af0269"},
+    {file = "pywin32-304-cp311-cp311-win_amd64.whl", hash = "sha256:7ffa0c0fa4ae4077e8b8aa73800540ef8c24530057768c3ac57c609f99a14fd4"},
+    {file = "pywin32-304-cp311-cp311-win_arm64.whl", hash = "sha256:cbbe34dad39bdbaa2889a424d28752f1b4971939b14b1bb48cbf0182a3bcfc43"},
+    {file = "pywin32-304-cp36-cp36m-win32.whl", hash = "sha256:be253e7b14bc601718f014d2832e4c18a5b023cbe72db826da63df76b77507a1"},
+    {file = "pywin32-304-cp36-cp36m-win_amd64.whl", hash = "sha256:de9827c23321dcf43d2f288f09f3b6d772fee11e809015bdae9e69fe13213988"},
+    {file = "pywin32-304-cp37-cp37m-win32.whl", hash = "sha256:f64c0377cf01b61bd5e76c25e1480ca8ab3b73f0c4add50538d332afdf8f69c5"},
+    {file = "pywin32-304-cp37-cp37m-win_amd64.whl", hash = "sha256:bb2ea2aa81e96eee6a6b79d87e1d1648d3f8b87f9a64499e0b92b30d141e76df"},
+    {file = "pywin32-304-cp38-cp38-win32.whl", hash = "sha256:94037b5259701988954931333aafd39cf897e990852115656b014ce72e052e96"},
+    {file = "pywin32-304-cp38-cp38-win_amd64.whl", hash = "sha256:ead865a2e179b30fb717831f73cf4373401fc62fbc3455a0889a7ddac848f83e"},
+    {file = "pywin32-304-cp39-cp39-win32.whl", hash = "sha256:25746d841201fd9f96b648a248f731c1dec851c9a08b8e33da8b56148e4c65cc"},
+    {file = "pywin32-304-cp39-cp39-win_amd64.whl", hash = "sha256:d24a3382f013b21aa24a5cfbfad5a2cd9926610c0affde3e8ab5b3d7dbcf4ac9"},
+]
+pywin32-ctypes = [
+    {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
+    {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
+]
+PyYAML = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+requests = [
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
+responses = [
+    {file = "responses-0.21.0-py3-none-any.whl", hash = "sha256:2dcc863ba63963c0c3d9ee3fa9507cbe36b7d7b0fccb4f0bdfd9e96c539b1487"},
+    {file = "responses-0.21.0.tar.gz", hash = "sha256:b82502eb5f09a0289d8e209e7bad71ef3978334f56d09b444253d5ad67bf5253"},
+]
+rsa = [
+    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
+    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
+]
+s3transfer = [
+    {file = "s3transfer-0.6.0-py3-none-any.whl", hash = "sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd"},
+    {file = "s3transfer-0.6.0.tar.gz", hash = "sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947"},
+]
+sarif-om = [
+    {file = "sarif_om-1.0.4-py3-none-any.whl", hash = "sha256:539ef47a662329b1c8502388ad92457425e95dc0aaaf995fe46f4984c4771911"},
+    {file = "sarif_om-1.0.4.tar.gz", hash = "sha256:cd5f416b3083e00d402a92e449a7ff67af46f11241073eea0461802a3b5aef98"},
+]
+SecretStorage = [
+    {file = "SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99"},
+    {file = "SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77"},
+]
+setproctitle = [
+    {file = "setproctitle-1.2.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9106bcbacae534b6f82955b176723f1b2ca6514518aab44dffec05a583f8dca8"},
+    {file = "setproctitle-1.2.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:30bc7a769a4451639a0adcbc97bdf7a6e9ac0ef3ddad8d63eb1e338edb3ebeda"},
+    {file = "setproctitle-1.2.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:e8ef655eab26e83ec105ce79036bb87e5f2bf8ba2d6f48afdd9595ef7647fcf4"},
+    {file = "setproctitle-1.2.2-cp36-cp36m-win32.whl", hash = "sha256:0df728d0d350e6b1ad8436cc7add052faebca6f4d03257182d427d86d4422065"},
+    {file = "setproctitle-1.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:5260e8700c5793d48e79c5e607e8e552e795b698491a4b9bb9111eb74366a450"},
+    {file = "setproctitle-1.2.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ba1fb32e7267330bd9f72e69e076777a877f1cb9be5beac5e62d1279e305f37f"},
+    {file = "setproctitle-1.2.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e696c93d93c23f377ccd2d72e38908d3dbfc90e45561602b805f53f2627d42ea"},
+    {file = "setproctitle-1.2.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:fbf914179dc4540ee6bfd8228b4cc1f1f6fb12dad66b72b5c9b955b222403220"},
+    {file = "setproctitle-1.2.2-cp37-cp37m-win32.whl", hash = "sha256:28b884e1cb9a53974e15838864283f9bad774b5c7db98c9609416bd123cb9fd1"},
+    {file = "setproctitle-1.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:a11d329f33221443317e2aeaee9442f22fcae25be3aa4fb8489e4f7b1f65cdd2"},
+    {file = "setproctitle-1.2.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e13a5c1d9c369cb11cdfc4b75be432b83eb3205c95a69006008ffd4366f87b9e"},
+    {file = "setproctitle-1.2.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c611f65bc9de5391a1514de556f71101e6531bb0715d240efd3e9732626d5c9e"},
+    {file = "setproctitle-1.2.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:bc4393576ed3ac87ddac7d1bd0faaa2fab24840a025cc5f3c21d14cf0c9c8a12"},
+    {file = "setproctitle-1.2.2-cp38-cp38-win32.whl", hash = "sha256:17598f38be9ef499d74f2380bf76b558be72e87da75d66b153350e586649171b"},
+    {file = "setproctitle-1.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:0d160d46c8f3567e0aa27b26b1f36e03122e3de475aacacc14a92b8fe45b648a"},
+    {file = "setproctitle-1.2.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:077943272d0490b3f43d17379432d5e49c263f608fdf4cf624b419db762ca72b"},
+    {file = "setproctitle-1.2.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:970798d948f0c90a3eb0f8750f08cb215b89dcbee1b55ffb353ad62d9361daeb"},
+    {file = "setproctitle-1.2.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:3f6136966c81daaf5b4b010613fe33240a045a4036132ef040b623e35772d998"},
+    {file = "setproctitle-1.2.2-cp39-cp39-win32.whl", hash = "sha256:249526a06f16d493a2cb632abc1b1fdfaaa05776339a50dd9f27c941f6ff1383"},
+    {file = "setproctitle-1.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:4fc5bebd34f451dc87d2772ae6093adea1ea1dc29afc24641b250140decd23bb"},
+    {file = "setproctitle-1.2.2.tar.gz", hash = "sha256:7dfb472c8852403d34007e01d6e3c68c57eb66433fb8a5c77b13b89a160d97df"},
+]
+setuptools = [
+    {file = "setuptools-59.2.0-py3-none-any.whl", hash = "sha256:4adde3d1e1c89bde1c643c64d89cdd94cbfd8c75252ee459d4500bccb9c7d05d"},
+    {file = "setuptools-59.2.0.tar.gz", hash = "sha256:157d21de9d055ab9e8ea3186d91e7f4f865e11f42deafa952d90842671fc2576"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+SQLAlchemy = [
+    {file = "SQLAlchemy-1.4.41-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:13e397a9371ecd25573a7b90bd037db604331cf403f5318038c46ee44908c44d"},
+    {file = "SQLAlchemy-1.4.41-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:2d6495f84c4fd11584f34e62f9feec81bf373787b3942270487074e35cbe5330"},
+    {file = "SQLAlchemy-1.4.41-cp27-cp27m-win32.whl", hash = "sha256:e570cfc40a29d6ad46c9aeaddbdcee687880940a3a327f2c668dd0e4ef0a441d"},
+    {file = "SQLAlchemy-1.4.41-cp27-cp27m-win_amd64.whl", hash = "sha256:5facb7fd6fa8a7353bbe88b95695e555338fb038ad19ceb29c82d94f62775a05"},
+    {file = "SQLAlchemy-1.4.41-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f37fa70d95658763254941ddd30ecb23fc4ec0c5a788a7c21034fc2305dab7cc"},
+    {file = "SQLAlchemy-1.4.41-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:361f6b5e3f659e3c56ea3518cf85fbdae1b9e788ade0219a67eeaaea8a4e4d2a"},
+    {file = "SQLAlchemy-1.4.41-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0990932f7cca97fece8017414f57fdd80db506a045869d7ddf2dda1d7cf69ecc"},
+    {file = "SQLAlchemy-1.4.41-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cd767cf5d7252b1c88fcfb58426a32d7bd14a7e4942497e15b68ff5d822b41ad"},
+    {file = "SQLAlchemy-1.4.41-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5102fb9ee2c258a2218281adcb3e1918b793c51d6c2b4666ce38c35101bb940e"},
+    {file = "SQLAlchemy-1.4.41-cp310-cp310-win32.whl", hash = "sha256:2082a2d2fca363a3ce21cfa3d068c5a1ce4bf720cf6497fb3a9fc643a8ee4ddd"},
+    {file = "SQLAlchemy-1.4.41-cp310-cp310-win_amd64.whl", hash = "sha256:e4b12e3d88a8fffd0b4ca559f6d4957ed91bd4c0613a4e13846ab8729dc5c251"},
+    {file = "SQLAlchemy-1.4.41-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:90484a2b00baedad361402c257895b13faa3f01780f18f4a104a2f5c413e4536"},
+    {file = "SQLAlchemy-1.4.41-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b67fc780cfe2b306180e56daaa411dd3186bf979d50a6a7c2a5b5036575cbdbb"},
+    {file = "SQLAlchemy-1.4.41-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ad2b727fc41c7f8757098903f85fafb4bf587ca6605f82d9bf5604bd9c7cded"},
+    {file = "SQLAlchemy-1.4.41-cp311-cp311-win32.whl", hash = "sha256:59bdc291165b6119fc6cdbc287c36f7f2859e6051dd923bdf47b4c55fd2f8bd0"},
+    {file = "SQLAlchemy-1.4.41-cp311-cp311-win_amd64.whl", hash = "sha256:d2e054aed4645f9b755db85bc69fc4ed2c9020c19c8027976f66576b906a74f1"},
+    {file = "SQLAlchemy-1.4.41-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:4ba7e122510bbc07258dc42be6ed45997efdf38129bde3e3f12649be70683546"},
+    {file = "SQLAlchemy-1.4.41-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0dcf127bb99458a9d211e6e1f0f3edb96c874dd12f2503d4d8e4f1fd103790b"},
+    {file = "SQLAlchemy-1.4.41-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e16c2be5cb19e2c08da7bd3a87fed2a0d4e90065ee553a940c4fc1a0fb1ab72b"},
+    {file = "SQLAlchemy-1.4.41-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5ebeeec5c14533221eb30bad716bc1fd32f509196318fb9caa7002c4a364e4c"},
+    {file = "SQLAlchemy-1.4.41-cp36-cp36m-win32.whl", hash = "sha256:3e2ef592ac3693c65210f8b53d0edcf9f4405925adcfc031ff495e8d18169682"},
+    {file = "SQLAlchemy-1.4.41-cp36-cp36m-win_amd64.whl", hash = "sha256:eb30cf008850c0a26b72bd1b9be6730830165ce049d239cfdccd906f2685f892"},
+    {file = "SQLAlchemy-1.4.41-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:c23d64a0b28fc78c96289ffbd0d9d1abd48d267269b27f2d34e430ea73ce4b26"},
+    {file = "SQLAlchemy-1.4.41-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8eb8897367a21b578b26f5713833836f886817ee2ffba1177d446fa3f77e67c8"},
+    {file = "SQLAlchemy-1.4.41-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:14576238a5f89bcf504c5f0a388d0ca78df61fb42cb2af0efe239dc965d4f5c9"},
+    {file = "SQLAlchemy-1.4.41-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:639e1ae8d48b3c86ffe59c0daa9a02e2bfe17ca3d2b41611b30a0073937d4497"},
+    {file = "SQLAlchemy-1.4.41-cp37-cp37m-win32.whl", hash = "sha256:0005bd73026cd239fc1e8ccdf54db58b6193be9a02b3f0c5983808f84862c767"},
+    {file = "SQLAlchemy-1.4.41-cp37-cp37m-win_amd64.whl", hash = "sha256:5323252be2bd261e0aa3f33cb3a64c45d76829989fa3ce90652838397d84197d"},
+    {file = "SQLAlchemy-1.4.41-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:05f0de3a1dc3810a776275763764bb0015a02ae0f698a794646ebc5fb06fad33"},
+    {file = "SQLAlchemy-1.4.41-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0002e829142b2af00b4eaa26c51728f3ea68235f232a2e72a9508a3116bd6ed0"},
+    {file = "SQLAlchemy-1.4.41-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:22ff16cedab5b16a0db79f1bc99e46a6ddececb60c396562e50aab58ddb2871c"},
+    {file = "SQLAlchemy-1.4.41-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ccfd238f766a5bb5ee5545a62dd03f316ac67966a6a658efb63eeff8158a4bbf"},
+    {file = "SQLAlchemy-1.4.41-cp38-cp38-win32.whl", hash = "sha256:58bb65b3274b0c8a02cea9f91d6f44d0da79abc993b33bdedbfec98c8440175a"},
+    {file = "SQLAlchemy-1.4.41-cp38-cp38-win_amd64.whl", hash = "sha256:ce8feaa52c1640de9541eeaaa8b5fb632d9d66249c947bb0d89dd01f87c7c288"},
+    {file = "SQLAlchemy-1.4.41-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:199a73c31ac8ea59937cc0bf3dfc04392e81afe2ec8a74f26f489d268867846c"},
+    {file = "SQLAlchemy-1.4.41-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4676d51c9f6f6226ae8f26dc83ec291c088fe7633269757d333978df78d931ab"},
+    {file = "SQLAlchemy-1.4.41-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:036d8472356e1d5f096c5e0e1a7e0f9182140ada3602f8fff6b7329e9e7cfbcd"},
+    {file = "SQLAlchemy-1.4.41-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2307495d9e0ea00d0c726be97a5b96615035854972cc538f6e7eaed23a35886c"},
+    {file = "SQLAlchemy-1.4.41-cp39-cp39-win32.whl", hash = "sha256:9c56e19780cd1344fcd362fd6265a15f48aa8d365996a37fab1495cae8fcd97d"},
+    {file = "SQLAlchemy-1.4.41-cp39-cp39-win_amd64.whl", hash = "sha256:f5fa526d027d804b1f85cdda1eb091f70bde6fb7d87892f6dd5a48925bc88898"},
+    {file = "SQLAlchemy-1.4.41.tar.gz", hash = "sha256:0292f70d1797e3c54e862e6f30ae474014648bc9c723e14a2fda730adb0a9791"},
+]
+SQLAlchemy-Utils = [
+    {file = "SQLAlchemy-Utils-0.38.2.tar.gz", hash = "sha256:9e01d6d3fb52d3926fcd4ea4a13f3540701b751aced0316bff78264402c2ceb4"},
+    {file = "SQLAlchemy_Utils-0.38.2-py3-none-any.whl", hash = "sha256:622235b1598f97300e4d08820ab024f5219c9a6309937a8b908093f487b4ba54"},
+]
+sshpubkeys = [
+    {file = "sshpubkeys-3.3.1-py2.py3-none-any.whl", hash = "sha256:946f76b8fe86704b0e7c56a00d80294e39bc2305999844f079a217885060b1ac"},
+    {file = "sshpubkeys-3.3.1.tar.gz", hash = "sha256:3020ed4f8c846849299370fbe98ff4157b0ccc1accec105e07cfa9ae4bb55064"},
+]
+stack-data = [
+    {file = "stack_data-0.5.0-py3-none-any.whl", hash = "sha256:66d2ebd3d7f29047612ead465b6cae5371006a71f45037c7e2507d01367bce3b"},
+    {file = "stack_data-0.5.0.tar.gz", hash = "sha256:715c8855fbf5c43587b141e46cc9d9339cc0d1f8d6e0f98ed0d01c6cb974e29f"},
+]
+traitlets = [
+    {file = "traitlets-5.4.0-py3-none-any.whl", hash = "sha256:93663cc8236093d48150e2af5e2ed30fc7904a11a6195e21bab0408af4e6d6c8"},
+    {file = "traitlets-5.4.0.tar.gz", hash = "sha256:3f2c4e435e271592fe4390f1746ea56836e3a080f84e7833f0f801d9613fec39"},
+]
+tree-sitter = [
+    {file = "tree_sitter-0.20.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:51a609a7c1bd9d9e75d92ee128c12c7852ae70a482900fbbccf3d13a79e0378c"},
+    {file = "tree_sitter-0.20.0.tar.gz", hash = "sha256:1940f64be1e8c9c3c0e34a2258f1e4c324207534d5b1eefc5ab2960a9d98f668"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
+    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+websocket-client = [
+    {file = "websocket-client-1.4.1.tar.gz", hash = "sha256:f9611eb65c8241a67fb373bef040b3cf8ad377a9f6546a12b620b6511e8ea9ef"},
+    {file = "websocket_client-1.4.1-py3-none-any.whl", hash = "sha256:398909eb7e261f44b8f4bd474785b6ec5f5b499d4953342fe9755e01ef624090"},
+]
+Werkzeug = [
+    {file = "Werkzeug-2.2.2-py3-none-any.whl", hash = "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"},
+    {file = "Werkzeug-2.2.2.tar.gz", hash = "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f"},
+]
+wheel = [
+    {file = "wheel-0.37.0-py2.py3-none-any.whl", hash = "sha256:21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd"},
+    {file = "wheel-0.37.0.tar.gz", hash = "sha256:e2ef7239991699e3355d54f8e968a21bb940a1dbf34a4d226741e64462516fad"},
+]
+wrapt = [
+    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
+    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
+    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
+    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
+    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
+    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
+    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
+    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
+    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
+    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
+]
+xmltodict = [
+    {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
+    {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
+]
+zipp = [
+    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
+    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
+]

--- a/examples/crossenv/pyproject.toml
+++ b/examples/crossenv/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+name = "rules_pycross_example"
+version = "0.1"
+description = "rules_pycross"
+authors = []
+
+[tool.poetry.dependencies]
+python = "~=3.9"
+
+ipython = ">=8.0.1"
+moto = {version = "=3.1.1", extras = ["server", "all"]}
+SQLAlchemy-Utils = "=0.38.2"
+cognitojwt = "*"
+python-jose = "=3.1.0"
+numpy = "=1.22.3"
+Cython = ">=0.29.24,<3.0"
+setuptools = "=59.2.0"
+wheel = "=0.37.0"
+setproctitle = "=1.2.2"
+tree-sitter = "=0.20.0"
+future = "=0.18.2"
+opencv-python = "=4.6.0.66"
+keyring = "=23.9.1"

--- a/examples/crossenv/tools/BUILD.bazel
+++ b/examples/crossenv/tools/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@example_lock_repo//:requirements.bzl", "requirement")
+
+py_binary(
+    name = "ipython",
+    srcs = ["ipython.py"],
+    deps = ["//deps:ipython", "//deps:numpy", "//deps:keyring", "//deps:greenlet"],
+)
+
+py_binary(
+    name = "ipython_from_repo",
+    srcs = ["ipython.py"],
+    main = "ipython.py",
+    deps = [requirement("ipython")],
+)

--- a/examples/crossenv/tools/ipython.py
+++ b/examples/crossenv/tools/ipython.py
@@ -1,0 +1,3 @@
+from IPython import start_ipython
+
+start_ipython()

--- a/examples/poetry/.bazelversion
+++ b/examples/poetry/.bazelversion
@@ -1,4 +1,4 @@
-6.0.0rc1
+5.3.2
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/pycross/BUILD.bazel
+++ b/pycross/BUILD.bazel
@@ -3,6 +3,11 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 # For stardoc to reference the files
 exports_files(["defs.bzl"])
 
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "repositories",
     srcs = ["repositories.bzl"],
@@ -29,5 +34,14 @@ bzl_library(
         "//pycross/private:target_environment",
         "//pycross/private:wheel_build",
         "//pycross/private:wheel_library",
+    ],
+)
+
+bzl_library(
+    name = "toolchain",
+    srcs = ["toolchain.bzl"],
+    deps = [
+        "//pycross/private:providers",
+        "@bazel_skylib//lib:paths",
     ],
 )

--- a/pycross/private/tools/BUILD.bazel
+++ b/pycross/private/tools/BUILD.bazel
@@ -93,6 +93,7 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":lib",
+        "//pycross/private/tools/crossenv:crossenv",
         "@rules_pycross_pypi_deps_build//:pkg",
         "@rules_pycross_pypi_deps_packaging//:pkg",
     ],

--- a/pycross/private/tools/crossenv/BUILD.bazel
+++ b/pycross/private/tools/crossenv/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+package(default_visibility = ["//pycross/private/tools:__subpackages__"])
+
+py_library(
+    name = "crossenv_lib",
+    srcs = [
+        "__init__.py",
+        "template.py",
+        "utils.py",
+    ],
+    data = [
+        "//pycross/private/tools/crossenv/scripts",
+    ]
+)
+
+py_binary(
+    name = "crossenv",
+    srcs = ["__main__.py", "__init__.py"],
+    deps = [":crossenv_lib"],
+    main = "__main__.py",
+)

--- a/pycross/private/tools/crossenv/LICENSE.crossenv.txt
+++ b/pycross/private/tools/crossenv/LICENSE.crossenv.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2018 Benjamin Fogle
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pycross/private/tools/crossenv/README.md
+++ b/pycross/private/tools/crossenv/README.md
@@ -1,0 +1,5 @@
+This package contains a derivative of https://github.com/benfogle/crossenv,
+originally written by Ben Fogle. See
+[LICENSE.crossenv.txt](LICENSE.crossenv.txt) for its original licensing terms.
+
+It's been largely adapted for use with these Bazel rules, but many of the original concepts remain.

--- a/pycross/private/tools/crossenv/__init__.py
+++ b/pycross/private/tools/crossenv/__init__.py
@@ -1,0 +1,340 @@
+import dataclasses
+import json
+import os
+import platform
+import pprint
+import sys
+import sysconfig
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from . import utils
+
+SYSCONFIG_DATA_NAME = "_pycross_sysconfig_data"
+
+
+@dataclasses.dataclass
+class Uname:
+    machine: str
+    release: str
+    sysname: str
+
+
+@dataclasses.dataclass
+class TargetContext:
+    abiflags: Optional[str]
+    effective_glibc: Optional[str]
+    home: str
+    macosx_deployment_target: Optional[str]
+    manylinux_tags: List[str]
+    multiarch: Optional[str]
+    platform: str  # e.g. apple-aarch64
+    project_base: str  # bin dir of target executable
+    sysconfigdata_name: str
+    sysconfigdata_path: str
+    sysconfig_platform: str  # e.g. apple-x86_64
+    uname_machine: str  # from uname; e.g. x86_64
+    uname_release: str  # from uname
+    uname_sysname: str  # from uname
+
+
+@dataclasses.dataclass
+class Context:
+    exec_python_executable: str  # The exec python
+    exec_stdlib: str  # e.g. .../lib/python3.9
+    lib_path: str  # Where our patching scripts are written (i.e., venv/lib)
+    target: TargetContext
+
+
+def guess_target_platform(host_gnu_type: str) -> str:
+    # It was probably natively compiled, but not necessarily for this
+    # architecture. Guess from HOST_GNU_TYPE.
+    # TODO: Handle windows somehow (ha, ha)
+    host = host_gnu_type.lower().split("-")
+    if len(host) == 4:  # i.e., aarch64-unknown-linux-gnu
+        plat, machine = [host[2], host[0]]
+    elif len(host) == 3:  # i.e., aarch64-linux-gnu, unlikely.
+        plat, machine = [host[1], host[0]]
+    else:
+        raise ValueError(
+            f"Cannot determine target platform from HOST_GNU_TYPE: {host_gnu_type}"
+        )
+
+    if plat == "apple":
+        plat = "darwin"
+
+    return f"{plat}-{machine}"
+
+
+def guess_uname(
+    target_platform: str,
+    host_gnu_type: str,
+    uname_machine: Optional[str],
+    macosx_deployment_target: Optional[str],
+) -> Uname:
+    uname_release = "0.0.0"
+    uname_sysname = ""
+
+    # target_platform is _probably_ something like linux-x86_64, but it can
+    # vary.
+    target_info = target_platform.split("-")
+    if not target_info:
+        uname_sysname = sys.platform
+    elif len(target_info) >= 1:
+        uname_sysname = target_info[0]
+
+    if uname_machine is None:
+        if len(target_info) > 1 and target_info[-1] == "powerpc64le":
+            # Test that this is still a special case when we can.
+            # On uname.machine=ppc64le, _PYTHON_HOST_PLATFORM is linux-powerpc64le
+            uname_machine = "ppc64le"
+        else:
+            uname_machine = host_gnu_type.split("-")[0]
+
+    if macosx_deployment_target:
+        try:
+            major, minor = macosx_deployment_target.split(".")
+            major, minor = int(major), int(minor)
+        except ValueError:
+            raise ValueError(
+                f"Unexpected value {macosx_deployment_target} for MACOSX_DEPLOYMENT_TARGET"
+            )
+        if major == 10:
+            uname_release = "%s.0.0" % (minor + 4)
+        elif major == 11:
+            uname_release = "%s.0.0" % (minor + 20)
+        else:
+            raise ValueError(
+                f"Unexpected major version {major} for MACOSX_DEPLOYMENT_TARGET"
+            )
+
+    return Uname(machine=uname_machine, release=uname_release, sysname=uname_sysname)
+
+
+def guess_sysconfig_platform(
+    uname: Uname, target_platform: str, macosx_deployment_target: Optional[str]
+) -> str:
+    if uname.sysname.lower() == "darwin":
+        return "macosx-{}-{}".format(
+            macosx_deployment_target,
+            uname.machine,
+        )
+    elif uname.sysname == "linux":
+        # Use self.host_machine here as powerpc64le gets converted
+        # to ppc64le in self.host_machine
+        return f"linux-{uname.machine}"
+    else:
+        return target_platform
+
+
+def build_context(
+    target_python_exe: str,
+    lib_path: str,
+    sysconfig_vars: Dict[str, Any],
+    sysconfig_data_file: str,
+    manylinux_tags: List[str],
+    target_platform: Optional[str],
+    uname_machine: Optional[str],
+) -> Context:
+    project_base = Path(target_python_exe).absolute().parent
+    home = project_base.parent  # Not sure if this is always correct
+
+    host_gnu_type = sysconfig_vars["HOST_GNU_TYPE"]
+    macosx_deployment_target = sysconfig_vars.get("MACOSX_DEPLOYMENT_TARGET")
+
+    if target_platform is None:
+        target_platform = guess_target_platform(host_gnu_type)
+
+    target_uname = guess_uname(
+        target_platform=target_platform,
+        host_gnu_type=host_gnu_type,
+        uname_machine=uname_machine,
+        macosx_deployment_target=macosx_deployment_target,
+    )
+
+    target_sysconfig_platform = guess_sysconfig_platform(
+        uname=target_uname,
+        target_platform=target_platform,
+        macosx_deployment_target=macosx_deployment_target,
+    )
+
+    target_context = TargetContext(
+        abiflags=sysconfig_vars.get("ABIFLAGS"),
+        effective_glibc="TODO",  # TODO
+        home=str(home),
+        macosx_deployment_target=macosx_deployment_target,
+        manylinux_tags=manylinux_tags,
+        multiarch=sysconfig_vars.get("MULTIARCH"),
+        platform=target_platform,
+        project_base=str(project_base),
+        sysconfigdata_name=SYSCONFIG_DATA_NAME,
+        sysconfigdata_path=sysconfig_data_file,
+        sysconfig_platform=target_sysconfig_platform,
+        uname_machine=target_uname.machine,
+        uname_release=target_uname.release,
+        uname_sysname=target_uname.sysname,
+    )
+
+    context = Context(
+        exec_python_executable=os.path.abspath(sys.executable),
+        exec_stdlib=os.path.abspath(os.path.dirname(os.__file__)),
+        lib_path=lib_path,
+        target=target_context,
+    )
+
+    return context
+
+
+def expand_manylinux_tags(tags: List[str]) -> List[str]:
+    """
+    Convert legacy manylinux tags to PEP600, because pip only looks for one
+    or the other
+    """
+
+    manylinux_tags = set(tags)
+    extra_tags = set()
+
+    # we'll be very strict here: don't assume that manylinux2014 implies
+    # manylinux1 and so on.
+    if "manylinux1" in manylinux_tags:
+        extra_tags.add("manylinux_2_5")
+    if "manylinux2010" in manylinux_tags:
+        extra_tags.add("manylinux_2_12")
+    if "manylinux2014" in manylinux_tags:
+        extra_tags.add("manylinux_2_17")
+    if "manylinux_2_5" in manylinux_tags:
+        extra_tags.add("manylinux1")
+    if "manylinux_2_12" in manylinux_tags:
+        extra_tags.add("manylinux2010")
+    if "manylinux_2_17" in manylinux_tags:
+        extra_tags.add("manylinux2014")
+
+    manylinux_tags.update(extra_tags)
+    return sorted(manylinux_tags)
+
+
+def write_sysconfig_data(
+    sysconfig_data_path: Path, sysconfig_vars: Dict[str, Any]
+) -> None:
+    with open(sysconfig_data_path, "w") as f:
+        f.write("# Generated by rules_pycross\n")
+        f.write("build_time_vars = ")
+        pprint.pprint(sysconfig_vars, stream=f, compact=True)
+
+
+def write_pyvenv_cfg(env_path: Path, target_bin: str) -> None:
+    with open(env_path / "pyvenv.cfg", "w") as f:
+        f.writelines(
+            [
+                f"home = {target_bin}\n",
+                "include-system-site-packages = false\n",
+                f"version = {platform.python_version()}\n",
+            ]
+        )
+
+
+def build_env(
+    env_path: str,
+    target_python_exe: str,
+    sysconfig_vars: Dict[str, Any],
+    manylinux_tags: List[str],
+) -> Path:
+    pyver = "python" + sysconfig.get_config_var("py_version_short")
+    env_path = Path(env_path)
+    lib_path = env_path / "lib"
+    site_path = lib_path / pyver / "site-packages"
+    bin_path = env_path / "bin"
+    exe = bin_path / pyver
+    sysconfig_data_file = site_path / (SYSCONFIG_DATA_NAME + ".py")
+
+    bin_path.mkdir(parents=True)
+    lib_path.mkdir(parents=True)
+    site_path.mkdir(parents=True)
+
+    write_sysconfig_data(sysconfig_data_file, sysconfig_vars)
+    context = build_context(
+        target_python_exe=target_python_exe,
+        lib_path=str(lib_path),
+        sysconfig_vars=sysconfig_vars,
+        sysconfig_data_file=str(sysconfig_data_file),
+        manylinux_tags=expand_manylinux_tags(manylinux_tags),
+        target_platform=None,  # guess
+        uname_machine=None,  # guess
+    )
+
+    write_pyvenv_cfg(env_path, str(context.target.project_base))
+
+    tmpl = utils.TemplateContext()
+    tmpl.update(context.__dict__)
+    utils.install_script("pywrapper.py.tmpl", str(exe), tmpl)
+
+    # Everything in lib_path follows the same pattern
+    site_scripts = [
+        "site.py",
+        "sys-patch.py",
+        "os-patch.py",
+        "platform-patch.py",
+        "sysconfig-patch.py",
+        "distutils-sysconfig-patch.py",
+    ]
+
+    for script in site_scripts:
+        src = script + ".tmpl"
+        dst = os.path.join(context.lib_path, script)
+        utils.install_script(src, dst, tmpl)
+
+    utils.install_script(
+        "_manylinux.py.tmpl",
+        os.path.join(str(site_path), "_manylinux.py"),
+        tmpl,
+    )
+
+    # Symlink alternate names to our wrapper
+    for link_name in ("python", "python3"):
+        link = bin_path / link_name
+        if not link.exists():
+            link.symlink_to(exe)
+
+    return env_path
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--sysconfig-json",
+        help="A JSON file containing sysconfig data.",
+    )
+    parser.add_argument(
+        "--manylinux",
+        action="append",
+        default=[],
+        help="""Declare compatibility with the given manylinux platform tag to
+                enable pre-compiled wheels. This argument may be given multiple
+                times.""",
+    )
+    parser.add_argument(
+        "--env-dir",
+        help="Path to the created environment.",
+    )
+    parser.add_argument(
+        "--target-python",
+        help="Path to the target Python interpreter executable.",
+    )
+
+    args = parser.parse_args()
+
+    with open(args.sysconfig_json, "r") as f:
+        sysconfig_vars = json.load(f)
+
+    build_env(
+        env_path=args.env_dir,
+        target_python_exe=args.target_python,
+        sysconfig_vars=sysconfig_vars,
+        manylinux_tags=args.manylinux,
+    )

--- a/pycross/private/tools/crossenv/__main__.py
+++ b/pycross/private/tools/crossenv/__main__.py
@@ -1,0 +1,3 @@
+from pycross.private.tools.crossenv import main
+
+main()

--- a/pycross/private/tools/crossenv/scripts/BUILD.bazel
+++ b/pycross/private/tools/crossenv/scripts/BUILD.bazel
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:private"])
+
+filegroup(
+    name = "scripts",
+    srcs = glob(["*.tmpl"]),
+    visibility = ["//pycross/private/tools/crossenv:__subpackages__"],
+)

--- a/pycross/private/tools/crossenv/scripts/_manylinux.py.tmpl
+++ b/pycross/private/tools/crossenv/scripts/_manylinux.py.tmpl
@@ -1,0 +1,15 @@
+# Unconditionally disable manylinux support in a cross environment
+
+_tags = {{repr(target.manylinux_tags)}}
+
+def manylinux_compatible(tag_major, tag_minor, tag_arch):
+    import platform
+    if tag_arch != platform.machine():
+        return False
+
+    tag = 'manylinux_%s_%s' % (tag_major, tag_minor)
+    return tag in _tags
+
+manylinux1_compatible = {{'manylinux1' in target.manylinux_tags}}
+manylinux2010_compatible = {{'manylinux2010' in target.manylinux_tags}}
+manylinux2014_compatible = {{'manylinux2014' in target.manylinux_tags}}

--- a/pycross/private/tools/crossenv/scripts/distutils-sysconfig-patch.py.tmpl
+++ b/pycross/private/tools/crossenv/scripts/distutils-sysconfig-patch.py.tmpl
@@ -1,0 +1,29 @@
+# Patch the things that depend on os.environ or sys
+# This is very similar to the sysconfig patch
+
+# Only patch if get_config_vars was implemented in this module. Python 3.10
+# merged the implementations by importing from sysconfig, so we don't need to
+# patch twice.
+if get_config_vars.__module__ == __name__:
+    project_base = {{repr(target.project_base)}}
+
+    try:
+        __real_init_posix = _init_posix
+        def _init_posix():
+            old = os.environ.get('_PYTHON_SYSCONFIGDATA_NAME')
+            os.environ['_PYTHON_SYSCONFIGDATA_NAME'] = {{repr(target.sysconfigdata_name)}}
+            try:
+                return __real_init_posix()
+            finally:
+                if old is None:
+                    del os.environ['_PYTHON_SYSCONFIGDATA_NAME']
+                else:
+                    os.environ['_PYTHON_SYSCONFIGDATA_NAME'] = old
+    except NameError:
+        # setuptools >=61, removed _init_posix and fixes distutils.sysconfig
+        # to use sysconfig which we patch in sysconfig-patch.py
+        pass
+
+    assert not _config_vars, "distutils.sysconfig was set up prior to patching?"
+
+#vi: ft=python

--- a/pycross/private/tools/crossenv/scripts/os-patch.py.tmpl
+++ b/pycross/private/tools/crossenv/scripts/os-patch.py.tmpl
@@ -1,0 +1,31 @@
+from collections import namedtuple
+
+# Fixup os.uname, which should fix most of platform module
+uname_result_type = namedtuple('uname_result',
+        'sysname nodename release version machine')
+_uname_result = uname_result_type(
+        {{repr(target.uname_sysname.title())}},
+        'build',
+        {{repr(target.uname_release)}},
+        '',
+        {{repr(target.uname_machine)}})
+
+def uname():
+    return _uname_result
+
+# pip, packaging, and subprocess all use confstr to get the libc version. We do
+# not want the host's glibc version to show up, as this affects things like
+# manylinux determination. Always return something of the form "name version",
+# or pip will fall back to querying ctypes, which I am not brave enough to
+# patch. Subprocess will likely end up using less efficient implementations,
+# but functionality shouldn't be affected.
+_original_confstr = confstr
+def confstr(name):
+    if name == 'CS_GNU_LIBC_VERSION':
+        version = {{repr(target.effective_glibc)}}
+        if version is None:
+            return 'unknown 0.0'
+        else:
+            return f'glibc {version}'
+    else:
+        return _original_confstr(name)

--- a/pycross/private/tools/crossenv/scripts/platform-patch.py.tmpl
+++ b/pycross/private/tools/crossenv/scripts/platform-patch.py.tmpl
@@ -1,0 +1,23 @@
+from collections import namedtuple
+
+platform_uname_result_type = namedtuple('uname_result',
+                    'system node release version machine processor')
+_uname_result = platform_uname_result_type(
+        {{repr(target.uname_sysname.title())}},
+        'build',
+        {{repr(target.uname_release)}},
+        '',
+        {{repr(target.uname_machine)}},
+        {{repr(target.uname_machine)}})
+def uname():
+    return _uname_result
+
+def libc_ver(*args, **kwargs):
+    return ('', '')
+
+def mac_ver(release='', versioninfo=('', '', ''), machine=''):
+    if release == '':
+        release = {{repr(target.macosx_deployment_target)}}
+    if machine == '':
+        machine = _uname_result.machine
+    return release, versioninfo, machine

--- a/pycross/private/tools/crossenv/scripts/pywrapper.py.tmpl
+++ b/pycross/private/tools/crossenv/scripts/pywrapper.py.tmpl
@@ -1,0 +1,27 @@
+#!{{exec_python_executable}} -I
+
+import os
+import sys
+
+
+for name in ['_PYTHON_PROJECT_BASE', '_PYTHON_HOST_PLATFORM',
+        '_PYTHON_SYSCONFIGDATA_NAME', 'PYTHONHOME', 'PYTHONPATH']:
+    old = '_OLD_' + name
+    if old not in os.environ and name in os.environ:
+        os.environ[old] = os.environ[name]
+
+os.environ['_PYTHON_PROJECT_BASE']={{repr(target.project_base)}}
+os.environ['_PYTHON_HOST_PLATFORM']={{repr(target.platform)}}
+os.environ['_PYTHON_SYSCONFIGDATA_NAME']={{repr(target.sysconfigdata_name)}}
+os.environ['PYTHONHOME']={{repr(target.home)}}
+oldpath = os.environ.get('PYTHONPATH')
+newpath = os.pathsep.join([{{repr(lib_path)}}, {{repr(exec_stdlib)}}])
+if oldpath:
+    path = os.pathsep.join([newpath, oldpath])
+else:
+    path = newpath
+
+os.environ['PYTHONPATH'] = path
+
+# This will fix up argv0 so that sys.executable will be correct
+os.execv({{repr(exec_python_executable)}}, sys.argv)

--- a/pycross/private/tools/crossenv/scripts/site.py.tmpl
+++ b/pycross/private/tools/crossenv/scripts/site.py.tmpl
@@ -1,0 +1,161 @@
+# Import only what we absolutely need before the path fixup
+
+# First a guard: If we left these environment variables in place we might
+# have messed with another Python installation. It's broken beyond repair
+# by this point in the startup process, but we can at least offer a helpful
+# warning...and who knows, it might still work, mostly.
+# There's also a chance that this is python2 we've messed with, so don't
+# import os, which can cause a SyntaxError.
+import sys
+import posix
+
+import os
+import importlib.machinery
+import importlib.abc
+import importlib.util
+import traceback  # used in sys-patch.py.tmpl; needs to be in sys.modules
+
+# To prevent the above scenario from playing out every time run a script that
+# starts with #!/usr/bin/python, we need to remove the environment variables so
+# subprocesses won't see them.
+for name in ['_PYTHON_PROJECT_BASE', '_PYTHON_HOST_PLATFORM',
+             '_PYTHON_SYSCONFIGDATA_NAME', 'PYTHONHOME', 'PYTHONPATH']:
+    prev = '_OLD_' + name
+    try:
+        os.environ[name] = os.environ[prev]
+    except KeyError:
+        os.environ.pop(name, None)
+    os.environ.pop(prev, None)
+
+# Very little is imported right now, which gives us a chance to patch most
+# things on import. A custom meta path finder will both patch things up and
+# forcibly load sysconfigdata from where we want it.
+#
+# This is more flexible than manually implementing our patches here.
+# Additionally, we need to patch something in distutils, but importing it in
+# order to patch will subsequently cause setuptools to complain.
+
+def _patch_module(module, patch):
+    # add our patch as if it had been typed just after
+    # explicit encoding, because we know that utf-8 has been loaded already.
+    # The default causes an import to happen too early.
+    with open(patch, 'r', encoding='utf-8') as fp:
+        src = fp.read()
+    exec(src, module.__dict__, module.__dict__)
+    module.__patched__ = True
+
+def make_loader(original, patch):
+    if hasattr(original, 'exec_module'):
+        return CrossenvPatchLoader(original, patch)
+    else:
+        return CrossenvPatchLegacyLoader(original, patch)
+
+class CrossenvPatchLoader(importlib.abc.Loader):
+    def __init__(self, original, patch):
+        self.original = original
+        self.patch = patch
+
+    def create_module(self, spec):
+        return self.original.create_module(spec)
+
+    def exec_module(self, module):
+        self.original.exec_module(module)
+        _patch_module(module, self.patch)
+
+    # runpy module expects a source loader, should we try to run 'python -m
+    # sysconfig'. This has extra methods, so we'll keep it happy with whatever
+    # it wants.
+    def __getattr__(self, name):
+        return getattr(self.original, name)
+
+class CrossenvPatchLegacyLoader(importlib.abc.Loader):
+    def __init__(self, original, patch):
+        self.original = original
+        self.patch = patch
+
+    def load_module(self, fullname):
+        module = self.original.load_module(fullname)
+        if not hasattr(module, '__patched__'):
+            _patch_module(module, self.patch)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self.original, name)
+
+class CrossenvFinder(importlib.abc.MetaPathFinder):
+    """Mucks with import machinery in two ways:
+
+    1) loads sysconfigdata from our hard-coded path, regardless of sys.path
+    2) intercepts and patches modules as they are loaded
+    """
+
+    PATCHES = {
+        'sys': '{{lib_path}}/sys-patch.py',
+        'os': '{{lib_path}}/os-patch.py',
+        'sysconfig': '{{lib_path}}/sysconfig-patch.py',
+        'distutils.sysconfig': '{{lib_path}}/distutils-sysconfig-patch.py',
+        'distutils.sysconfig_pypy': '{{lib_path}}/distutils-sysconfig-patch.py',
+        'platform': '{{lib_path}}/platform-patch.py',
+    }
+
+    def __init__(self):
+        # At startup, manually patch things that have already been loaded.  We
+        # can't re-load them because they might be used in many places already.
+        # This will be sys and os at the very least.
+        self.manually_patch_loaded()
+
+    def find_spec(self, fullname, path, target=None):
+        spec = self._find_sysconfigdata(fullname, path, target)
+        if spec:
+            return spec
+
+        return self._patch_spec(fullname, path, target)
+
+    def _find_sysconfigdata(self, fullname, path, target):
+        if fullname == {{repr(target.sysconfigdata_name)}}:
+            return importlib.util.spec_from_file_location(
+                    fullname, {{repr(target.sysconfigdata_path)}})
+        else:
+            return None
+
+    def _patch_spec(self, fullname, path, target):
+        """If necessary, set up to patch a module"""
+        if fullname not in self.PATCHES:
+            return None
+
+        # query the next finders to see who really would have loaded it
+        try:
+            start = sys.meta_path.index(self) + 1
+        except ValueError:
+            return None
+
+        for finder in sys.meta_path[start:]:
+            spec = finder.find_spec(fullname, path, target)
+            if spec is not None:
+                break
+        else:
+            return None
+
+        patch = self.PATCHES[fullname]
+        spec.loader = make_loader(spec.loader, patch)
+        return spec
+
+    def manually_patch_loaded(self):
+        for name, module in sys.modules.items():
+            if name in self.PATCHES:
+                _patch_module(module, self.PATCHES[name])
+
+# add just before the real path finder
+try:
+    _index = sys.meta_path.index(importlib.machinery.PathFinder)
+except ValueError:
+    _index = 0
+sys.meta_path.insert(_index, CrossenvFinder())
+
+# Re-import the real site module, so Python can continue booting. Crossenv is
+# ready! We do want to remove sysconfig or any other module that relies on
+# patching after site has messed with sys.
+del sys.modules['site']
+sys.modules.pop('sysconfig', None)
+sys.modules.pop('os', None)
+import site

--- a/pycross/private/tools/crossenv/scripts/sys-patch.py.tmpl
+++ b/pycross/private/tools/crossenv/scripts/sys-patch.py.tmpl
@@ -1,0 +1,42 @@
+cross_compiling = True
+
+abiflags = {{repr(target.abiflags)}}
+if abiflags is None:
+    del abiflags
+
+implementation._multiarch = {{repr(target.multiarch)}}
+if implementation._multiarch is None:
+    del implementation._multiarch
+
+# Remove cross-python from sys.path. It's not needed after startup.
+path.remove({{repr(lib_path)}})
+path.remove({{repr(exec_stdlib)}})
+
+# Patch sys.platform
+exec_platform = platform
+target_platform = {{repr(target.uname_sysname.lower())}}
+del platform
+
+# TODO: improve the target vs. exec criteria in this method.
+def __getattr__(name):
+    if name != 'platform':
+        raise AttributeError(name)
+
+    import traceback
+    frames = traceback.extract_stack(limit=2)
+    assert len(frames) == 2
+    frame = frames[0]
+
+    # frozen modules - part of the interpreter itself? Report exec platform.
+    if frame.filename.startswith("<frozen"):
+        return exec_platform
+    # Report cross platform to distutils
+    elif "distutils/" in frame.filename:
+        return target_platform
+    # Report the target platform to anything local
+    # (e.g., setup.py in the module we're building)
+    elif not frame.filename.startswith("/"):
+        return target_platform
+    # Report exec platform to everything else
+    else:
+        return exec_platform

--- a/pycross/private/tools/crossenv/scripts/sysconfig-patch.py.tmpl
+++ b/pycross/private/tools/crossenv/scripts/sysconfig-patch.py.tmpl
@@ -1,0 +1,32 @@
+# Patch the things that depend on os.environ
+_PROJECT_BASE = {{repr(target.project_base)}}
+
+# Things that need to be re-evaluated after patching
+_PYTHON_BUILD = is_python_build(True)
+_PREFIX = os.path.normpath(sys.prefix)
+_BASE_PREFIX = os.path.normpath(sys.base_prefix)
+_EXEC_PREFIX = os.path.normpath(sys.exec_prefix)
+_BASE_EXEC_PREFIX = os.path.normpath(sys.base_exec_prefix)
+
+def _get_sysconfigdata_name():
+    return {{repr(target.sysconfigdata_name)}}
+
+# On CPython patching _get_sysconfigdata_name is enough.
+# On PyPy, we need to patch _init_posix, because pypy
+# doesn't use _get_sysconfig_data_name in _init_posix
+__real_init_posix = _init_posix
+def _init_posix(*args, **kwargs):
+    old = os.environ.get('_PYTHON_SYSCONFIGDATA_NAME')
+    os.environ['_PYTHON_SYSCONFIGDATA_NAME'] = {{repr(target.sysconfigdata_name)}}
+    try:
+        return __real_init_posix(*args, **kwargs)
+    finally:
+        if old is None:
+            del os.environ['_PYTHON_SYSCONFIGDATA_NAME']
+        else:
+            os.environ['_PYTHON_SYSCONFIGDATA_NAME'] = old
+
+def get_platform():
+    return {{repr(target.sysconfig_platform)}}
+
+assert _CONFIG_VARS is None, "sysconfig was set up prior to patching?"

--- a/pycross/private/tools/crossenv/template.py
+++ b/pycross/private/tools/crossenv/template.py
@@ -1,0 +1,30 @@
+"""
+Dead simple template engine.
+"""
+
+import copy
+import re
+
+
+class Context:
+    def __init__(self):
+        self.locals = {}
+        self.globals = {
+            "__builtins__": __builtins__,
+        }
+
+    def update(self, other):
+        self.locals.update(other)
+
+    def update_globals(self, other):
+        self.globals.update(other)
+
+    def expand(self, template):
+        return re.sub(r"\{\{(.*?)\}\}", self._replace, template)
+
+    def _replace(self, match):
+        expr = match.group(1)
+        return str(eval(expr, self.locals, self.globals))
+
+    def copy(self):
+        return copy.copy(self)

--- a/pycross/private/tools/crossenv/utils.py
+++ b/pycross/private/tools/crossenv/utils.py
@@ -1,0 +1,207 @@
+import contextlib
+import importlib.util
+import os
+import pkgutil
+import re
+import shutil
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+# We're using %-style formatting everywhere because it's more convenient for
+# building Python and Bourne Shell source code. We'll build some helpers to
+# make it just a bit more like f-strings.
+
+
+class FormatMapping:
+    """Map strings such that %(foo.bar)s works in %-format strings"""
+
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def __getitem__(self, key):
+        parts = key.split(".")
+        obj = self.mapping[parts[0]]
+        for p in parts[1:]:
+            obj = getattr(obj, p)
+        return obj
+
+
+def F(s, values):
+    values = FormatMapping(values)
+    return s % values
+
+
+class TemplateContext:
+    def __init__(self):
+        self.locals = {}
+        self.globals = {
+            "__builtins__": __builtins__,
+        }
+
+    def update(self, other):
+        self.locals.update(other)
+
+    def update_globals(self, other):
+        self.globals.update(other)
+
+    def expand(self, template):
+        return re.sub(r"\{\{(.*?)\}\}", self._replace, template)
+
+    def _replace(self, match):
+        expr = match.group(1)
+        return str(eval(expr, self.locals, self.globals))
+
+
+@contextlib.contextmanager
+def overwrite_file(name, mode="w", perms=None):
+    """A context manager that will overwrite the given file
+    only after it was closed with no error"""
+
+    fp = tempfile.NamedTemporaryFile(mode, delete=False)
+    try:
+        yield fp
+        fp.close()
+        if perms is not None:
+            os.chmod(fp.name, perms)
+        shutil.move(fp.name, name)
+    except Exception as e:
+        fp.close()
+        try:
+            os.unlink(fp.name)
+        except OSError:
+            pass
+        raise
+
+
+def mkdir_if_needed(d):
+    if not os.path.exists(d):
+        os.makedirs(d)
+    elif os.path.islink(d) or os.path.isfile(d):
+        raise ValueError("Unable to make directory %r" % d)
+
+
+def remove_path(p):
+    if os.path.islink(p) or not os.path.isdir(p):
+        os.unlink(p)
+    else:
+        shutil.rmtree(p)
+
+
+def symlink(src, dst):
+    if os.path.exists(dst):
+        os.unlink(dst)
+    os.symlink(src, dst)
+
+
+def make_launcher(src, dst):
+    with overwrite_file(dst, perms=0o755) as fp:
+        fp.write(
+            dedent(
+                F(
+                    """\
+            #!/bin/sh
+            exec %(src)s "$@"
+            """,
+                    locals(),
+                )
+            )
+        )
+
+
+def fixup_shebang(src):
+    """Alter the shebang line if it's too long, as can happen somethings with
+    e.g., Jenkins. This trick is taken from what pip does."""
+    if not src.startswith("#!"):
+        return src
+
+    # full line, including newline
+    try:
+        end = src.index("\n") + 1
+    except ValueError:
+        end = len(src)
+    shebang = src[:end]
+
+    if len(shebang.encode("utf-8")) <= 127:
+        return src
+
+    interp = shebang[2:].strip()
+    preamble = dedent(
+        F(
+            """\
+        #!/bin/sh
+        '''exec' %(interp)s $0 "$@"
+        '''
+        """,
+            locals(),
+        )
+    )
+    return preamble + src[end:]
+
+
+def install_script(name, dst, context=None, perms=0o755):
+    srcname = os.path.join("scripts", name)
+    src = pkgutil.get_data(__package__, srcname)
+    if context is not None:
+        src = context.expand(src.decode())
+    src = fixup_shebang(src)
+    mkdir_if_needed(os.path.dirname(dst))
+
+    with overwrite_file(dst, perms=perms) as fp:
+        fp.write(src)
+
+
+def find_sysconfig_data(
+    paths: List[os.PathLike], given_file: Optional[os.PathLike] = None
+) -> Dict[str, Any]:
+    pattern = "_sysconfigdata_*.py*"
+    maybe = []
+    for path in paths:
+        maybe.extend(Path(path).glob(pattern))
+
+    if given_file:
+        sysconfig_paths = [given_file]
+    else:
+        found = set()
+        for filename in maybe:
+            if os.path.isfile(filename) and os.path.splitext(filename)[1] in (
+                ".py",
+                ".pyc",
+            ):
+                found.add(filename)
+
+        # Multiples can happen, but so long as they all have the same
+        # info we should be okay. Seen in buildroot
+        # When choosing the correct one, prefer, in order:
+        #   1) The .py file
+        #   2) The .pyc file
+        #   3) Any .opt-*.pyc files
+        # so sort by the length of the longest extension
+        sysconfig_paths = sorted(found, key=lambda x: len(str(x).split(".", 1)[1]))
+
+    target_sysconfigdata = None
+    target_sysconfigdata_file = None
+    for path in sysconfig_paths:
+        basename = os.path.basename(path)
+        name, _ = os.path.splitext(basename)
+        spec = importlib.util.spec_from_file_location(name, path)
+        syscfg = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(syscfg)
+        if target_sysconfigdata is None:
+            target_sysconfigdata = syscfg
+            target_sysconfigdata_file = path
+        elif target_sysconfigdata.build_time_vars != syscfg.build_time_vars:
+            raise ValueError(
+                f"Malformed Python installation: Conflicting build info in {target_sysconfigdata_file} and {path}"
+            )
+    if not target_sysconfigdata:
+        path_strs = [str(p) for p in sysconfig_paths]
+        raise FileNotFoundError(
+            f"No {pattern} found in target paths. Looked in {', '.join(path_strs)}"
+        )
+
+    return target_sysconfigdata.build_time_vars

--- a/pycross/toolchain.bzl
+++ b/pycross/toolchain.bzl
@@ -1,0 +1,57 @@
+"""This module implements the language-specific toolchain rule.
+"""
+load("//pycross/private:providers.bzl", "PycrossTargetEnvironmentInfo")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+PycrossBuildExecRuntimeInfo = provider(
+    doc = "Extended information about a (exec, target) Python interpreter pair.",
+    fields = {
+        "exec_python_files": "A depset containing all files for the exec interpreter.",
+        "exec_python_executable": "The path to the exec Python interpreter, either absolute or relative to execroot.",
+        "target_python_files": "A depset containing all files for the target interpreter.",
+        "target_python_executable": "The path to the target Python interpreter, either absolute or relative to execroot.",
+        "target_sys_path": "An array of system path directories (i.e., the value of sys.path from `python -m site`).",
+        "target_environment": "The label of an associated PycrossTargetEnvironmentInfo target.",
+    },
+)
+
+def _pycross_hermetic_toolchain_impl(ctx):
+    exec_py_info = ctx.attr.exec_interpreter[PyRuntimeInfo]
+    target_py_info = ctx.attr.target_interpreter[PyRuntimeInfo]
+
+    pycross_info = PycrossBuildExecRuntimeInfo(
+        exec_python_files=exec_py_info.files,
+        exec_python_executable=exec_py_info.interpreter.path,
+        target_python_files=target_py_info.files,
+        target_python_executable=target_py_info.interpreter.path,
+        target_sys_path=[], #find_hermetic_sys_path(target_py_info),
+        target_environment=ctx.attr.target_environment,
+    )
+
+    return [
+        platform_common.ToolchainInfo(
+            pycross_info = pycross_info,
+        ),
+    ]
+
+
+pycross_hermetic_toolchain = rule(
+    implementation = _pycross_hermetic_toolchain_impl,
+    attrs = {
+        "target_environment": attr.label(
+            doc = "The target environment associated with this toolchain.",
+            mandatory = True,
+            providers = [PycrossTargetEnvironmentInfo],
+        ),
+        "target_interpreter": attr.label(
+            doc = "The target Python interpreter (PyRuntimeInfo).",
+            mandatory = True,
+            providers = [PyRuntimeInfo],
+        ),
+        "exec_interpreter": attr.label(
+            doc = "The execution Python interpreter (PyRuntimeInfo).",
+            mandatory = True,
+            providers = [PyRuntimeInfo],
+        ),
+    },
+)


### PR DESCRIPTION
Uses a derivative of https://github.com/benfogle/crossenv to support compiling wheels cross-platform. It's a bag of hacks, so there will no doubt be things that don't work. But it at least works for numpy.

See examples/crossenv/README.md.