### PR TITLE
Add `data` to wheel_build

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -130,7 +130,7 @@ pycross_target_environment(<a href="#pycross_target_environment-name">name</a>, 
 ## pycross_wheel_build
 
 <pre>
-pycross_wheel_build(<a href="#pycross_wheel_build-name">name</a>, <a href="#pycross_wheel_build-copts">copts</a>, <a href="#pycross_wheel_build-deps">deps</a>, <a href="#pycross_wheel_build-linkopts">linkopts</a>, <a href="#pycross_wheel_build-sdist">sdist</a>, <a href="#pycross_wheel_build-target_environment">target_environment</a>)
+pycross_wheel_build(<a href="#pycross_wheel_build-name">name</a>, <a href="#pycross_wheel_build-copts">copts</a>, <a href="#pycross_wheel_build-data">data</a>, <a href="#pycross_wheel_build-deps">deps</a>, <a href="#pycross_wheel_build-linkopts">linkopts</a>, <a href="#pycross_wheel_build-sdist">sdist</a>, <a href="#pycross_wheel_build-target_environment">target_environment</a>)
 </pre>
 
 
@@ -142,6 +142,7 @@ pycross_wheel_build(<a href="#pycross_wheel_build-name">name</a>, <a href="#pycr
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="pycross_wheel_build-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="pycross_wheel_build-copts"></a>copts |  Additional C compiler options.   | List of strings | optional | <code>[]</code> |
+| <a id="pycross_wheel_build-data"></a>data |  A list of resources needed to build the wheel. For example, additional headers and libraries.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="pycross_wheel_build-deps"></a>deps |  A list of build dependencies for the wheel.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="pycross_wheel_build-linkopts"></a>linkopts |  Additional C linker options.   | List of strings | optional | <code>[]</code> |
 | <a id="pycross_wheel_build-sdist"></a>sdist |  The sdist file.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |

--- a/pycross/private/wheel_build.bzl
+++ b/pycross/private/wheel_build.bzl
@@ -190,7 +190,7 @@ def _pycross_wheel_build_impl(ctx):
     deps = [
         ctx.file.sdist,
         cc_sysconfig_data,
-    ]
+    ] + ctx.files.data
 
     transitive_sources = [dep[PyInfo].transitive_sources for dep in ctx.attr.deps if PyInfo in dep]
 
@@ -238,6 +238,10 @@ pycross_wheel_build = rule(
         "deps": attr.label_list(
             doc = "A list of build dependencies for the wheel.",
             providers = [DefaultInfo, PyInfo],
+        ),
+        "data": attr.label_list(
+            doc = "A list of resources needed to build the wheel. For example, " + 
+            "additional headers and libraries.",
         ),
         "sdist": attr.label(
             doc = "The sdist file.",


### PR DESCRIPTION
Hi! Thank you for creating this awesome prototype! I am evaluating adopting it for our python code base.

For our use case we encountered some sdist that requires certain headers and libraries not available from the environment. (it's also nice to make things hermetic through this PR). 

Hence, this PR adds `data` attribute which can bring additional files into the sandbox. Also, to make the compiler able to consume the additional data, this PR adds make variable expansion support to copts and linkopts.