### PR TITLE
Fix support for default python version when using pycross_register_for_python_toolchains

### DIFF
--- a/pycross/private/target_environment.bzl
+++ b/pycross/private/target_environment.bzl
@@ -29,6 +29,9 @@ def _target_python_impl(ctx):
     for key, val in ctx.attr.envornment_markers.items():
         args.add_all("--environment-marker", [key, val])
 
+    if ctx.attr.config_setting:
+        args.add("--config-setting-target", fully_qualified_label(ctx.attr.config_setting.label))
+
     ctx.actions.run(
         outputs = [f],
         executable = ctx.executable._tool,
@@ -81,6 +84,9 @@ pycross_target_environment = rule(
         ),
         "envornment_markers": attr.string_dict(
             doc = "Environment marker overrides.",
+        ),
+        "config_setting": attr.label(
+            doc = "Optional config_setting target to select this environment.",
         ),
         "_tool": attr.label(
             default = Label("//pycross/private/tools:target_environment_generator"),

--- a/pycross/private/tools/target_environment.py
+++ b/pycross/private/tools/target_environment.py
@@ -8,11 +8,12 @@ from dataclasses import dataclass
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 
 from pip._internal.models.target_python import TargetPython
 
 
-@dataclass
+@dataclass(frozen=True)
 class TargetEnv:
     name: str
     implementation: str
@@ -23,6 +24,7 @@ class TargetEnv:
     markers: Dict[str, str]
     python_compatible_with: List[str]
     flag_values: Dict[str, str]
+    config_setting_target: Optional[str] = None
 
     @staticmethod
     def from_target_python(
@@ -31,6 +33,7 @@ class TargetEnv:
         markers: Dict[str, str],
         python_compatible_with: List[str],
         flag_values: Dict[str, str],
+        config_setting_target: Optional[str] = None,
     ) -> "TargetEnv":
         all_markers = guess_environment_markers(target_python)
         for key, val in markers.items():
@@ -48,6 +51,7 @@ class TargetEnv:
             markers=all_markers,
             python_compatible_with=python_compatible_with,
             flag_values=flag_values,
+            config_setting_target=config_setting_target,
         )
 
     @property

--- a/pycross/private/tools/target_environment_generator.py
+++ b/pycross/private/tools/target_environment_generator.py
@@ -57,7 +57,12 @@ def main(args: Any) -> None:
     )
 
     target = TargetEnv.from_target_python(
-        args.name, target_python, overrides, args.python_compatible_with, args.flag_value
+        args.name,
+        target_python,
+        overrides,
+        args.python_compatible_with,
+        args.flag_value,
+        args.config_setting_target,
     )
     with open(args.output, "w") as f:
         json.dump(target.to_dict(), f, indent=2, sort_keys=True)
@@ -114,7 +119,12 @@ def parse_flags() -> Any:
         "--flag-value",
         nargs=2,
         action="append",
-        help="A config",
+        help="A config_setting flag value.",
+    )
+
+    parser.add_argument(
+        "--config-setting-target",
+        help="The config_setting target to use.",
     )
 
     parser.add_argument(

--- a/tests/smoke/pdm/lock.bzl
+++ b/tests/smoke/pdm/lock.bzl
@@ -40,152 +40,20 @@ def targets():
             actual = ":" + pin_target,
         )
 
-    native.config_setting(
-        name = "_env_python_3.10.12_aarch64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.10.12",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.10.12_aarch64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.10.12",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.10.12_x86_64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.10.12",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.10.12_x86_64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.10.12",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.11.6_aarch64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.11.6",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.11.6_aarch64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.11.6",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.11.6_x86_64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.11.6",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.11.6_x86_64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.11.6",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.12.0_aarch64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.12.0",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.12.0_aarch64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.12.0",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.12.0_x86_64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.12.0",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.12.0_x86_64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.12.0",
-        },
-    )
-
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_3.10.12_aarch64_apple_darwin": "@pycross_toolchains//:python_3.10.12_aarch64-apple-darwin",
-        ":_env_python_3.10.12_aarch64_unknown_linux_gnu": "@pycross_toolchains//:python_3.10.12_aarch64-unknown-linux-gnu",
-        ":_env_python_3.10.12_x86_64_apple_darwin": "@pycross_toolchains//:python_3.10.12_x86_64-apple-darwin",
-        ":_env_python_3.10.12_x86_64_unknown_linux_gnu": "@pycross_toolchains//:python_3.10.12_x86_64-unknown-linux-gnu",
-        ":_env_python_3.11.6_aarch64_apple_darwin": "@pycross_toolchains//:python_3.11.6_aarch64-apple-darwin",
-        ":_env_python_3.11.6_aarch64_unknown_linux_gnu": "@pycross_toolchains//:python_3.11.6_aarch64-unknown-linux-gnu",
-        ":_env_python_3.11.6_x86_64_apple_darwin": "@pycross_toolchains//:python_3.11.6_x86_64-apple-darwin",
-        ":_env_python_3.11.6_x86_64_unknown_linux_gnu": "@pycross_toolchains//:python_3.11.6_x86_64-unknown-linux-gnu",
-        ":_env_python_3.12.0_aarch64_apple_darwin": "@pycross_toolchains//:python_3.12.0_aarch64-apple-darwin",
-        ":_env_python_3.12.0_aarch64_unknown_linux_gnu": "@pycross_toolchains//:python_3.12.0_aarch64-unknown-linux-gnu",
-        ":_env_python_3.12.0_x86_64_apple_darwin": "@pycross_toolchains//:python_3.12.0_x86_64-apple-darwin",
-        ":_env_python_3.12.0_x86_64_unknown_linux_gnu": "@pycross_toolchains//:python_3.12.0_x86_64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.10.12_aarch64-apple-darwin_config": "@pycross_toolchains//:python_3.10.12_aarch64-apple-darwin",
+        "@pycross_toolchains//:python_3.10.12_aarch64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.10.12_aarch64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.10.12_x86_64-apple-darwin_config": "@pycross_toolchains//:python_3.10.12_x86_64-apple-darwin",
+        "@pycross_toolchains//:python_3.10.12_x86_64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.10.12_x86_64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.11.6_aarch64-apple-darwin_config": "@pycross_toolchains//:python_3.11.6_aarch64-apple-darwin",
+        "@pycross_toolchains//:python_3.11.6_aarch64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.11.6_aarch64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.11.6_x86_64-apple-darwin_config": "@pycross_toolchains//:python_3.11.6_x86_64-apple-darwin",
+        "@pycross_toolchains//:python_3.11.6_x86_64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.11.6_x86_64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.12.0_aarch64-apple-darwin_config": "@pycross_toolchains//:python_3.12.0_aarch64-apple-darwin",
+        "@pycross_toolchains//:python_3.12.0_aarch64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.12.0_aarch64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.12.0_x86_64-apple-darwin_config": "@pycross_toolchains//:python_3.12.0_x86_64-apple-darwin",
+        "@pycross_toolchains//:python_3.12.0_x86_64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.12.0_x86_64-unknown-linux-gnu",
     })
 
     pycross_wheel_library(
@@ -228,30 +96,30 @@ def targets():
         ":stack_data_0.6.3",
         ":traitlets_5.13.0",
     ] + select({
-        ":_env_python_3.10.12_aarch64_apple_darwin": [
+        "@pycross_toolchains//:python_3.10.12_aarch64-apple-darwin_config": [
             ":appnope_0.1.3",
             ":exceptiongroup_1.1.3",
         ],
-        ":_env_python_3.10.12_aarch64_unknown_linux_gnu": [
+        "@pycross_toolchains//:python_3.10.12_aarch64-unknown-linux-gnu_config": [
             ":exceptiongroup_1.1.3",
         ],
-        ":_env_python_3.10.12_x86_64_apple_darwin": [
+        "@pycross_toolchains//:python_3.10.12_x86_64-apple-darwin_config": [
             ":appnope_0.1.3",
             ":exceptiongroup_1.1.3",
         ],
-        ":_env_python_3.10.12_x86_64_unknown_linux_gnu": [
+        "@pycross_toolchains//:python_3.10.12_x86_64-unknown-linux-gnu_config": [
             ":exceptiongroup_1.1.3",
         ],
-        ":_env_python_3.11.6_aarch64_apple_darwin": [
+        "@pycross_toolchains//:python_3.11.6_aarch64-apple-darwin_config": [
             ":appnope_0.1.3",
         ],
-        ":_env_python_3.11.6_x86_64_apple_darwin": [
+        "@pycross_toolchains//:python_3.11.6_x86_64-apple-darwin_config": [
             ":appnope_0.1.3",
         ],
-        ":_env_python_3.12.0_aarch64_apple_darwin": [
+        "@pycross_toolchains//:python_3.12.0_aarch64-apple-darwin_config": [
             ":appnope_0.1.3",
         ],
-        ":_env_python_3.12.0_x86_64_apple_darwin": [
+        "@pycross_toolchains//:python_3.12.0_x86_64-apple-darwin_config": [
             ":appnope_0.1.3",
         ],
         "//conditions:default": [],

--- a/tests/smoke/poetry/lock.bzl
+++ b/tests/smoke/poetry/lock.bzl
@@ -39,152 +39,20 @@ def targets():
             actual = ":" + pin_target,
         )
 
-    native.config_setting(
-        name = "_env_python_3.10.12_aarch64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.10.12",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.10.12_aarch64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.10.12",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.10.12_x86_64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.10.12",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.10.12_x86_64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.10.12",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.11.6_aarch64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.11.6",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.11.6_aarch64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.11.6",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.11.6_x86_64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.11.6",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.11.6_x86_64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.11.6",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.12.0_aarch64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.12.0",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.12.0_aarch64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:aarch64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.12.0",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.12.0_x86_64_apple_darwin",
-        constraint_values = [
-            "@platforms//os:osx",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.12.0",
-        },
-    )
-
-    native.config_setting(
-        name = "_env_python_3.12.0_x86_64_unknown_linux_gnu",
-        constraint_values = [
-            "@platforms//os:linux",
-            "@platforms//cpu:x86_64",
-        ],
-        flag_values = {
-            "@rules_python//python/config_settings:python_version": "3.12.0",
-        },
-    )
-
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_3.10.12_aarch64_apple_darwin": "@pycross_toolchains//:python_3.10.12_aarch64-apple-darwin",
-        ":_env_python_3.10.12_aarch64_unknown_linux_gnu": "@pycross_toolchains//:python_3.10.12_aarch64-unknown-linux-gnu",
-        ":_env_python_3.10.12_x86_64_apple_darwin": "@pycross_toolchains//:python_3.10.12_x86_64-apple-darwin",
-        ":_env_python_3.10.12_x86_64_unknown_linux_gnu": "@pycross_toolchains//:python_3.10.12_x86_64-unknown-linux-gnu",
-        ":_env_python_3.11.6_aarch64_apple_darwin": "@pycross_toolchains//:python_3.11.6_aarch64-apple-darwin",
-        ":_env_python_3.11.6_aarch64_unknown_linux_gnu": "@pycross_toolchains//:python_3.11.6_aarch64-unknown-linux-gnu",
-        ":_env_python_3.11.6_x86_64_apple_darwin": "@pycross_toolchains//:python_3.11.6_x86_64-apple-darwin",
-        ":_env_python_3.11.6_x86_64_unknown_linux_gnu": "@pycross_toolchains//:python_3.11.6_x86_64-unknown-linux-gnu",
-        ":_env_python_3.12.0_aarch64_apple_darwin": "@pycross_toolchains//:python_3.12.0_aarch64-apple-darwin",
-        ":_env_python_3.12.0_aarch64_unknown_linux_gnu": "@pycross_toolchains//:python_3.12.0_aarch64-unknown-linux-gnu",
-        ":_env_python_3.12.0_x86_64_apple_darwin": "@pycross_toolchains//:python_3.12.0_x86_64-apple-darwin",
-        ":_env_python_3.12.0_x86_64_unknown_linux_gnu": "@pycross_toolchains//:python_3.12.0_x86_64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.10.12_aarch64-apple-darwin_config": "@pycross_toolchains//:python_3.10.12_aarch64-apple-darwin",
+        "@pycross_toolchains//:python_3.10.12_aarch64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.10.12_aarch64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.10.12_x86_64-apple-darwin_config": "@pycross_toolchains//:python_3.10.12_x86_64-apple-darwin",
+        "@pycross_toolchains//:python_3.10.12_x86_64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.10.12_x86_64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.11.6_aarch64-apple-darwin_config": "@pycross_toolchains//:python_3.11.6_aarch64-apple-darwin",
+        "@pycross_toolchains//:python_3.11.6_aarch64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.11.6_aarch64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.11.6_x86_64-apple-darwin_config": "@pycross_toolchains//:python_3.11.6_x86_64-apple-darwin",
+        "@pycross_toolchains//:python_3.11.6_x86_64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.11.6_x86_64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.12.0_aarch64-apple-darwin_config": "@pycross_toolchains//:python_3.12.0_aarch64-apple-darwin",
+        "@pycross_toolchains//:python_3.12.0_aarch64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.12.0_aarch64-unknown-linux-gnu",
+        "@pycross_toolchains//:python_3.12.0_x86_64-apple-darwin_config": "@pycross_toolchains//:python_3.12.0_x86_64-apple-darwin",
+        "@pycross_toolchains//:python_3.12.0_x86_64-unknown-linux-gnu_config": "@pycross_toolchains//:python_3.12.0_x86_64-unknown-linux-gnu",
     })
 
     pycross_wheel_library(
@@ -227,30 +95,30 @@ def targets():
         ":stack_data_0.6.3",
         ":traitlets_5.13.0",
     ] + select({
-        ":_env_python_3.10.12_aarch64_apple_darwin": [
+        "@pycross_toolchains//:python_3.10.12_aarch64-apple-darwin_config": [
             ":appnope_0.1.3",
             ":exceptiongroup_1.1.3",
         ],
-        ":_env_python_3.10.12_aarch64_unknown_linux_gnu": [
+        "@pycross_toolchains//:python_3.10.12_aarch64-unknown-linux-gnu_config": [
             ":exceptiongroup_1.1.3",
         ],
-        ":_env_python_3.10.12_x86_64_apple_darwin": [
+        "@pycross_toolchains//:python_3.10.12_x86_64-apple-darwin_config": [
             ":appnope_0.1.3",
             ":exceptiongroup_1.1.3",
         ],
-        ":_env_python_3.10.12_x86_64_unknown_linux_gnu": [
+        "@pycross_toolchains//:python_3.10.12_x86_64-unknown-linux-gnu_config": [
             ":exceptiongroup_1.1.3",
         ],
-        ":_env_python_3.11.6_aarch64_apple_darwin": [
+        "@pycross_toolchains//:python_3.11.6_aarch64-apple-darwin_config": [
             ":appnope_0.1.3",
         ],
-        ":_env_python_3.11.6_x86_64_apple_darwin": [
+        "@pycross_toolchains//:python_3.11.6_x86_64-apple-darwin_config": [
             ":appnope_0.1.3",
         ],
-        ":_env_python_3.12.0_aarch64_apple_darwin": [
+        "@pycross_toolchains//:python_3.12.0_aarch64-apple-darwin_config": [
             ":appnope_0.1.3",
         ],
-        ":_env_python_3.12.0_x86_64_apple_darwin": [
+        "@pycross_toolchains//:python_3.12.0_x86_64-apple-darwin_config": [
             ":appnope_0.1.3",
         ],
         "//conditions:default": [],


### PR DESCRIPTION
When registering toolchains and environments using `pycross_register_for_python_toolchains`, the entries corresponding to the default Python version should not have a `@rules_python//python/config_settings:python_version` flag setting. This mirrors how rules_python's own toolchains are constructed.

Also, this PR adds a `config_setting` attribute to `pycross_target_environment`. If set, the generated lock file won't have a `config_setting` for that environment, and `select` statements will use the provided label.