### PR TITLE
fix: pdm translator fails to resolve dependency if pre-release version is required

### DIFF
--- a/pycross/private/tools/pdm_translator.py
+++ b/pycross/private/tools/pdm_translator.py
@@ -82,7 +82,7 @@ class PDMPackage:
         # Extras are case-insensitive. The left side is already lower-cased.
         if not self.extras.issuperset(set(r.lower() for r in req.extras)):
             return False
-        return req.specifier.contains(self.version)
+        return req.specifier.contains(self.version, prereleases=True)
 
     def to_lock_package(self) -> Package:
         dependencies_without_self = sorted(
@@ -258,7 +258,7 @@ def translate(
     for pin, pin_spec in pinned_package_specs.items():
         pin_packages = packages_by_canonical_name[pin]
         for pin_pkg in pin_packages:
-            if pin_spec.specifier.contains(pin_pkg.version):
+            if pin_spec.specifier.contains(pin_pkg.version, prereleases=True):
                 pinned_keys[pin] = pin_pkg.key
                 break
         else:

--- a/pycross/private/tools/pdm_translator.py
+++ b/pycross/private/tools/pdm_translator.py
@@ -189,12 +189,12 @@ def translate(
             raise Exception(f"Non-existent development dependency group: {group_name}")
         requirements.extend(development_dependencies[group_name])
 
-    pinned_package_specs = {}
+    pinned_package_specs: Dict[NormalizedName, Requirement] = {}
     for req in requirements:
         pin = package_canonical_name(req.name)
         pinned_package_specs[pin] = req
 
-    distinct_packages = {}
+    distinct_packages: Dict[PackageKey, PDMPackage] = {}
     # Pull out all Package entries in a pdm-specific model.
     for lock_pkg in lock_dict.get("package", []):
         package_listed_name = lock_pkg["name"]
@@ -254,7 +254,7 @@ def translate(
                     f"Found no packages to satisfy dependency (name={dep.name}, spec={dep.specifier})"
                 )
 
-    pinned_keys = {}
+    pinned_keys: Dict[NormalizedName, PackageKey] = {}
     for pin, pin_spec in pinned_package_specs.items():
         pin_packages = packages_by_canonical_name[pin]
         for pin_pkg in pin_packages:
@@ -264,7 +264,7 @@ def translate(
         else:
             raise MismatchedVersionException(f"Found no packages to satisfy pin (name={pin}, spec={pin_spec})")
 
-    lock_packages = {}
+    lock_packages: Dict[PackageKey, Package] = {}
     for package in all_packages:
         lock_package = package.to_lock_package()
         lock_packages[lock_package.key] = lock_package


### PR DESCRIPTION
fixes 
`__main__.MismatchedVersionException: Found no packages to satisfy dependency (name=sphinx-basic-ng, spec=)`

which occurs if a package does not specify any constraints for a dependency.