### PR TITLE
jvolkman_rules_pycross -> rules_pycross

### DIFF
--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -13,7 +13,7 @@ WORKSPACE snippet:
 \`\`\`starlark
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
-    name = "jvolkman_rules_pycross",
+    name = "rules_pycross",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
     url = "https://github.com/jvolkman/rules_pycross/archive/refs/tags/${TAG}.tar.gz",
@@ -24,7 +24,7 @@ http_archive(
 # you should fetch it *before* calling this.
 # Alternatively, you can skip calling this function, so long as you've
 # already fetched all the dependencies.
-load("@jvolkman_rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
+load("@rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
 rules_pycross_dependencies()
 
 \`\`\`

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(
-    name = "jvolkman_rules_pycross",
+    name = "rules_pycross",
 )
 
 load(":internal_deps.bzl", "rules_pycross_internal_deps")

--- a/examples/external_linking/BUILD.bazel
+++ b/examples/external_linking/BUILD.bazel
@@ -1,12 +1,12 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load(
-    "@jvolkman_rules_pycross//pycross:defs.bzl",
+    "@rules_pycross//pycross:defs.bzl",
     "pycross_lock_file",
     "pycross_pdm_lock_model",
     "pycross_target_environment",
 )
 load(
-    "@jvolkman_rules_pycross//pycross:toolchain.bzl",
+    "@rules_pycross//pycross:toolchain.bzl",
     "pycross_hermetic_toolchain",
 )
 
@@ -107,7 +107,7 @@ toolchain(
     exec_compatible_with = _darwin_arm64,
     target_compatible_with = _linux_x86_64,
     toolchain = ":pycross_darwin_linux",
-    toolchain_type = "@jvolkman_rules_pycross//pycross:toolchain_type",
+    toolchain_type = "@rules_pycross//pycross:toolchain_type",
 )
 
 pycross_hermetic_toolchain(
@@ -122,7 +122,7 @@ toolchain(
     exec_compatible_with = _linux_x86_64,
     target_compatible_with = _darwin_arm64,
     toolchain = ":pycross_linux_darwin",
-    toolchain_type = "@jvolkman_rules_pycross//pycross:toolchain_type",
+    toolchain_type = "@rules_pycross//pycross:toolchain_type",
 )
 
 pycross_hermetic_toolchain(
@@ -137,7 +137,7 @@ toolchain(
     exec_compatible_with = _linux_x86_64,
     target_compatible_with = _linux_arm64,
     toolchain = ":pycross_linux_x86_64_linux_arm64",
-    toolchain_type = "@jvolkman_rules_pycross//pycross:toolchain_type",
+    toolchain_type = "@rules_pycross//pycross:toolchain_type",
 )
 
 pycross_pdm_lock_model(

--- a/examples/external_linking/WORKSPACE
+++ b/examples/external_linking/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(
-    name = "jvolkman_rules_pycross_example",
+    name = "rules_pycross_example",
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -23,18 +23,18 @@ python_register_toolchains(
 )
 
 local_repository(
-    name = "jvolkman_rules_pycross",
+    name = "rules_pycross",
     path = "../..",
 )
 
-load("@jvolkman_rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
 load("@python3_10//:defs.bzl", python_interpreter = "interpreter")
+load("@rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
 
 rules_pycross_dependencies(
     python_interpreter_target = python_interpreter,
 )
 
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_lock_repo")
+load("@rules_pycross//pycross:defs.bzl", "pycross_lock_repo")
 
 pycross_lock_repo(
     name = "example_lock_repo",

--- a/examples/external_linking/deps/numpy/BUILD.bazel
+++ b/examples/external_linking/deps/numpy/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build")
+load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -15,7 +15,7 @@ pycross_wheel_build(
         "//third_party/openblas:libopenblas.a",
     ],
     post_build_hooks = [
-        "@jvolkman_rules_pycross//pycross/hooks:repair_wheel",
+        "@rules_pycross//pycross/hooks:repair_wheel",
     ],
     pre_build_hooks = [
         ":gen_site_cfg",

--- a/examples/external_linking/deps/psycopg2/BUILD.bazel
+++ b/examples/external_linking/deps/psycopg2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build")
+load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,7 +12,7 @@ pycross_wheel_build(
         ":pg_config": "pg_config",
     },
     post_build_hooks = [
-        "@jvolkman_rules_pycross//pycross/hooks:repair_wheel",
+        "@rules_pycross//pycross/hooks:repair_wheel",
     ],
     sdist = "@example_lock_sdist_psycopg2_2.9.5//file",
     tags = ["manual"],

--- a/examples/external_linking/example_lock.bzl
+++ b/examples/external_linking/example_lock.bzl
@@ -4,7 +4,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library")
+load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library")
 
 PINS = {
     "appnope": "appnope_0.1.3",
@@ -80,10 +80,10 @@ def targets():
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_darwin_arm64": "@jvolkman_rules_pycross_example//:python_darwin_arm64",
-        ":_env_python_darwin_x86_64": "@jvolkman_rules_pycross_example//:python_darwin_x86_64",
-        ":_env_python_linux_arm64": "@jvolkman_rules_pycross_example//:python_linux_arm64",
-        ":_env_python_linux_x86_64": "@jvolkman_rules_pycross_example//:python_linux_x86_64",
+        ":_env_python_darwin_arm64": "@rules_pycross_example//:python_darwin_arm64",
+        ":_env_python_darwin_x86_64": "@rules_pycross_example//:python_darwin_x86_64",
+        ":_env_python_linux_arm64": "@rules_pycross_example//:python_linux_arm64",
+        ":_env_python_linux_x86_64": "@rules_pycross_example//:python_linux_x86_64",
     })
 
     pycross_wheel_library(

--- a/examples/pdm/BUILD.bazel
+++ b/examples/pdm/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load(
-    "@jvolkman_rules_pycross//pycross:defs.bzl",
+    "@rules_pycross//pycross:defs.bzl",
     "pycross_lock_file",
     "pycross_pdm_lock_model",
     "pycross_target_environment",

--- a/examples/pdm/WORKSPACE
+++ b/examples/pdm/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(
-    name = "jvolkman_rules_pycross_example",
+    name = "rules_pycross_example",
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -23,18 +23,18 @@ python_register_toolchains(
 )
 
 local_repository(
-    name = "jvolkman_rules_pycross",
+    name = "rules_pycross",
     path = "../..",
 )
 
-load("@jvolkman_rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
 load("@python3_11//:defs.bzl", python_interpreter = "interpreter")
+load("@rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
 
 rules_pycross_dependencies(
     python_interpreter_target = python_interpreter,
 )
 
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_lock_repo")
+load("@rules_pycross//pycross:defs.bzl", "pycross_lock_repo")
 
 pycross_lock_repo(
     name = "example_lock_repo",

--- a/examples/pdm/deps/BUILD.bazel
+++ b/examples/pdm/deps/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build")
+load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build")
 load("//:example_lock.bzl", "targets")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/pdm/example_lock.bzl
+++ b/examples/pdm/example_lock.bzl
@@ -4,7 +4,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library")
+load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library")
 
 PINS = {
     "alabaster": "alabaster_0.7.13",
@@ -167,9 +167,9 @@ def targets():
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_darwin_arm64": "@jvolkman_rules_pycross_example//:python_darwin_arm64",
-        ":_env_python_darwin_x86_64": "@jvolkman_rules_pycross_example//:python_darwin_x86_64",
-        ":_env_python_linux_x86_64": "@jvolkman_rules_pycross_example//:python_linux_x86_64",
+        ":_env_python_darwin_arm64": "@rules_pycross_example//:python_darwin_arm64",
+        ":_env_python_darwin_x86_64": "@rules_pycross_example//:python_darwin_x86_64",
+        ":_env_python_linux_x86_64": "@rules_pycross_example//:python_linux_x86_64",
     })
 
     pycross_wheel_library(

--- a/examples/pkg_repo/WORKSPACE
+++ b/examples/pkg_repo/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(
-    name = "jvolkman_rules_pycross_example",
+    name = "rules_pycross_example",
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -28,18 +28,18 @@ python_register_multi_toolchains(
 load("@python//3.12:defs.bzl", python_interpreter = "interpreter")
 
 local_repository(
-    name = "jvolkman_rules_pycross",
+    name = "rules_pycross",
     path = "../..",
 )
 
-load("@jvolkman_rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
+load("@rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
 
 rules_pycross_dependencies(
     python_interpreter_target = python_interpreter,
 )
 
 load(
-    "@jvolkman_rules_pycross//pycross:defs.bzl",
+    "@rules_pycross//pycross:defs.bzl",
     "pkg_repo_model_pdm",
     "pycross_pkg_repo",
     "pycross_register_for_python_toolchains",

--- a/examples/poetry/BUILD.bazel
+++ b/examples/poetry/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load(
-    "@jvolkman_rules_pycross//pycross:defs.bzl",
+    "@rules_pycross//pycross:defs.bzl",
     "pycross_lock_file",
     "pycross_poetry_lock_model",
     "pycross_target_environment",

--- a/examples/poetry/WORKSPACE
+++ b/examples/poetry/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(
-    name = "jvolkman_rules_pycross_example",
+    name = "rules_pycross_example",
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -23,18 +23,18 @@ python_register_toolchains(
 )
 
 local_repository(
-    name = "jvolkman_rules_pycross",
+    name = "rules_pycross",
     path = "../..",
 )
 
-load("@jvolkman_rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
 load("@python3_11//:defs.bzl", python_interpreter = "interpreter")
+load("@rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
 
 rules_pycross_dependencies(
     python_interpreter_target = python_interpreter,
 )
 
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_lock_repo")
+load("@rules_pycross//pycross:defs.bzl", "pycross_lock_repo")
 
 pycross_lock_repo(
     name = "example_lock_repo",

--- a/examples/poetry/deps/BUILD.bazel
+++ b/examples/poetry/deps/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build")
+load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build")
 load("//:example_lock.bzl", "targets")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/poetry/example_lock.bzl
+++ b/examples/poetry/example_lock.bzl
@@ -4,7 +4,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library", "pypi_file")
+load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library", "pypi_file")
 
 PINS = {
     "annotated_types": "annotated_types_0.6.0",
@@ -147,9 +147,9 @@ def targets():
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_darwin_arm64": "@jvolkman_rules_pycross_example//:python_darwin_arm64",
-        ":_env_python_darwin_x86_64": "@jvolkman_rules_pycross_example//:python_darwin_x86_64",
-        ":_env_python_linux_x86_64": "@jvolkman_rules_pycross_example//:python_linux_x86_64",
+        ":_env_python_darwin_arm64": "@rules_pycross_example//:python_darwin_arm64",
+        ":_env_python_darwin_x86_64": "@rules_pycross_example//:python_darwin_x86_64",
+        ":_env_python_linux_x86_64": "@rules_pycross_example//:python_linux_x86_64",
     })
 
     pycross_wheel_library(

--- a/pycross/private/internal_repo.bzl
+++ b/pycross/private/internal_repo.bzl
@@ -5,9 +5,9 @@ load(":repo_venv_utils.bzl", "create_venv", "get_venv_python_executable", "insta
 
 INTERNAL_REPO_NAME = "rules_pycross_internal"
 LOCK_FILES = {
-    "build": "@jvolkman_rules_pycross//pycross/private:pycross_deps_build.lock.bzl",
-    "core": "@jvolkman_rules_pycross//pycross/private:pycross_deps_core.lock.bzl",
-    "repairwheel": "@jvolkman_rules_pycross//pycross/private:pycross_deps_repairwheel.lock.bzl",
+    "build": "//pycross/private:pycross_deps_build.lock.bzl",
+    "core": "//pycross/private:pycross_deps_core.lock.bzl",
+    "repairwheel": "//pycross/private:pycross_deps_repairwheel.lock.bzl",
 }
 
 _deps_build = """\
@@ -121,7 +121,7 @@ def _pip_whl(wheels):
 def _pycross_internal_repo_impl(rctx):
     python_executable = _resolve_python_interpreter(rctx)
     wheel_paths = sorted([rctx.path(w) for w in rctx.attr.wheels.keys()], key = lambda k: str(k))
-    pycross_path = rctx.path(Label("@jvolkman_rules_pycross//:BUILD.bazel")).dirname
+    pycross_path = rctx.path(Label("//:BUILD.bazel")).dirname
 
     venv_path = rctx.path("exec_venv")
     pip_whl = _pip_whl(rctx.attr.wheels)
@@ -134,7 +134,7 @@ def _pycross_internal_repo_impl(rctx):
     # All deps
     rctx.file(
         "deps/BUILD.bazel",
-        _deps_build.format(lock = "@jvolkman_rules_pycross//pycross/private:pycross_deps.lock.bzl"),
+        _deps_build.format(lock = Label("//pycross/private:pycross_deps.lock.bzl")),
     )
 
     # Root build file

--- a/pycross/private/lock_attrs.bzl
+++ b/pycross/private/lock_attrs.bzl
@@ -62,7 +62,16 @@ def handle_common_attrs(attrs, environment_files_and_labels):
     Returns:
       a list of arguments.
     """
-    args = []
+
+    # If build locks for pycross itself, we don't want a repo name prefix on labels in the
+    # generated .bzl file. We can figure that out by comparing our workspace against the root workspace.
+    if Label("@//:WORKSPACE").workspace_name == Label("//:WORKSPACE").workspace_name:
+        pycross_repo_name = ""
+    else:
+        pycross_repo_name = "@" + Label("//:WORKSPACE").workspace_name
+
+    args = ["--pycross-repo-name", pycross_repo_name]
+
     if attrs.repo_prefix:
         repo_prefix = attrs.repo_prefix
     else:

--- a/pycross/private/lock_file.bzl
+++ b/pycross/private/lock_file.bzl
@@ -2,9 +2,6 @@
 
 load(":lock_attrs.bzl", "COMMON_ATTRS", "handle_common_attrs")
 
-def fully_qualified_label(ctx, label):
-    return "@%s//%s:%s" % (label.workspace_name or ctx.workspace_name, label.package, label.name)
-
 def _pycross_lock_file_impl(ctx):
     out = ctx.outputs.out
 
@@ -16,9 +13,9 @@ def _pycross_lock_file_impl(ctx):
     for local_wheel in ctx.files.local_wheels:
         if not local_wheel.owner:
             fail("Could not determine owning label for local wheel: %s" % local_wheel)
-        args.add_all("--local-wheel", [local_wheel.basename, fully_qualified_label(ctx, local_wheel.owner)])
+        args.add_all("--local-wheel", [local_wheel.basename, local_wheel.owner])
 
-    environment_files_and_labels = [(t.path, fully_qualified_label(ctx, t.owner)) for t in ctx.files.target_environments]
+    environment_files_and_labels = [(t.path, t.owner) for t in ctx.files.target_environments]
     args.add_all(handle_common_attrs(ctx.attr, environment_files_and_labels))
 
     ctx.actions.run(

--- a/pycross/private/lock_repo.bzl
+++ b/pycross/private/lock_repo.bzl
@@ -1,8 +1,5 @@
 """Implementation of the pycross_lock_repo rule."""
 
-def fully_qualified_label(label):
-    return "@%s//%s:%s" % (label.workspace_name, label.package, label.name)
-
 def _pycross_lock_repo_impl(rctx):
     lock_file_label = rctx.attr.lock_file
 
@@ -22,7 +19,7 @@ def requirement(pkg):
 all_requirements = ["@{repo_name}//deps:%s" % v for v in PINS.values()]
 
 install_deps = repositories
-""".format(lock_file = fully_qualified_label(lock_file_label), repo_name = rctx.attr.name))
+""".format(lock_file = lock_file_label, repo_name = rctx.attr.name))
 
     rctx.file(
         rctx.path("BUILD.bazel"),
@@ -41,7 +38,7 @@ package(default_visibility = ["//visibility:public"])
 load("{lock_file}", "targets")
 
 targets()
-""".format(lock_file = fully_qualified_label(lock_file_label)),
+""".format(lock_file = lock_file_label),
     )
 
 pycross_lock_repo = repository_rule(

--- a/pycross/private/pdm_lock_model.bzl
+++ b/pycross/private/pdm_lock_model.bzl
@@ -122,6 +122,6 @@ def repo_create_pdm_model(rctx, params, output):
 
     exec_internal_tool(
         rctx,
-        Label("@jvolkman_rules_pycross//pycross/private/tools:pdm_translator.py"),
+        Label("//pycross/private/tools:pdm_translator.py"),
         args,
     )

--- a/pycross/private/pkg_repo.bzl
+++ b/pycross/private/pkg_repo.bzl
@@ -56,7 +56,7 @@ def _generate_lock_file(rctx):
 
     exec_internal_tool(
         rctx,
-        Label("@jvolkman_rules_pycross//pycross/private/tools:bzl_lock_generator.py"),
+        Label("//pycross/private/tools:bzl_lock_generator.py"),
         args,
     )
 

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -66,6 +66,6 @@ def repo_create_poetry_model(rctx, params, output):
 
     exec_internal_tool(
         rctx,
-        Label("@jvolkman_rules_pycross//pycross/private/tools:poetry_translator.py"),
+        Label("//pycross/private/tools:poetry_translator.py"),
         args,
     )

--- a/pycross/private/pycross_deps.lock.bzl
+++ b/pycross/private/pycross_deps.lock.bzl
@@ -4,7 +4,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_library")
+load("//pycross:defs.bzl", "pycross_wheel_library")
 
 PINS = {
     "build": "build_1.0.3",
@@ -33,7 +33,7 @@ def targets():
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_rules_pycross_deps_target_env": "@jvolkman_rules_pycross//pycross/private:rules_pycross_deps_target_env",
+        ":_env_rules_pycross_deps_target_env": "//pycross/private:rules_pycross_deps_target_env",
     })
 
     pycross_wheel_library(

--- a/pycross/private/pycross_deps_core.lock.bzl
+++ b/pycross/private/pycross_deps_core.lock.bzl
@@ -4,7 +4,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_library")
+load("//pycross:defs.bzl", "pycross_wheel_library")
 
 PINS = {
     "dacite": "dacite_1.6.0",
@@ -40,7 +40,7 @@ def targets():
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_rules_pycross_deps_target_env": "@jvolkman_rules_pycross//pycross/private:rules_pycross_deps_target_env",
+        ":_env_rules_pycross_deps_target_env": "//pycross/private:rules_pycross_deps_target_env",
     })
 
     pycross_wheel_library(

--- a/pycross/private/target_environment.bzl
+++ b/pycross/private/target_environment.bzl
@@ -107,7 +107,7 @@ def repo_batch_create_target_environments(rctx, env_settings_list):
 
     exec_internal_tool(
         rctx,
-        Label("@jvolkman_rules_pycross//pycross/private/tools:target_environment_generator.py"),
+        Label("//pycross/private/tools:target_environment_generator.py"),
         ["batch-create", "--input", str(env_file)],
     )
 

--- a/pycross/private/toolchain_helpers.bzl
+++ b/pycross/private/toolchain_helpers.bzl
@@ -210,16 +210,16 @@ def _get_multi_python_version_info(rctx, python_toolchain_repo):
     }
 
 _ROOT_BUILD_HEADER = """\
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_target_environment")
+load("{}", "pycross_target_environment")
 
 package(default_visibility = ["//visibility:public"])
-"""
+""".format(Label("//pycross:defs.bzl"))
 
 _TOOLCHAINS_BUILD_HEADER = """\
-load("@jvolkman_rules_pycross//pycross:toolchain.bzl", "pycross_hermetic_toolchain")
+load("{}", "pycross_hermetic_toolchain")
 
 package(default_visibility = ["//visibility:public"])
-"""
+""".format(Label("//pycross:toolchain.bzl"))
 
 _ENVIRONMENT_TEMPLATE = """\
 config_setting(
@@ -248,9 +248,9 @@ toolchain(
     exec_compatible_with = {exec_compatible_with},
     target_settings = [{target_config_name}],
     toolchain = {provider_name},
-    toolchain_type = "@jvolkman_rules_pycross//pycross:toolchain_type",
+    toolchain_type = "%s",
 )
-"""
+""" % Label("//pycross:toolchain_type")
 
 def _pycross_toolchain_repo_impl(rctx):
     python_repo = rctx.attr.python_toolchains_repo_name

--- a/pycross/private/wheel_build.bzl
+++ b/pycross/private/wheel_build.bzl
@@ -14,8 +14,8 @@ load(
 )
 load(":providers.bzl", "PycrossWheelInfo")
 
-PYTHON_TOOLCHAIN_TYPE = "@bazel_tools//tools/python:toolchain_type"
-PYCROSS_TOOLCHAIN_TYPE = "@jvolkman_rules_pycross//pycross:toolchain_type"
+PYTHON_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/python:toolchain_type")
+PYCROSS_TOOLCHAIN_TYPE = Label("//pycross:toolchain_type")
 
 def _absolute_tool_value(workspace_name, value):
     if value:

--- a/tests/smoke/WORKSPACE
+++ b/tests/smoke/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(
-    name = "jvolkman_rules_pycross_smoke",
+    name = "rules_pycross_smoke",
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -95,15 +95,15 @@ third_party_repositories()
 # Pycross
 
 local_repository(
-    name = "jvolkman_rules_pycross",
+    name = "rules_pycross",
     path = "../..",
 )
 
-load("@jvolkman_rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
+load("@rules_pycross//pycross:repositories.bzl", "rules_pycross_dependencies")
 
 rules_pycross_dependencies(python_interpreter)
 
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pkg_repo_model_pdm", "pkg_repo_model_poetry", "pycross_lock_repo", "pycross_pkg_repo", "pycross_register_for_python_toolchains")
+load("@rules_pycross//pycross:defs.bzl", "pkg_repo_model_pdm", "pkg_repo_model_poetry", "pycross_lock_repo", "pycross_pkg_repo", "pycross_register_for_python_toolchains")
 
 pycross_register_for_python_toolchains(
     name = "pycross_toolchains",

--- a/tests/smoke/pdm/BUILD.bazel
+++ b/tests/smoke/pdm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_pdm_lock_model")
+load("@rules_pycross//pycross:defs.bzl", "pycross_pdm_lock_model")
 load("//:testlib.bzl", "setup_test_targets")
 
 package(default_visibility = ["//visibility:public"])

--- a/tests/smoke/pdm/lock.bzl
+++ b/tests/smoke/pdm/lock.bzl
@@ -4,7 +4,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library")
+load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library")
 
 PINS = {
     "appnope": "appnope_0.1.3",

--- a/tests/smoke/poetry/BUILD.bazel
+++ b/tests/smoke/poetry/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_poetry_lock_model")
+load("@rules_pycross//pycross:defs.bzl", "pycross_poetry_lock_model")
 load("//:testlib.bzl", "setup_test_targets")
 
 package(default_visibility = ["//visibility:public"])

--- a/tests/smoke/poetry/lock.bzl
+++ b/tests/smoke/poetry/lock.bzl
@@ -3,7 +3,7 @@
 """Pycross-generated dependency targets."""
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@jvolkman_rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library", "pypi_file")
+load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library", "pypi_file")
 
 PINS = {
     "appnope": "appnope_0.1.3",

--- a/tests/smoke/testlib.bzl
+++ b/tests/smoke/testlib.bzl
@@ -2,12 +2,12 @@
 
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@pycross_toolchains//:defs.bzl", "environments")
 load(
-    "@jvolkman_rules_pycross//pycross:defs.bzl",
+    "@rules_pycross//pycross:defs.bzl",
     "pycross_lock_file",
     "pycross_wheel_build",
 )
-load("@pycross_toolchains//:defs.bzl", "environments")
 load("@rules_python//python:defs.bzl", "py_test")
 
 def setup_test_targets(lock_name, lock_model):
@@ -29,7 +29,7 @@ def setup_test_targets(lock_name, lock_model):
             "//third_party/zstd",
         ],
         post_build_hooks = [
-            "@jvolkman_rules_pycross//pycross/hooks:repair_wheel",
+            "@rules_pycross//pycross/hooks:repair_wheel",
         ],
         config_settings = {
             "--build-option": [


### PR DESCRIPTION
Get rid of hardcoded self-ref repo names in implementation.

The goal is to use `@rules_pycross` with bzlmod rather than `@jvolkman_rules_pycross`. With these changes, either name can be used in WORKSPACE rules.

Examples and `tests/smoke` are updated to be @rules_pycross.
