### PR TITLE
Add `post_extraction_command`

### DIFF
--- a/pycross/private/tools/wheel_installer.py
+++ b/pycross/private/tools/wheel_installer.py
@@ -3,6 +3,7 @@ A tool that invokes pypa/build to build the given sdist tarball.
 """
 import os
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -79,6 +80,8 @@ def main(args: Any) -> None:
         shutil.rmtree(link_dir, ignore_errors=True)
 
     setup_namespace_pkg_compatibility(lib_dir)
+    if args.post_extraction_command:
+        subprocess.run(str(args.post_extraction_command.resolve()), cwd=str(lib_dir), check=True)
 
 
 def parse_flags() -> Any:
@@ -108,6 +111,12 @@ def parse_flags() -> Any:
         "--directory",
         type=Path,
         help="The output path.",
+    )
+
+    parser.add_argument(
+        "--post-extraction-command",
+        type=Path,
+        required=False,
     )
 
     return parser.parse_args()

--- a/pycross/private/wheel_library.bzl
+++ b/pycross/private/wheel_library.bzl
@@ -27,6 +27,12 @@ def _pycross_wheel_library_impl(ctx):
     if ctx.attr.enable_implicit_namespace_pkgs:
         args.add("--enable-implicit-namespace-pkgs")
 
+    if ctx.attr.post_extraction_command:
+        script = ctx.actions.declare_file(ctx.attr.name + "_post_extraction_command")
+        inputs.append(script)
+        ctx.actions.write(script, "#!/usr/bin/env bash\n" + ctx.attr.post_extraction_command, is_executable = True)
+        args.add("--post-extraction-command", script)
+
     ctx.actions.run(
         inputs = inputs,
         outputs = [out],
@@ -112,6 +118,10 @@ This option is required to support some packages which cannot handle the convers
         "python_version": attr.string(
             doc = "The python version required for this wheel ('PY2' or 'PY3')",
             values = ["PY2", "PY3", ""],
+        ),
+        "post_extraction_command": attr.string(
+            doc = "Bash command to run after content of the wheel gets extracted. The working directory is set to the extraction location",
+            default = "",
         ),
         "_tool": attr.label(
             default = Label("//pycross/private/tools:wheel_installer"),


### PR DESCRIPTION
This flag is useful when one needs to do some ad-hoc operations on the wheel files. For example, our use case pulls in a lot of third party dependencies and some of them may have name conflict each other and we sometimes need to remove or patch `__init__.py` files in order for conflicting dependencies to coexist.

I am open to other suggestions or work arounds. But adding the ability to do ad-hoc patches for each wheel_library seems to be the simplest way to achieve this.