### PR TITLE
Remove target_environment from toolchain

### DIFF
--- a/examples/external_linking/BUILD.bazel
+++ b/examples/external_linking/BUILD.bazel
@@ -98,7 +98,6 @@ pycross_target_environment(
 pycross_hermetic_toolchain(
     name = "pycross_darwin_linux",
     exec_interpreter = "@python3_10_aarch64-apple-darwin//:py3_runtime",
-    target_environment = ":python_linux_x86_64",
     target_interpreter = "@python3_10_x86_64-unknown-linux-gnu//:py3_runtime",
 )
 
@@ -113,7 +112,6 @@ toolchain(
 pycross_hermetic_toolchain(
     name = "pycross_linux_darwin",
     exec_interpreter = "@python3_10_x86_64-unknown-linux-gnu//:py3_runtime",
-    target_environment = ":python_darwin_x86_64",
     target_interpreter = "@python3_10_aarch64-apple-darwin//:py3_runtime",
 )
 
@@ -128,7 +126,6 @@ toolchain(
 pycross_hermetic_toolchain(
     name = "pycross_linux_x86_64_linux_arm64",
     exec_interpreter = "@python3_10_x86_64-unknown-linux-gnu//:py3_runtime",
-    target_environment = ":python_darwin_x86_64",
     target_interpreter = "@python3_10_aarch64-unknown-linux-gnu//:py3_runtime",
 )
 

--- a/pycross/private/toolchain_helpers.bzl
+++ b/pycross/private/toolchain_helpers.bzl
@@ -134,7 +134,6 @@ def _compute_environments_and_toolchains(
                         flag_values = flag_values,
                         exec_interpreter = exec_interpreter,
                         target_interpreter = target_interpreter,
-                        target_environment = "//:" + target_env_json,
                         exec_compatible_with = exec_compatible_with,
                         target_compatible_with = target_compatible_with,
                     ),
@@ -233,7 +232,6 @@ _TOOLCHAIN_TEMPLATE = """\
 pycross_hermetic_toolchain(
     name = {provider_name},
     exec_interpreter = {exec_interpreter},
-    target_environment = {target_environment},
     target_interpreter = {target_interpreter},
 )
 

--- a/pycross/toolchain.bzl
+++ b/pycross/toolchain.bzl
@@ -9,7 +9,6 @@ PycrossBuildExecRuntimeInfo = provider(
         "target_python_files": "A depset containing all files for the target interpreter.",
         "target_python_executable": "The path to the target Python interpreter, either absolute or relative to execroot.",
         "target_sys_path": "An array of system path directories (i.e., the value of sys.path from `python -m site`).",
-        "target_environment": "The label of a pycross_target_environment JSON file.",
     },
 )
 
@@ -22,8 +21,7 @@ def _pycross_hermetic_toolchain_impl(ctx):
         exec_python_executable = exec_py_info.interpreter.path,
         target_python_files = target_py_info.files,
         target_python_executable = target_py_info.interpreter.path,
-        target_sys_path = [],  #find_hermetic_sys_path(target_py_info),
-        target_environment = ctx.attr.target_environment,
+        target_sys_path = None,
     )
 
     return [
@@ -35,11 +33,6 @@ def _pycross_hermetic_toolchain_impl(ctx):
 pycross_hermetic_toolchain = rule(
     implementation = _pycross_hermetic_toolchain_impl,
     attrs = {
-        "target_environment": attr.label(
-            doc = "The target environment associated with this toolchain.",
-            mandatory = True,
-            allow_single_file = [".json"],
-        ),
         "target_interpreter": attr.label(
             doc = "The target Python interpreter (PyRuntimeInfo).",
             mandatory = True,


### PR DESCRIPTION
It's unused and makes upcoming bzlmod stuff more difficult.