### PR TITLE
fix: Add imports to allow experimental_python_import_all_repositories

### DIFF
--- a/pycross/private/tools/BUILD.bazel
+++ b/pycross/private/tools/BUILD.bazel
@@ -8,11 +8,13 @@ py_library(
     srcs = [
         "args.py",
     ],
+    imports = ["../../.."],
 )
 
 py_binary(
     name = "bzl_lock_generator",
     srcs = ["bzl_lock_generator.py"],
+    imports = ["../../.."],
     visibility = ["//visibility:public"],
     deps = [
         ":args",
@@ -24,11 +26,13 @@ py_binary(
 py_binary(
     name = "extract_lock_repos",
     srcs = ["extract_lock_repos.py"],
+    imports = ["../../.."],
 )
 
 py_binary(
     name = "raw_lock_resolver",
     srcs = ["raw_lock_resolver.py"],
+    imports = ["../../.."],
     visibility = ["//visibility:public"],
     deps = [
         ":args",
@@ -42,6 +46,7 @@ py_binary(
 py_binary(
     name = "resolved_lock_renderer",
     srcs = ["resolved_lock_renderer.py"],
+    imports = ["../../.."],
     visibility = ["//visibility:public"],
     deps = [
         ":args",
@@ -59,6 +64,7 @@ py_library(
     srcs = [
         "target_environment.py",
     ],
+    imports = ["../../.."],
     deps = [
         "@rules_pycross_internal//deps:pip",
     ],
@@ -67,6 +73,7 @@ py_library(
 py_library(
     name = "lock_model",
     srcs = ["lock_model.py"],
+    imports = ["../../.."],
     deps = [
         ":target_environment",
         "@rules_pycross_internal//deps:dacite",
@@ -79,6 +86,7 @@ py_library(
     srcs = [
         "namespace_pkgs.py",
     ],
+    imports = ["../../.."],
 )
 
 py_test(
@@ -96,6 +104,7 @@ py_test(
 py_binary(
     name = "pdm_translator",
     srcs = ["pdm_translator.py"],
+    imports = ["../../.."],
     visibility = ["//visibility:public"],
     deps = [
         ":args",
@@ -107,6 +116,7 @@ py_binary(
 py_binary(
     name = "poetry_translator",
     srcs = ["poetry_translator.py"],
+    imports = ["../../.."],
     visibility = ["//visibility:public"],
     deps = [
         ":args",
@@ -119,6 +129,7 @@ py_binary(
 py_binary(
     name = "target_environment_generator",
     srcs = ["target_environment_generator.py"],
+    imports = ["../../.."],
     visibility = ["//visibility:public"],
     deps = [
         ":args",
@@ -132,6 +143,7 @@ py_binary(
 py_binary(
     name = "wheel_builder",
     srcs = ["wheel_builder.py"],
+    imports = ["../../.."],
     visibility = ["//visibility:public"],
     deps = [
         ":args",
@@ -146,6 +158,7 @@ py_binary(
 py_binary(
     name = "wheel_installer",
     srcs = ["wheel_installer.py"],
+    imports = ["../../.."],
     visibility = ["//visibility:public"],
     deps = [
         ":args",

--- a/pycross/private/tools/crossenv/BUILD.bazel
+++ b/pycross/private/tools/crossenv/BUILD.bazel
@@ -12,6 +12,7 @@ py_library(
     data = [
         "//pycross/private/tools/crossenv/scripts",
     ],
+    imports = ["../../../.."],
 )
 
 py_binary(
@@ -20,6 +21,7 @@ py_binary(
         "__init__.py",
         "__main__.py",
     ],
+    imports = ["../../../.."],
     main = "__main__.py",
     deps = [":crossenv_lib"],
 )


### PR DESCRIPTION
This fixes breakage for users of this repository when --experimental_python_import_all_repositories=false is set, which the Bazel team would like to do in https://github.com/bazelbuild/bazel/issues/2636.

See also https://github.com/bazelbuild/rules_python/issues/792

Without this change, users get the error:.

```
runfiles/rules_pycross/pycross/private/tools/wheel_installer.py", line 14, in <module>
    from pycross.private.tools import namespace_pkgs
ModuleNotFoundError: No module named 'pycross'
```

