### PR TITLE
fix: Don't generate pyc files on installation

### DIFF
--- a/pycross/private/tools/wheel_installer.py
+++ b/pycross/private/tools/wheel_installer.py
@@ -52,7 +52,7 @@ def main(args: Any) -> None:
         },
         interpreter="/usr/bin/env python3",  # Generic; it's not feasible to run these scripts directly.
         script_kind="posix",
-        bytecode_optimization_levels=[0, 1],
+        bytecode_optimization_levels=[],  # Setting to empty list to disable generation of .pyc files.
     )
 
     link_dir = Path(tempfile.mkdtemp())


### PR DESCRIPTION
I  experienced this error https://github.com/openai/tiktoken/pull/152 and figured it is better to remove all __pycache__ directories in general