### PR TITLE
Fix e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,8 +77,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        # This needs to stay in sync with e2e/bzlmod/MODULE.bazel
-        python-version: ["3.10.12", "3.11.6", "3.12.0"]
+        # This needs to stay in sync with e2e/workspace/WORKSPACE
+        python-version: ["3.10.11", "3.11.6", "3.12.0"]
 
     defaults:
       run:
@@ -105,7 +105,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # This needs to stay in sync with e2e/bzlmod/MODULE.bazel
-        python-version: ["3.10.12", "3.11.6", "3.12.0"]
+        python-version: ["3.10.11", "3.11.6", "3.12.0"]
     defaults:
       run:
         working-directory: e2e/bzlmod
@@ -127,7 +127,7 @@ jobs:
         run: |
           ARTIFACT_PATH="${{ runner.temp }}/testwheel-out/${{ matrix.python-version }}/${{ matrix.os }}"
           mkdir -p "$ARTIFACT_PATH"
-          for plat in macos_x86_64 linux_x86_64; do
+          for plat in macos_arm64 linux_x86_64; do
             bazel build //pdm:zstandard_build \
               --@rules_python//python/config_settings:python_version=${{ matrix.python-version }} \
               --platforms=@zig_sdk//platform:$plat \
@@ -150,7 +150,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # This needs to stay in sync with e2e/bzlmod/MODULE.bazel
-        python-version: ["3.10.12", "3.11.6", "3.12.0"]
+        python-version: ["3.10.11", "3.11.6", "3.12.0"]
     defaults:
       run:
         working-directory: e2e/bzlmod

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -34,7 +34,7 @@ register_toolchains(
 # Python
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(python_version = "3.10.12")
+python.toolchain(python_version = "3.10.11")
 
 # The default is latest - 1 to make sure nothing assumes latest == default
 python.toolchain(
@@ -54,12 +54,11 @@ environments.create_for_python_toolchains(
     name = "smoke_environments",
     platforms = [
         "aarch64-apple-darwin",
-        "x86_64-apple-darwin",
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
     python_versions = [
-        "3.10.12",
+        "3.10.11",
         "3.11.6",
         "3.12.0",
         "3.12",

--- a/e2e/bzlmod/lock_file/pdm_lock.bzl
+++ b/e2e/bzlmod/lock_file/pdm_lock.bzl
@@ -43,23 +43,18 @@ def targets():
         )
 
     native.alias(
-        name = "_env_python_3.10.12_aarch64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_aarch64-apple-darwin_config",
+        name = "_env_python_3.10.11_aarch64-apple-darwin",
+        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_aarch64-apple-darwin_config",
     )
 
     native.alias(
-        name = "_env_python_3.10.12_aarch64-unknown-linux-gnu",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_aarch64-unknown-linux-gnu_config",
+        name = "_env_python_3.10.11_aarch64-unknown-linux-gnu",
+        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_aarch64-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.10.12_x86_64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
-        name = "_env_python_3.10.12_x86_64-unknown-linux-gnu",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_x86_64-unknown-linux-gnu_config",
+        name = "_env_python_3.10.11_x86_64-unknown-linux-gnu",
+        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_x86_64-unknown-linux-gnu_config",
     )
 
     native.alias(
@@ -70,11 +65,6 @@ def targets():
     native.alias(
         name = "_env_python_3.11.6_aarch64-unknown-linux-gnu",
         actual = "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_aarch64-unknown-linux-gnu_config",
-    )
-
-    native.alias(
-        name = "_env_python_3.11.6_x86_64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_x86_64-apple-darwin_config",
     )
 
     native.alias(
@@ -93,11 +83,6 @@ def targets():
     )
 
     native.alias(
-        name = "_env_python_3.12.0_x86_64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
         name = "_env_python_3.12.0_x86_64-unknown-linux-gnu",
         actual = "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_x86_64-unknown-linux-gnu_config",
     )
@@ -113,32 +98,23 @@ def targets():
     )
 
     native.alias(
-        name = "_env_python_3.12_x86_64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.12_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
         name = "_env_python_3.12_x86_64-unknown-linux-gnu",
         actual = "@@rules_pycross~~environments~smoke_environments//:python_3.12_x86_64-unknown-linux-gnu_config",
     )
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_3.10.12_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_aarch64-apple-darwin.json",
-        ":_env_python_3.10.12_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.10.12_x86_64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_x86_64-apple-darwin.json",
-        ":_env_python_3.10.12_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_x86_64-unknown-linux-gnu.json",
+        ":_env_python_3.10.11_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_aarch64-apple-darwin.json",
+        ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_aarch64-unknown-linux-gnu.json",
+        ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.11.6_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_aarch64-apple-darwin.json",
         ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.11.6_x86_64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_x86_64-apple-darwin.json",
         ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.12.0_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_aarch64-apple-darwin.json",
         ":_env_python_3.12.0_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.12.0_x86_64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_x86_64-apple-darwin.json",
         ":_env_python_3.12.0_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.12_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.12_aarch64-apple-darwin.json",
         ":_env_python_3.12_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.12_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.12_x86_64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.12_x86_64-apple-darwin.json",
         ":_env_python_3.12_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.12_x86_64-unknown-linux-gnu.json",
     })
 
@@ -217,36 +193,23 @@ def targets():
         ":stack-data@0.6.3",
         ":traitlets@5.14.1",
     ] + select({
-        ":_env_python_3.10.12_aarch64-apple-darwin": [
+        ":_env_python_3.10.11_aarch64-apple-darwin": [
             ":appnope@0.1.4",
             ":exceptiongroup@1.2.0",
         ],
-        ":_env_python_3.10.12_aarch64-unknown-linux-gnu": [
+        ":_env_python_3.10.11_aarch64-unknown-linux-gnu": [
             ":exceptiongroup@1.2.0",
         ],
-        ":_env_python_3.10.12_x86_64-apple-darwin": [
-            ":appnope@0.1.4",
-            ":exceptiongroup@1.2.0",
-        ],
-        ":_env_python_3.10.12_x86_64-unknown-linux-gnu": [
+        ":_env_python_3.10.11_x86_64-unknown-linux-gnu": [
             ":exceptiongroup@1.2.0",
         ],
         ":_env_python_3.11.6_aarch64-apple-darwin": [
             ":appnope@0.1.4",
         ],
-        ":_env_python_3.11.6_x86_64-apple-darwin": [
-            ":appnope@0.1.4",
-        ],
         ":_env_python_3.12.0_aarch64-apple-darwin": [
             ":appnope@0.1.4",
         ],
-        ":_env_python_3.12.0_x86_64-apple-darwin": [
-            ":appnope@0.1.4",
-        ],
         ":_env_python_3.12_aarch64-apple-darwin": [
-            ":appnope@0.1.4",
-        ],
-        ":_env_python_3.12_x86_64-apple-darwin": [
             ":appnope@0.1.4",
         ],
         "//conditions:default": [],
@@ -366,21 +329,17 @@ def targets():
     native.alias(
         name = "_wheel_regex@2023.10.3",
         actual = select({
-            ":_env_python_3.10.12_aarch64-apple-darwin": "@pdm_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_11_0_arm64//file",
-            ":_env_python_3.10.12_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.12_x86_64-apple-darwin": "@pdm_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_10_9_x86_64//file",
-            ":_env_python_3.10.12_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
+            ":_env_python_3.10.11_aarch64-apple-darwin": "@pdm_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_11_0_arm64//file",
+            ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@pdm_lock_wheel_regex_2023.10.3_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.11.6_x86_64-apple-darwin": "@pdm_lock_wheel_regex_2023.10.3_cp311_cp311_macosx_10_9_x86_64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.12.0_aarch64-apple-darwin": "@pdm_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_11_0_arm64//file",
             ":_env_python_3.12.0_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp312_cp312_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.12.0_x86_64-apple-darwin": "@pdm_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_10_9_x86_64//file",
             ":_env_python_3.12.0_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.12_aarch64-apple-darwin": "@pdm_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_11_0_arm64//file",
             ":_env_python_3.12_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp312_cp312_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.12_x86_64-apple-darwin": "@pdm_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_10_9_x86_64//file",
             ":_env_python_3.12_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_regex_2023.10.3_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
         }),
     )
@@ -460,21 +419,17 @@ def targets():
     native.alias(
         name = "_wheel_zstandard@0.22.0",
         actual = select({
-            ":_env_python_3.10.12_aarch64-apple-darwin": "@pdm_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_11_0_arm64//file",
-            ":_env_python_3.10.12_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.12_x86_64-apple-darwin": "@pdm_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_10_9_x86_64//file",
-            ":_env_python_3.10.12_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+            ":_env_python_3.10.11_aarch64-apple-darwin": "@pdm_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_11_0_arm64//file",
+            ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@pdm_lock_wheel_zstandard_0.22.0_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.11.6_x86_64-apple-darwin": "@pdm_lock_wheel_zstandard_0.22.0_cp311_cp311_macosx_10_9_x86_64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.12.0_aarch64-apple-darwin": "@pdm_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_11_0_arm64//file",
             ":_env_python_3.12.0_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp312_cp312_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.12.0_x86_64-apple-darwin": "@pdm_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_10_9_x86_64//file",
             ":_env_python_3.12.0_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.12_aarch64-apple-darwin": "@pdm_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_11_0_arm64//file",
             ":_env_python_3.12_aarch64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp312_cp312_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.12_x86_64-apple-darwin": "@pdm_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_10_9_x86_64//file",
             ":_env_python_3.12_x86_64-unknown-linux-gnu": "@pdm_lock_wheel_zstandard_0.22.0_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
         }),
     )
@@ -640,16 +595,6 @@ def repositories():
 
     maybe(
         http_file,
-        name = "pdm_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_10_9_x86_64",
-        urls = [
-            "https://files.pythonhosted.org/packages/2c/6b/4828fdbbabcb51986ddc1e7c618cf9dc8606f75c2f0cc381d3729cf31348/regex-2023.10.3-cp310-cp310-macosx_10_9_x86_64.whl",
-        ],
-        sha256 = "4c34d4f73ea738223a094d8e0ffd6d2c1a1b4c175da34d6b0de3d8d69bee6bcc",
-        downloaded_file_path = "regex-2023.10.3-cp310-cp310-macosx_10_9_x86_64.whl",
-    )
-
-    maybe(
-        http_file,
         name = "pdm_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_11_0_arm64",
         urls = [
             "https://files.pythonhosted.org/packages/d1/f1/9c50c0e1e76234f05f876dd49df925dae49da7fb8cb152a429006c71f65b/regex-2023.10.3-cp310-cp310-macosx_11_0_arm64.whl",
@@ -680,16 +625,6 @@ def repositories():
 
     maybe(
         http_file,
-        name = "pdm_lock_wheel_regex_2023.10.3_cp311_cp311_macosx_10_9_x86_64",
-        urls = [
-            "https://files.pythonhosted.org/packages/27/b8/fde0e99442b328d159bd0b2c0ff5401e1f1839e7a8d7339308b3915c7faa/regex-2023.10.3-cp311-cp311-macosx_10_9_x86_64.whl",
-        ],
-        sha256 = "90a79bce019c442604662d17bf69df99090e24cdc6ad95b18b6725c2988a490e",
-        downloaded_file_path = "regex-2023.10.3-cp311-cp311-macosx_10_9_x86_64.whl",
-    )
-
-    maybe(
-        http_file,
         name = "pdm_lock_wheel_regex_2023.10.3_cp311_cp311_macosx_11_0_arm64",
         urls = [
             "https://files.pythonhosted.org/packages/4d/d3/38b09813a32618acd437906c4d0194119e27139dbcd7486e69d58e375a27/regex-2023.10.3-cp311-cp311-macosx_11_0_arm64.whl",
@@ -716,16 +651,6 @@ def repositories():
         ],
         sha256 = "8d1f21af4c1539051049796a0f50aa342f9a27cde57318f2fc41ed50b0dbc4ac",
         downloaded_file_path = "regex-2023.10.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    )
-
-    maybe(
-        http_file,
-        name = "pdm_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_10_9_x86_64",
-        urls = [
-            "https://files.pythonhosted.org/packages/59/f6/b719df3bc93004bb0c646d4fddd769a018ad2eff7f149f5c72770faedf7a/regex-2023.10.3-cp312-cp312-macosx_10_9_x86_64.whl",
-        ],
-        sha256 = "bff507ae210371d4b1fe316d03433ac099f184d570a1a611e541923f78f05037",
-        downloaded_file_path = "regex-2023.10.3-cp312-cp312-macosx_10_9_x86_64.whl",
     )
 
     maybe(
@@ -820,16 +745,6 @@ def repositories():
 
     maybe(
         http_file,
-        name = "pdm_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_10_9_x86_64",
-        urls = [
-            "https://files.pythonhosted.org/packages/aa/a4/b7cc74e836ec006427d18439c12b7898697c1eae91b06ffdfa63da8cd041/zstandard-0.22.0-cp310-cp310-macosx_10_9_x86_64.whl",
-        ],
-        sha256 = "275df437ab03f8c033b8a2c181e51716c32d831082d93ce48002a5227ec93019",
-        downloaded_file_path = "zstandard-0.22.0-cp310-cp310-macosx_10_9_x86_64.whl",
-    )
-
-    maybe(
-        http_file,
         name = "pdm_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_11_0_arm64",
         urls = [
             "https://files.pythonhosted.org/packages/fc/e5/a1fa6f70764777553cb8ab668690ba793ebf512b3d415e28720d2275d445/zstandard-0.22.0-cp310-cp310-macosx_11_0_arm64.whl",
@@ -860,16 +775,6 @@ def repositories():
 
     maybe(
         http_file,
-        name = "pdm_lock_wheel_zstandard_0.22.0_cp311_cp311_macosx_10_9_x86_64",
-        urls = [
-            "https://files.pythonhosted.org/packages/32/41/80fc08ed96e68df920d28592710f5ed96fb288fda1fbb4b6aee5fdbaa5f6/zstandard-0.22.0-cp311-cp311-macosx_10_9_x86_64.whl",
-        ],
-        sha256 = "589402548251056878d2e7c8859286eb91bd841af117dbe4ab000e6450987e08",
-        downloaded_file_path = "zstandard-0.22.0-cp311-cp311-macosx_10_9_x86_64.whl",
-    )
-
-    maybe(
-        http_file,
         name = "pdm_lock_wheel_zstandard_0.22.0_cp311_cp311_macosx_11_0_arm64",
         urls = [
             "https://files.pythonhosted.org/packages/54/fc/c1b1a1e140451f3362789f546731b3ef36c78668be19d7fc6fbd4326b535/zstandard-0.22.0-cp311-cp311-macosx_11_0_arm64.whl",
@@ -896,16 +801,6 @@ def repositories():
         ],
         sha256 = "33591d59f4956c9812f8063eff2e2c0065bc02050837f152574069f5f9f17775",
         downloaded_file_path = "zstandard-0.22.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    )
-
-    maybe(
-        http_file,
-        name = "pdm_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_10_9_x86_64",
-        urls = [
-            "https://files.pythonhosted.org/packages/0f/f9/6b531e83f2e61bb9d66508113fd68557d990639be3dd37116af272932614/zstandard-0.22.0-cp312-cp312-macosx_10_9_x86_64.whl",
-        ],
-        sha256 = "6c25b8eb733d4e741246151d895dd0308137532737f337411160ff69ca24f93a",
-        downloaded_file_path = "zstandard-0.22.0-cp312-cp312-macosx_10_9_x86_64.whl",
     )
 
     maybe(

--- a/e2e/bzlmod/lock_file/poetry_lock.bzl
+++ b/e2e/bzlmod/lock_file/poetry_lock.bzl
@@ -41,23 +41,18 @@ def targets():
         )
 
     native.alias(
-        name = "_env_python_3.10.12_aarch64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_aarch64-apple-darwin_config",
+        name = "_env_python_3.10.11_aarch64-apple-darwin",
+        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_aarch64-apple-darwin_config",
     )
 
     native.alias(
-        name = "_env_python_3.10.12_aarch64-unknown-linux-gnu",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_aarch64-unknown-linux-gnu_config",
+        name = "_env_python_3.10.11_aarch64-unknown-linux-gnu",
+        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_aarch64-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.10.12_x86_64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
-        name = "_env_python_3.10.12_x86_64-unknown-linux-gnu",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_x86_64-unknown-linux-gnu_config",
+        name = "_env_python_3.10.11_x86_64-unknown-linux-gnu",
+        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_x86_64-unknown-linux-gnu_config",
     )
 
     native.alias(
@@ -68,11 +63,6 @@ def targets():
     native.alias(
         name = "_env_python_3.11.6_aarch64-unknown-linux-gnu",
         actual = "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_aarch64-unknown-linux-gnu_config",
-    )
-
-    native.alias(
-        name = "_env_python_3.11.6_x86_64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_x86_64-apple-darwin_config",
     )
 
     native.alias(
@@ -91,11 +81,6 @@ def targets():
     )
 
     native.alias(
-        name = "_env_python_3.12.0_x86_64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
         name = "_env_python_3.12.0_x86_64-unknown-linux-gnu",
         actual = "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_x86_64-unknown-linux-gnu_config",
     )
@@ -111,32 +96,23 @@ def targets():
     )
 
     native.alias(
-        name = "_env_python_3.12_x86_64-apple-darwin",
-        actual = "@@rules_pycross~~environments~smoke_environments//:python_3.12_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
         name = "_env_python_3.12_x86_64-unknown-linux-gnu",
         actual = "@@rules_pycross~~environments~smoke_environments//:python_3.12_x86_64-unknown-linux-gnu_config",
     )
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_3.10.12_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_aarch64-apple-darwin.json",
-        ":_env_python_3.10.12_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.10.12_x86_64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_x86_64-apple-darwin.json",
-        ":_env_python_3.10.12_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.10.12_x86_64-unknown-linux-gnu.json",
+        ":_env_python_3.10.11_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_aarch64-apple-darwin.json",
+        ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_aarch64-unknown-linux-gnu.json",
+        ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.10.11_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.11.6_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_aarch64-apple-darwin.json",
         ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.11.6_x86_64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_x86_64-apple-darwin.json",
         ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.11.6_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.12.0_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_aarch64-apple-darwin.json",
         ":_env_python_3.12.0_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.12.0_x86_64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_x86_64-apple-darwin.json",
         ":_env_python_3.12.0_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.12.0_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.12_aarch64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.12_aarch64-apple-darwin.json",
         ":_env_python_3.12_aarch64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.12_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.12_x86_64-apple-darwin": "@@rules_pycross~~environments~smoke_environments//:python_3.12_x86_64-apple-darwin.json",
         ":_env_python_3.12_x86_64-unknown-linux-gnu": "@@rules_pycross~~environments~smoke_environments//:python_3.12_x86_64-unknown-linux-gnu.json",
     })
 
@@ -205,36 +181,23 @@ def targets():
         ":stack-data@0.6.3",
         ":traitlets@5.14.0",
     ] + select({
-        ":_env_python_3.10.12_aarch64-apple-darwin": [
+        ":_env_python_3.10.11_aarch64-apple-darwin": [
             ":appnope@0.1.3",
             ":exceptiongroup@1.2.0",
         ],
-        ":_env_python_3.10.12_aarch64-unknown-linux-gnu": [
+        ":_env_python_3.10.11_aarch64-unknown-linux-gnu": [
             ":exceptiongroup@1.2.0",
         ],
-        ":_env_python_3.10.12_x86_64-apple-darwin": [
-            ":appnope@0.1.3",
-            ":exceptiongroup@1.2.0",
-        ],
-        ":_env_python_3.10.12_x86_64-unknown-linux-gnu": [
+        ":_env_python_3.10.11_x86_64-unknown-linux-gnu": [
             ":exceptiongroup@1.2.0",
         ],
         ":_env_python_3.11.6_aarch64-apple-darwin": [
             ":appnope@0.1.3",
         ],
-        ":_env_python_3.11.6_x86_64-apple-darwin": [
-            ":appnope@0.1.3",
-        ],
         ":_env_python_3.12.0_aarch64-apple-darwin": [
             ":appnope@0.1.3",
         ],
-        ":_env_python_3.12.0_x86_64-apple-darwin": [
-            ":appnope@0.1.3",
-        ],
         ":_env_python_3.12_aarch64-apple-darwin": [
-            ":appnope@0.1.3",
-        ],
-        ":_env_python_3.12_x86_64-apple-darwin": [
             ":appnope@0.1.3",
         ],
         "//conditions:default": [],
@@ -354,21 +317,17 @@ def targets():
     native.alias(
         name = "_wheel_regex@2023.10.3",
         actual = select({
-            ":_env_python_3.10.12_aarch64-apple-darwin": "@poetry_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_11_0_arm64//file",
-            ":_env_python_3.10.12_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.12_x86_64-apple-darwin": "@poetry_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_10_9_x86_64//file",
-            ":_env_python_3.10.12_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
+            ":_env_python_3.10.11_aarch64-apple-darwin": "@poetry_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_11_0_arm64//file",
+            ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@poetry_lock_wheel_regex_2023.10.3_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.11.6_x86_64-apple-darwin": "@poetry_lock_wheel_regex_2023.10.3_cp311_cp311_macosx_10_9_x86_64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.12.0_aarch64-apple-darwin": "@poetry_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_11_0_arm64//file",
             ":_env_python_3.12.0_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp312_cp312_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.12.0_x86_64-apple-darwin": "@poetry_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_10_9_x86_64//file",
             ":_env_python_3.12.0_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.12_aarch64-apple-darwin": "@poetry_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_11_0_arm64//file",
             ":_env_python_3.12_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp312_cp312_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.12_x86_64-apple-darwin": "@poetry_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_10_9_x86_64//file",
             ":_env_python_3.12_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_regex_2023.10.3_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
         }),
     )
@@ -448,21 +407,17 @@ def targets():
     native.alias(
         name = "_wheel_zstandard@0.22.0",
         actual = select({
-            ":_env_python_3.10.12_aarch64-apple-darwin": "@poetry_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_11_0_arm64//file",
-            ":_env_python_3.10.12_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.12_x86_64-apple-darwin": "@poetry_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_10_9_x86_64//file",
-            ":_env_python_3.10.12_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
+            ":_env_python_3.10.11_aarch64-apple-darwin": "@poetry_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_11_0_arm64//file",
+            ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@poetry_lock_wheel_zstandard_0.22.0_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.11.6_x86_64-apple-darwin": "@poetry_lock_wheel_zstandard_0.22.0_cp311_cp311_macosx_10_9_x86_64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.12.0_aarch64-apple-darwin": "@poetry_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_11_0_arm64//file",
             ":_env_python_3.12.0_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp312_cp312_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.12.0_x86_64-apple-darwin": "@poetry_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_10_9_x86_64//file",
             ":_env_python_3.12.0_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.12_aarch64-apple-darwin": "@poetry_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_11_0_arm64//file",
             ":_env_python_3.12_aarch64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp312_cp312_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.12_x86_64-apple-darwin": "@poetry_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_10_9_x86_64//file",
             ":_env_python_3.12_x86_64-unknown-linux-gnu": "@poetry_lock_wheel_zstandard_0.22.0_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
         }),
     )
@@ -604,15 +559,6 @@ def repositories():
 
     maybe(
         pypi_file,
-        name = "poetry_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_10_9_x86_64",
-        package_name = "regex",
-        package_version = "2023.10.3",
-        filename = "regex-2023.10.3-cp310-cp310-macosx_10_9_x86_64.whl",
-        sha256 = "4c34d4f73ea738223a094d8e0ffd6d2c1a1b4c175da34d6b0de3d8d69bee6bcc",
-    )
-
-    maybe(
-        pypi_file,
         name = "poetry_lock_wheel_regex_2023.10.3_cp310_cp310_macosx_11_0_arm64",
         package_name = "regex",
         package_version = "2023.10.3",
@@ -640,15 +586,6 @@ def repositories():
 
     maybe(
         pypi_file,
-        name = "poetry_lock_wheel_regex_2023.10.3_cp311_cp311_macosx_10_9_x86_64",
-        package_name = "regex",
-        package_version = "2023.10.3",
-        filename = "regex-2023.10.3-cp311-cp311-macosx_10_9_x86_64.whl",
-        sha256 = "90a79bce019c442604662d17bf69df99090e24cdc6ad95b18b6725c2988a490e",
-    )
-
-    maybe(
-        pypi_file,
         name = "poetry_lock_wheel_regex_2023.10.3_cp311_cp311_macosx_11_0_arm64",
         package_name = "regex",
         package_version = "2023.10.3",
@@ -672,15 +609,6 @@ def repositories():
         package_version = "2023.10.3",
         filename = "regex-2023.10.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
         sha256 = "8d1f21af4c1539051049796a0f50aa342f9a27cde57318f2fc41ed50b0dbc4ac",
-    )
-
-    maybe(
-        pypi_file,
-        name = "poetry_lock_wheel_regex_2023.10.3_cp312_cp312_macosx_10_9_x86_64",
-        package_name = "regex",
-        package_version = "2023.10.3",
-        filename = "regex-2023.10.3-cp312-cp312-macosx_10_9_x86_64.whl",
-        sha256 = "bff507ae210371d4b1fe316d03433ac099f184d570a1a611e541923f78f05037",
     )
 
     maybe(
@@ -766,15 +694,6 @@ def repositories():
 
     maybe(
         pypi_file,
-        name = "poetry_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_10_9_x86_64",
-        package_name = "zstandard",
-        package_version = "0.22.0",
-        filename = "zstandard-0.22.0-cp310-cp310-macosx_10_9_x86_64.whl",
-        sha256 = "275df437ab03f8c033b8a2c181e51716c32d831082d93ce48002a5227ec93019",
-    )
-
-    maybe(
-        pypi_file,
         name = "poetry_lock_wheel_zstandard_0.22.0_cp310_cp310_macosx_11_0_arm64",
         package_name = "zstandard",
         package_version = "0.22.0",
@@ -802,15 +721,6 @@ def repositories():
 
     maybe(
         pypi_file,
-        name = "poetry_lock_wheel_zstandard_0.22.0_cp311_cp311_macosx_10_9_x86_64",
-        package_name = "zstandard",
-        package_version = "0.22.0",
-        filename = "zstandard-0.22.0-cp311-cp311-macosx_10_9_x86_64.whl",
-        sha256 = "589402548251056878d2e7c8859286eb91bd841af117dbe4ab000e6450987e08",
-    )
-
-    maybe(
-        pypi_file,
         name = "poetry_lock_wheel_zstandard_0.22.0_cp311_cp311_macosx_11_0_arm64",
         package_name = "zstandard",
         package_version = "0.22.0",
@@ -834,15 +744,6 @@ def repositories():
         package_version = "0.22.0",
         filename = "zstandard-0.22.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
         sha256 = "33591d59f4956c9812f8063eff2e2c0065bc02050837f152574069f5f9f17775",
-    )
-
-    maybe(
-        pypi_file,
-        name = "poetry_lock_wheel_zstandard_0.22.0_cp312_cp312_macosx_10_9_x86_64",
-        package_name = "zstandard",
-        package_version = "0.22.0",
-        filename = "zstandard-0.22.0-cp312-cp312-macosx_10_9_x86_64.whl",
-        sha256 = "6c25b8eb733d4e741246151d895dd0308137532737f337411160ff69ca24f93a",
     )
 
     maybe(

--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -59,7 +59,7 @@ python_register_multi_toolchains(
     # The default is latest - 1 to make sure nothing assumes latest == default
     default_version = "3.11.6",
     python_versions = [
-        "3.10.12",
+        "3.10.11",
         "3.11.6",
         "3.12.0",
     ],
@@ -95,7 +95,6 @@ pycross_register_for_python_toolchains(
     name = "smoke_environments",
     platforms = [
         "aarch64-apple-darwin",
-        "x86_64-apple-darwin",
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],

--- a/e2e/workspace/pdm/lock.bzl
+++ b/e2e/workspace/pdm/lock.bzl
@@ -43,23 +43,18 @@ def targets():
         )
 
     native.alias(
-        name = "_env_python_3.10.12_aarch64-apple-darwin",
-        actual = "@smoke_environments//:python_3.10.12_aarch64-apple-darwin_config",
+        name = "_env_python_3.10.11_aarch64-apple-darwin",
+        actual = "@smoke_environments//:python_3.10.11_aarch64-apple-darwin_config",
     )
 
     native.alias(
-        name = "_env_python_3.10.12_aarch64-unknown-linux-gnu",
-        actual = "@smoke_environments//:python_3.10.12_aarch64-unknown-linux-gnu_config",
+        name = "_env_python_3.10.11_aarch64-unknown-linux-gnu",
+        actual = "@smoke_environments//:python_3.10.11_aarch64-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.10.12_x86_64-apple-darwin",
-        actual = "@smoke_environments//:python_3.10.12_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
-        name = "_env_python_3.10.12_x86_64-unknown-linux-gnu",
-        actual = "@smoke_environments//:python_3.10.12_x86_64-unknown-linux-gnu_config",
+        name = "_env_python_3.10.11_x86_64-unknown-linux-gnu",
+        actual = "@smoke_environments//:python_3.10.11_x86_64-unknown-linux-gnu_config",
     )
 
     native.alias(
@@ -70,11 +65,6 @@ def targets():
     native.alias(
         name = "_env_python_3.11.6_aarch64-unknown-linux-gnu",
         actual = "@smoke_environments//:python_3.11.6_aarch64-unknown-linux-gnu_config",
-    )
-
-    native.alias(
-        name = "_env_python_3.11.6_x86_64-apple-darwin",
-        actual = "@smoke_environments//:python_3.11.6_x86_64-apple-darwin_config",
     )
 
     native.alias(
@@ -93,28 +83,20 @@ def targets():
     )
 
     native.alias(
-        name = "_env_python_3.12.0_x86_64-apple-darwin",
-        actual = "@smoke_environments//:python_3.12.0_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
         name = "_env_python_3.12.0_x86_64-unknown-linux-gnu",
         actual = "@smoke_environments//:python_3.12.0_x86_64-unknown-linux-gnu_config",
     )
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_3.10.12_aarch64-apple-darwin": "@smoke_environments//:python_3.10.12_aarch64-apple-darwin.json",
-        ":_env_python_3.10.12_aarch64-unknown-linux-gnu": "@smoke_environments//:python_3.10.12_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.10.12_x86_64-apple-darwin": "@smoke_environments//:python_3.10.12_x86_64-apple-darwin.json",
-        ":_env_python_3.10.12_x86_64-unknown-linux-gnu": "@smoke_environments//:python_3.10.12_x86_64-unknown-linux-gnu.json",
+        ":_env_python_3.10.11_aarch64-apple-darwin": "@smoke_environments//:python_3.10.11_aarch64-apple-darwin.json",
+        ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@smoke_environments//:python_3.10.11_aarch64-unknown-linux-gnu.json",
+        ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@smoke_environments//:python_3.10.11_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.11.6_aarch64-apple-darwin": "@smoke_environments//:python_3.11.6_aarch64-apple-darwin.json",
         ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@smoke_environments//:python_3.11.6_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.11.6_x86_64-apple-darwin": "@smoke_environments//:python_3.11.6_x86_64-apple-darwin.json",
         ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@smoke_environments//:python_3.11.6_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.12.0_aarch64-apple-darwin": "@smoke_environments//:python_3.12.0_aarch64-apple-darwin.json",
         ":_env_python_3.12.0_aarch64-unknown-linux-gnu": "@smoke_environments//:python_3.12.0_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.12.0_x86_64-apple-darwin": "@smoke_environments//:python_3.12.0_x86_64-apple-darwin.json",
         ":_env_python_3.12.0_x86_64-unknown-linux-gnu": "@smoke_environments//:python_3.12.0_x86_64-unknown-linux-gnu.json",
     })
 
@@ -193,30 +175,20 @@ def targets():
         ":stack-data@0.6.3",
         ":traitlets@5.14.1",
     ] + select({
-        ":_env_python_3.10.12_aarch64-apple-darwin": [
+        ":_env_python_3.10.11_aarch64-apple-darwin": [
             ":appnope@0.1.4",
             ":exceptiongroup@1.2.0",
         ],
-        ":_env_python_3.10.12_aarch64-unknown-linux-gnu": [
+        ":_env_python_3.10.11_aarch64-unknown-linux-gnu": [
             ":exceptiongroup@1.2.0",
         ],
-        ":_env_python_3.10.12_x86_64-apple-darwin": [
-            ":appnope@0.1.4",
-            ":exceptiongroup@1.2.0",
-        ],
-        ":_env_python_3.10.12_x86_64-unknown-linux-gnu": [
+        ":_env_python_3.10.11_x86_64-unknown-linux-gnu": [
             ":exceptiongroup@1.2.0",
         ],
         ":_env_python_3.11.6_aarch64-apple-darwin": [
             ":appnope@0.1.4",
         ],
-        ":_env_python_3.11.6_x86_64-apple-darwin": [
-            ":appnope@0.1.4",
-        ],
         ":_env_python_3.12.0_aarch64-apple-darwin": [
-            ":appnope@0.1.4",
-        ],
-        ":_env_python_3.12.0_x86_64-apple-darwin": [
             ":appnope@0.1.4",
         ],
         "//conditions:default": [],

--- a/e2e/workspace/poetry/lock.bzl
+++ b/e2e/workspace/poetry/lock.bzl
@@ -41,23 +41,18 @@ def targets():
         )
 
     native.alias(
-        name = "_env_python_3.10.12_aarch64-apple-darwin",
-        actual = "@smoke_environments//:python_3.10.12_aarch64-apple-darwin_config",
+        name = "_env_python_3.10.11_aarch64-apple-darwin",
+        actual = "@smoke_environments//:python_3.10.11_aarch64-apple-darwin_config",
     )
 
     native.alias(
-        name = "_env_python_3.10.12_aarch64-unknown-linux-gnu",
-        actual = "@smoke_environments//:python_3.10.12_aarch64-unknown-linux-gnu_config",
+        name = "_env_python_3.10.11_aarch64-unknown-linux-gnu",
+        actual = "@smoke_environments//:python_3.10.11_aarch64-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.10.12_x86_64-apple-darwin",
-        actual = "@smoke_environments//:python_3.10.12_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
-        name = "_env_python_3.10.12_x86_64-unknown-linux-gnu",
-        actual = "@smoke_environments//:python_3.10.12_x86_64-unknown-linux-gnu_config",
+        name = "_env_python_3.10.11_x86_64-unknown-linux-gnu",
+        actual = "@smoke_environments//:python_3.10.11_x86_64-unknown-linux-gnu_config",
     )
 
     native.alias(
@@ -68,11 +63,6 @@ def targets():
     native.alias(
         name = "_env_python_3.11.6_aarch64-unknown-linux-gnu",
         actual = "@smoke_environments//:python_3.11.6_aarch64-unknown-linux-gnu_config",
-    )
-
-    native.alias(
-        name = "_env_python_3.11.6_x86_64-apple-darwin",
-        actual = "@smoke_environments//:python_3.11.6_x86_64-apple-darwin_config",
     )
 
     native.alias(
@@ -91,28 +81,20 @@ def targets():
     )
 
     native.alias(
-        name = "_env_python_3.12.0_x86_64-apple-darwin",
-        actual = "@smoke_environments//:python_3.12.0_x86_64-apple-darwin_config",
-    )
-
-    native.alias(
         name = "_env_python_3.12.0_x86_64-unknown-linux-gnu",
         actual = "@smoke_environments//:python_3.12.0_x86_64-unknown-linux-gnu_config",
     )
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_3.10.12_aarch64-apple-darwin": "@smoke_environments//:python_3.10.12_aarch64-apple-darwin.json",
-        ":_env_python_3.10.12_aarch64-unknown-linux-gnu": "@smoke_environments//:python_3.10.12_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.10.12_x86_64-apple-darwin": "@smoke_environments//:python_3.10.12_x86_64-apple-darwin.json",
-        ":_env_python_3.10.12_x86_64-unknown-linux-gnu": "@smoke_environments//:python_3.10.12_x86_64-unknown-linux-gnu.json",
+        ":_env_python_3.10.11_aarch64-apple-darwin": "@smoke_environments//:python_3.10.11_aarch64-apple-darwin.json",
+        ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@smoke_environments//:python_3.10.11_aarch64-unknown-linux-gnu.json",
+        ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@smoke_environments//:python_3.10.11_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.11.6_aarch64-apple-darwin": "@smoke_environments//:python_3.11.6_aarch64-apple-darwin.json",
         ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@smoke_environments//:python_3.11.6_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.11.6_x86_64-apple-darwin": "@smoke_environments//:python_3.11.6_x86_64-apple-darwin.json",
         ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@smoke_environments//:python_3.11.6_x86_64-unknown-linux-gnu.json",
         ":_env_python_3.12.0_aarch64-apple-darwin": "@smoke_environments//:python_3.12.0_aarch64-apple-darwin.json",
         ":_env_python_3.12.0_aarch64-unknown-linux-gnu": "@smoke_environments//:python_3.12.0_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.12.0_x86_64-apple-darwin": "@smoke_environments//:python_3.12.0_x86_64-apple-darwin.json",
         ":_env_python_3.12.0_x86_64-unknown-linux-gnu": "@smoke_environments//:python_3.12.0_x86_64-unknown-linux-gnu.json",
     })
 
@@ -181,30 +163,20 @@ def targets():
         ":stack-data@0.6.3",
         ":traitlets@5.14.0",
     ] + select({
-        ":_env_python_3.10.12_aarch64-apple-darwin": [
+        ":_env_python_3.10.11_aarch64-apple-darwin": [
             ":appnope@0.1.3",
             ":exceptiongroup@1.2.0",
         ],
-        ":_env_python_3.10.12_aarch64-unknown-linux-gnu": [
+        ":_env_python_3.10.11_aarch64-unknown-linux-gnu": [
             ":exceptiongroup@1.2.0",
         ],
-        ":_env_python_3.10.12_x86_64-apple-darwin": [
-            ":appnope@0.1.3",
-            ":exceptiongroup@1.2.0",
-        ],
-        ":_env_python_3.10.12_x86_64-unknown-linux-gnu": [
+        ":_env_python_3.10.11_x86_64-unknown-linux-gnu": [
             ":exceptiongroup@1.2.0",
         ],
         ":_env_python_3.11.6_aarch64-apple-darwin": [
             ":appnope@0.1.3",
         ],
-        ":_env_python_3.11.6_x86_64-apple-darwin": [
-            ":appnope@0.1.3",
-        ],
         ":_env_python_3.12.0_aarch64-apple-darwin": [
-            ":appnope@0.1.3",
-        ],
-        ":_env_python_3.12.0_x86_64-apple-darwin": [
             ":appnope@0.1.3",
         ],
         "//conditions:default": [],


### PR DESCRIPTION
Our Github darwin runners seemed to switch to arm64. This required downgrading two 3.10.11 since 3.10.12 doesn't seem available for Github + darwin, and changing the arch.
