### PR TITLE
feat(bzlmod): mark lock_import and lock_repos as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.38.1")
-bazel_dep(name = "bazel_features", version = "1.1.1")
+bazel_dep(name = "bazel_features", version = "1.11.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_python", version = "0.29.0")

--- a/pycross/private/bzlmod/BUILD.bazel
+++ b/pycross/private/bzlmod/BUILD.bazel
@@ -35,6 +35,7 @@ bzl_library(
         "//pycross/private:poetry_lock_model",
         "//pycross/private:pypi_file",
         "//pycross/private:resolved_lock_repo",
+        "@bazel_features//:features",
     ] + REPO_HTTP_DEPS,
 )
 
@@ -61,6 +62,7 @@ bzl_library(
         ":tag_attrs",
         "//pycross/private:package_repo",
         "//pycross/private:pypi_file",
+        "@bazel_features//:features",
         "@lock_import_repos_hub//:locks.bzl",
     ] + REPO_HTTP_DEPS,
 )

--- a/pycross/private/bzlmod/lock_import.bzl
+++ b/pycross/private/bzlmod/lock_import.bzl
@@ -1,5 +1,6 @@
 """The lock_import extension."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//pycross/private:lock_attrs.bzl", "package_annotation")
 load("//pycross/private:pdm_lock_model.bzl", "lock_repo_model_pdm")
 load("//pycross/private:poetry_lock_model.bzl", "lock_repo_model_poetry")
@@ -127,6 +128,10 @@ def _lock_import_impl(module_ctx):
         name = "lock_import_repos_hub",
         repo_files = resolved_lock_files,
     )
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    return module_ctx.extension_metadata()
 
 # Tag classes
 _import_pdm_tag = tag_class(

--- a/pycross/private/bzlmod/lock_repos.bzl
+++ b/pycross/private/bzlmod/lock_repos.bzl
@@ -1,5 +1,6 @@
 """The lock_repos extension."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@lock_import_repos_hub//:locks.bzl", lock_import_locks = "locks")
 load("//pycross/private:package_repo.bzl", "package_repo")
@@ -81,6 +82,10 @@ def _lock_repos_impl(module_ctx):
             resolved_lock_file = lock_file,
             repo_map = repo_remote_files,
         )
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    return module_ctx.extension_metadata()
 
 # Tag classes
 _create_tag = tag_class(


### PR DESCRIPTION
`MODULE.bazel.lock` also contains all the repos created by `lock_import` and `lock_repos`.
This makes the file extremely big (>1MB in our monorepo).

Since bazel `7.1.1` [`extension_metadata`](https://bazel.build/rules/lib/builtins/module_ctx#extension_metadata) allows marking an extension as being reproducible.

Some more background:
- https://github.com/bazelbuild/bazel/issues/20272
- https://github.com/aspect-build/rules_js/pull/1541
- https://github.com/bazelbuild/rules_python/pull/1892
- https://bazel.build/rules/lib/builtins/module_ctx#extension_metadata