### PR TITLE
Use an absolute path to C/C++ compilers for better compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,16 @@ jobs:
         run: |
           bazel test @rules_pycross//pycross/...
 
+      - name: run e2e tests - workspace with toolchains_llvm
+        working-directory: e2e/workspace
+        run: |
+          bazel test --config=toolchains_llvm //...
+
+      - name: run e2e tests - bzlmod with toolchains_llvm
+        working-directory: e2e/bzlmod
+        run: |
+          bazel test --config=toolchains_llvm -- //... -//lock_file/...
+
   workspace-e2e-test:
     name: workspace e2e test - Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
     runs-on: ubuntu-latest

--- a/e2e/bzlmod/.bazelrc
+++ b/e2e/bzlmod/.bazelrc
@@ -11,5 +11,7 @@ build --sandbox_add_mount_pair=/tmp
 build -c opt
 build --strip=always
 
+build:toolchains_llvm --extra_toolchains=@llvm_toolchain//:all
+
 try-import %workspace%/.bazelrc.user
 try-import %workspace%/.bazelrc.ci

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -31,6 +31,19 @@ register_toolchains(
     "@zig_sdk//toolchain:darwin_arm64",
 )
 
+# Alternative CC toolchain (not registered, selected via --extra_toolchains in .bazelrc)
+
+bazel_dep(name = "toolchains_llvm", version = "0.10.3")
+
+# Configure and register the toolchain.
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(
+    llvm_version = "16.0.0",
+)
+use_repo(llvm, "llvm_toolchain")
+# use_repo(llvm, "llvm_toolchain_llvm") # if you depend on specific tools in scripts
+#register_toolchains("@llvm_toolchain//:all")
+
 # Python
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/e2e/workspace/.bazelrc
+++ b/e2e/workspace/.bazelrc
@@ -11,5 +11,7 @@ build --sandbox_add_mount_pair=/tmp
 build -c opt
 build --strip=always
 
+build:toolchains_llvm --extra_toolchains=@llvm_toolchain//:all
+
 try-import %workspace%/.bazelrc.user
 try-import %workspace%/.bazelrc.ci

--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -41,6 +41,27 @@ register_toolchains(
     "@zig_sdk//toolchain:darwin_arm64",
 )
 
+# Alternative CC toolchain (not registered, selected via --extra_toolchains in .bazelrc)
+
+http_archive(
+    name = "toolchains_llvm",
+    canonical_id = "0.10.3",
+    sha256 = "b7cd301ef7b0ece28d20d3e778697a5e3b81828393150bed04838c0c52963a01",
+    strip_prefix = "toolchains_llvm-0.10.3",
+    url = "https://github.com/grailbio/bazel-toolchain/releases/download/0.10.3/toolchains_llvm-0.10.3.tar.gz",
+)
+
+load("@toolchains_llvm//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
+load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "16.0.0",
+)
+
 # Python
 
 http_archive(

--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -312,8 +312,8 @@ def wrap_cc(lang: str, cc_exe: Path, cflags: str, python_exe: Path, bin_dir: Pat
 
 
 def generate_cc_wrappers(toolchain_vars: Dict[str, Any], python_exe: Path, bin_dir: Path) -> Dict[str, str]:
-    orig_cc = toolchain_vars["CC"]
-    orig_cxx = toolchain_vars["CXX"]
+    orig_cc = os.path.abspath(toolchain_vars["CC"])
+    orig_cxx = os.path.abspath(toolchain_vars["CXX"])
     cflags = toolchain_vars["CFLAGS"]
     # Possibly generate wrappers around the CC and CXX executables.
     wrapped_cc = wrap_cc("cc", orig_cc, cflags, python_exe, bin_dir)


### PR DESCRIPTION
[`toolchains_llvm`][1] only triggers its logic to locate files relative to the compiler wrapper when called with an absolute path, for example. Otherwise it assumes it's being called from the bazel execroot, which is not true in this case.

`toolchains_llvm` already has similar logic as `wheel_builder` for mapping paths, which could be used by just calling it with an absolute path instead of using `wheel_builder`'s wrapper, but I think it's easier to use the `wheel_builder` version instead of trying to detect whether the toolchain has this logic.

[1]: https://github.com/bazel-contrib/toolchains_llvm/blob/1d685a99db5f1e6523c392e7dfaced583062cbc4/toolchain/cc_wrapper.sh.tpl#L37