### PR TITLE
Add support for exposing C/C++ dependencies

### DIFF
--- a/e2e/bzlmod/lock_file/pdm_lock.bzl
+++ b/e2e/bzlmod/lock_file/pdm_lock.bzl
@@ -126,6 +126,12 @@ def targets():
     pycross_wheel_library(
         name = "appnope@0.1.4",
         wheel = ":_wheel_appnope@0.1.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _asttokens_2_4_1_deps = [
@@ -141,6 +147,12 @@ def targets():
         name = "asttokens@2.4.1",
         deps = _asttokens_2_4_1_deps,
         wheel = ":_wheel_asttokens@2.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -151,6 +163,12 @@ def targets():
     pycross_wheel_library(
         name = "cowsay@6.1",
         wheel = ":_wheel_cowsay@6.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -161,6 +179,12 @@ def targets():
     pycross_wheel_library(
         name = "decorator@5.1.1",
         wheel = ":_wheel_decorator@5.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -171,6 +195,12 @@ def targets():
     pycross_wheel_library(
         name = "exceptiongroup@1.2.0",
         wheel = ":_wheel_exceptiongroup@1.2.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -181,6 +211,12 @@ def targets():
     pycross_wheel_library(
         name = "executing@2.0.1",
         wheel = ":_wheel_executing@2.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ipython_8_17_2_deps = [
@@ -224,6 +260,12 @@ def targets():
         name = "ipython@8.17.2",
         deps = _ipython_8_17_2_deps,
         wheel = ":_wheel_ipython@8.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jedi_0_19_1_deps = [
@@ -239,6 +281,12 @@ def targets():
         name = "jedi@0.19.1",
         deps = _jedi_0_19_1_deps,
         wheel = ":_wheel_jedi@0.19.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _matplotlib_inline_0_1_6_deps = [
@@ -254,6 +302,12 @@ def targets():
         name = "matplotlib-inline@0.1.6",
         deps = _matplotlib_inline_0_1_6_deps,
         wheel = ":_wheel_matplotlib-inline@0.1.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -264,6 +318,12 @@ def targets():
     pycross_wheel_library(
         name = "parso@0.8.3",
         wheel = ":_wheel_parso@0.8.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pexpect_4_9_0_deps = [
@@ -279,6 +339,12 @@ def targets():
         name = "pexpect@4.9.0",
         deps = _pexpect_4_9_0_deps,
         wheel = ":_wheel_pexpect@4.9.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _prompt_toolkit_3_0_43_deps = [
@@ -294,6 +360,12 @@ def targets():
         name = "prompt-toolkit@3.0.43",
         deps = _prompt_toolkit_3_0_43_deps,
         wheel = ":_wheel_prompt-toolkit@3.0.43",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -304,6 +376,12 @@ def targets():
     pycross_wheel_library(
         name = "ptyprocess@0.7.0",
         wheel = ":_wheel_ptyprocess@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -314,6 +392,12 @@ def targets():
     pycross_wheel_library(
         name = "pure-eval@0.2.2",
         wheel = ":_wheel_pure-eval@0.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -324,6 +408,12 @@ def targets():
     pycross_wheel_library(
         name = "pygments@2.17.2",
         wheel = ":_wheel_pygments@2.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -347,6 +437,12 @@ def targets():
     pycross_wheel_library(
         name = "regex@2023.10.3",
         wheel = ":_wheel_regex@2023.10.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -357,6 +453,12 @@ def targets():
     pycross_wheel_library(
         name = "setuptools@68.2.2",
         wheel = ":_wheel_setuptools@68.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -367,6 +469,12 @@ def targets():
     pycross_wheel_library(
         name = "six@1.16.0",
         wheel = ":_wheel_six@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _stack_data_0_6_3_deps = [
@@ -384,6 +492,12 @@ def targets():
         name = "stack-data@0.6.3",
         deps = _stack_data_0_6_3_deps,
         wheel = ":_wheel_stack-data@0.6.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -394,6 +508,12 @@ def targets():
     pycross_wheel_library(
         name = "traitlets@5.14.1",
         wheel = ":_wheel_traitlets@5.14.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -404,6 +524,12 @@ def targets():
     pycross_wheel_library(
         name = "wcwidth@0.2.13",
         wheel = ":_wheel_wcwidth@0.2.13",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -414,6 +540,12 @@ def targets():
     pycross_wheel_library(
         name = "wheel@0.41.3",
         wheel = ":_wheel_wheel@0.41.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -437,6 +569,12 @@ def targets():
     pycross_wheel_library(
         name = "zstandard@0.22.0",
         wheel = ":_wheel_zstandard@0.22.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
 # buildifier: disable=unnamed-macro

--- a/e2e/bzlmod/lock_file/poetry_lock.bzl
+++ b/e2e/bzlmod/lock_file/poetry_lock.bzl
@@ -124,6 +124,12 @@ def targets():
     pycross_wheel_library(
         name = "appnope@0.1.3",
         wheel = ":_wheel_appnope@0.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _asttokens_2_4_1_deps = [
@@ -139,6 +145,12 @@ def targets():
         name = "asttokens@2.4.1",
         deps = _asttokens_2_4_1_deps,
         wheel = ":_wheel_asttokens@2.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -149,6 +161,12 @@ def targets():
     pycross_wheel_library(
         name = "decorator@5.1.1",
         wheel = ":_wheel_decorator@5.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -159,6 +177,12 @@ def targets():
     pycross_wheel_library(
         name = "exceptiongroup@1.2.0",
         wheel = ":_wheel_exceptiongroup@1.2.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -169,6 +193,12 @@ def targets():
     pycross_wheel_library(
         name = "executing@2.0.1",
         wheel = ":_wheel_executing@2.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ipython_8_17_2_deps = [
@@ -212,6 +242,12 @@ def targets():
         name = "ipython@8.17.2",
         deps = _ipython_8_17_2_deps,
         wheel = ":_wheel_ipython@8.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jedi_0_19_1_deps = [
@@ -227,6 +263,12 @@ def targets():
         name = "jedi@0.19.1",
         deps = _jedi_0_19_1_deps,
         wheel = ":_wheel_jedi@0.19.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _matplotlib_inline_0_1_6_deps = [
@@ -242,6 +284,12 @@ def targets():
         name = "matplotlib-inline@0.1.6",
         deps = _matplotlib_inline_0_1_6_deps,
         wheel = ":_wheel_matplotlib-inline@0.1.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -252,6 +300,12 @@ def targets():
     pycross_wheel_library(
         name = "parso@0.8.3",
         wheel = ":_wheel_parso@0.8.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pexpect_4_9_0_deps = [
@@ -267,6 +321,12 @@ def targets():
         name = "pexpect@4.9.0",
         deps = _pexpect_4_9_0_deps,
         wheel = ":_wheel_pexpect@4.9.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _prompt_toolkit_3_0_41_deps = [
@@ -282,6 +342,12 @@ def targets():
         name = "prompt-toolkit@3.0.41",
         deps = _prompt_toolkit_3_0_41_deps,
         wheel = ":_wheel_prompt-toolkit@3.0.41",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -292,6 +358,12 @@ def targets():
     pycross_wheel_library(
         name = "ptyprocess@0.7.0",
         wheel = ":_wheel_ptyprocess@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -302,6 +374,12 @@ def targets():
     pycross_wheel_library(
         name = "pure-eval@0.2.2",
         wheel = ":_wheel_pure-eval@0.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -312,6 +390,12 @@ def targets():
     pycross_wheel_library(
         name = "pygments@2.17.2",
         wheel = ":_wheel_pygments@2.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -335,6 +419,12 @@ def targets():
     pycross_wheel_library(
         name = "regex@2023.10.3",
         wheel = ":_wheel_regex@2023.10.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -345,6 +435,12 @@ def targets():
     pycross_wheel_library(
         name = "setuptools@68.2.2",
         wheel = ":_wheel_setuptools@68.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -355,6 +451,12 @@ def targets():
     pycross_wheel_library(
         name = "six@1.16.0",
         wheel = ":_wheel_six@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _stack_data_0_6_3_deps = [
@@ -372,6 +474,12 @@ def targets():
         name = "stack-data@0.6.3",
         deps = _stack_data_0_6_3_deps,
         wheel = ":_wheel_stack-data@0.6.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -382,6 +490,12 @@ def targets():
     pycross_wheel_library(
         name = "traitlets@5.14.0",
         wheel = ":_wheel_traitlets@5.14.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -392,6 +506,12 @@ def targets():
     pycross_wheel_library(
         name = "wcwidth@0.2.12",
         wheel = ":_wheel_wcwidth@0.2.12",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -402,6 +522,12 @@ def targets():
     pycross_wheel_library(
         name = "wheel@0.41.3",
         wheel = ":_wheel_wheel@0.41.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -425,6 +551,12 @@ def targets():
     pycross_wheel_library(
         name = "zstandard@0.22.0",
         wheel = ":_wheel_zstandard@0.22.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
 # buildifier: disable=unnamed-macro

--- a/e2e/workspace/pdm/lock.bzl
+++ b/e2e/workspace/pdm/lock.bzl
@@ -108,6 +108,12 @@ def targets():
     pycross_wheel_library(
         name = "appnope@0.1.4",
         wheel = ":_wheel_appnope@0.1.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _asttokens_2_4_1_deps = [
@@ -123,6 +129,12 @@ def targets():
         name = "asttokens@2.4.1",
         deps = _asttokens_2_4_1_deps,
         wheel = ":_wheel_asttokens@2.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -133,6 +145,12 @@ def targets():
     pycross_wheel_library(
         name = "cowsay@6.1",
         wheel = ":_wheel_cowsay@6.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -143,6 +161,12 @@ def targets():
     pycross_wheel_library(
         name = "decorator@5.1.1",
         wheel = ":_wheel_decorator@5.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -153,6 +177,12 @@ def targets():
     pycross_wheel_library(
         name = "exceptiongroup@1.2.0",
         wheel = ":_wheel_exceptiongroup@1.2.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -163,6 +193,12 @@ def targets():
     pycross_wheel_library(
         name = "executing@2.0.1",
         wheel = ":_wheel_executing@2.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ipython_8_17_2_deps = [
@@ -203,6 +239,12 @@ def targets():
         name = "ipython@8.17.2",
         deps = _ipython_8_17_2_deps,
         wheel = ":_wheel_ipython@8.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jedi_0_19_1_deps = [
@@ -218,6 +260,12 @@ def targets():
         name = "jedi@0.19.1",
         deps = _jedi_0_19_1_deps,
         wheel = ":_wheel_jedi@0.19.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _matplotlib_inline_0_1_6_deps = [
@@ -233,6 +281,12 @@ def targets():
         name = "matplotlib-inline@0.1.6",
         deps = _matplotlib_inline_0_1_6_deps,
         wheel = ":_wheel_matplotlib-inline@0.1.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -243,6 +297,12 @@ def targets():
     pycross_wheel_library(
         name = "parso@0.8.3",
         wheel = ":_wheel_parso@0.8.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pexpect_4_9_0_deps = [
@@ -258,6 +318,12 @@ def targets():
         name = "pexpect@4.9.0",
         deps = _pexpect_4_9_0_deps,
         wheel = ":_wheel_pexpect@4.9.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _prompt_toolkit_3_0_43_deps = [
@@ -273,6 +339,12 @@ def targets():
         name = "prompt-toolkit@3.0.43",
         deps = _prompt_toolkit_3_0_43_deps,
         wheel = ":_wheel_prompt-toolkit@3.0.43",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -283,6 +355,12 @@ def targets():
     pycross_wheel_library(
         name = "ptyprocess@0.7.0",
         wheel = ":_wheel_ptyprocess@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -293,6 +371,12 @@ def targets():
     pycross_wheel_library(
         name = "pure-eval@0.2.2",
         wheel = ":_wheel_pure-eval@0.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -303,6 +387,12 @@ def targets():
     pycross_wheel_library(
         name = "pygments@2.17.2",
         wheel = ":_wheel_pygments@2.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -331,6 +421,12 @@ def targets():
     pycross_wheel_library(
         name = "regex@2023.10.3",
         wheel = ":_wheel_regex@2023.10.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -341,6 +437,12 @@ def targets():
     pycross_wheel_library(
         name = "setuptools@68.2.2",
         wheel = ":_wheel_setuptools@68.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -351,6 +453,12 @@ def targets():
     pycross_wheel_library(
         name = "six@1.16.0",
         wheel = ":_wheel_six@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _stack_data_0_6_3_deps = [
@@ -368,6 +476,12 @@ def targets():
         name = "stack-data@0.6.3",
         deps = _stack_data_0_6_3_deps,
         wheel = ":_wheel_stack-data@0.6.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -378,6 +492,12 @@ def targets():
     pycross_wheel_library(
         name = "traitlets@5.14.1",
         wheel = ":_wheel_traitlets@5.14.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -388,6 +508,12 @@ def targets():
     pycross_wheel_library(
         name = "wcwidth@0.2.13",
         wheel = ":_wheel_wcwidth@0.2.13",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -398,6 +524,12 @@ def targets():
     pycross_wheel_library(
         name = "wheel@0.41.3",
         wheel = ":_wheel_wheel@0.41.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -413,6 +545,12 @@ def targets():
     pycross_wheel_library(
         name = "zstandard@0.22.0",
         wheel = ":_wheel_zstandard@0.22.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
 # buildifier: disable=unnamed-macro

--- a/e2e/workspace/poetry/lock.bzl
+++ b/e2e/workspace/poetry/lock.bzl
@@ -106,6 +106,12 @@ def targets():
     pycross_wheel_library(
         name = "appnope@0.1.3",
         wheel = ":_wheel_appnope@0.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _asttokens_2_4_1_deps = [
@@ -121,6 +127,12 @@ def targets():
         name = "asttokens@2.4.1",
         deps = _asttokens_2_4_1_deps,
         wheel = ":_wheel_asttokens@2.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -131,6 +143,12 @@ def targets():
     pycross_wheel_library(
         name = "decorator@5.1.1",
         wheel = ":_wheel_decorator@5.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -141,6 +159,12 @@ def targets():
     pycross_wheel_library(
         name = "exceptiongroup@1.2.0",
         wheel = ":_wheel_exceptiongroup@1.2.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -151,6 +175,12 @@ def targets():
     pycross_wheel_library(
         name = "executing@2.0.1",
         wheel = ":_wheel_executing@2.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ipython_8_17_2_deps = [
@@ -191,6 +221,12 @@ def targets():
         name = "ipython@8.17.2",
         deps = _ipython_8_17_2_deps,
         wheel = ":_wheel_ipython@8.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jedi_0_19_1_deps = [
@@ -206,6 +242,12 @@ def targets():
         name = "jedi@0.19.1",
         deps = _jedi_0_19_1_deps,
         wheel = ":_wheel_jedi@0.19.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _matplotlib_inline_0_1_6_deps = [
@@ -221,6 +263,12 @@ def targets():
         name = "matplotlib-inline@0.1.6",
         deps = _matplotlib_inline_0_1_6_deps,
         wheel = ":_wheel_matplotlib-inline@0.1.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -231,6 +279,12 @@ def targets():
     pycross_wheel_library(
         name = "parso@0.8.3",
         wheel = ":_wheel_parso@0.8.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pexpect_4_9_0_deps = [
@@ -246,6 +300,12 @@ def targets():
         name = "pexpect@4.9.0",
         deps = _pexpect_4_9_0_deps,
         wheel = ":_wheel_pexpect@4.9.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _prompt_toolkit_3_0_41_deps = [
@@ -261,6 +321,12 @@ def targets():
         name = "prompt-toolkit@3.0.41",
         deps = _prompt_toolkit_3_0_41_deps,
         wheel = ":_wheel_prompt-toolkit@3.0.41",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -271,6 +337,12 @@ def targets():
     pycross_wheel_library(
         name = "ptyprocess@0.7.0",
         wheel = ":_wheel_ptyprocess@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -281,6 +353,12 @@ def targets():
     pycross_wheel_library(
         name = "pure-eval@0.2.2",
         wheel = ":_wheel_pure-eval@0.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -291,6 +369,12 @@ def targets():
     pycross_wheel_library(
         name = "pygments@2.17.2",
         wheel = ":_wheel_pygments@2.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -319,6 +403,12 @@ def targets():
     pycross_wheel_library(
         name = "regex@2023.10.3",
         wheel = ":_wheel_regex@2023.10.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -329,6 +419,12 @@ def targets():
     pycross_wheel_library(
         name = "setuptools@68.2.2",
         wheel = ":_wheel_setuptools@68.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -339,6 +435,12 @@ def targets():
     pycross_wheel_library(
         name = "six@1.16.0",
         wheel = ":_wheel_six@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _stack_data_0_6_3_deps = [
@@ -356,6 +458,12 @@ def targets():
         name = "stack-data@0.6.3",
         deps = _stack_data_0_6_3_deps,
         wheel = ":_wheel_stack-data@0.6.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -366,6 +474,12 @@ def targets():
     pycross_wheel_library(
         name = "traitlets@5.14.0",
         wheel = ":_wheel_traitlets@5.14.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -376,6 +490,12 @@ def targets():
     pycross_wheel_library(
         name = "wcwidth@0.2.12",
         wheel = ":_wheel_wcwidth@0.2.12",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -386,6 +506,12 @@ def targets():
     pycross_wheel_library(
         name = "wheel@0.41.3",
         wheel = ":_wheel_wheel@0.41.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -401,6 +527,12 @@ def targets():
     pycross_wheel_library(
         name = "zstandard@0.22.0",
         wheel = ":_wheel_zstandard@0.22.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
 # buildifier: disable=unnamed-macro

--- a/examples/bzlmod/poetry_lock.bzl
+++ b/examples/bzlmod/poetry_lock.bzl
@@ -57,98 +57,98 @@ def targets():
     )
 
     native.alias(
-        name = "_env_python_3.11.6_aarch64-apple-darwin",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11.6_aarch64-apple-darwin_config",
+        name = "_env_python_3.11_aarch64-apple-darwin",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11_aarch64-apple-darwin_config",
     )
 
     native.alias(
-        name = "_env_python_3.11.6_aarch64-unknown-linux-gnu",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11.6_aarch64-unknown-linux-gnu_config",
+        name = "_env_python_3.11_aarch64-unknown-linux-gnu",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11_aarch64-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.11.6_ppc64le-unknown-linux-gnu",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11.6_ppc64le-unknown-linux-gnu_config",
+        name = "_env_python_3.11_ppc64le-unknown-linux-gnu",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11_ppc64le-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.11.6_s390x-unknown-linux-gnu",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11.6_s390x-unknown-linux-gnu_config",
+        name = "_env_python_3.11_s390x-unknown-linux-gnu",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11_s390x-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.11.6_x86_64-apple-darwin",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11.6_x86_64-apple-darwin_config",
+        name = "_env_python_3.11_x86_64-apple-darwin",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11_x86_64-apple-darwin_config",
     )
 
     native.alias(
-        name = "_env_python_3.11.6_x86_64-pc-windows-msvc",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11.6_x86_64-pc-windows-msvc_config",
+        name = "_env_python_3.11_x86_64-pc-windows-msvc",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11_x86_64-pc-windows-msvc_config",
     )
 
     native.alias(
-        name = "_env_python_3.11.6_x86_64-unknown-linux-gnu",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11.6_x86_64-unknown-linux-gnu_config",
+        name = "_env_python_3.11_x86_64-unknown-linux-gnu",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.11_x86_64-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.12.0_aarch64-apple-darwin",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12.0_aarch64-apple-darwin_config",
+        name = "_env_python_3.12_aarch64-apple-darwin",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12_aarch64-apple-darwin_config",
     )
 
     native.alias(
-        name = "_env_python_3.12.0_aarch64-unknown-linux-gnu",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12.0_aarch64-unknown-linux-gnu_config",
+        name = "_env_python_3.12_aarch64-unknown-linux-gnu",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12_aarch64-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.12.0_ppc64le-unknown-linux-gnu",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12.0_ppc64le-unknown-linux-gnu_config",
+        name = "_env_python_3.12_ppc64le-unknown-linux-gnu",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12_ppc64le-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.12.0_s390x-unknown-linux-gnu",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12.0_s390x-unknown-linux-gnu_config",
+        name = "_env_python_3.12_s390x-unknown-linux-gnu",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12_s390x-unknown-linux-gnu_config",
     )
 
     native.alias(
-        name = "_env_python_3.12.0_x86_64-apple-darwin",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12.0_x86_64-apple-darwin_config",
+        name = "_env_python_3.12_x86_64-apple-darwin",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12_x86_64-apple-darwin_config",
     )
 
     native.alias(
-        name = "_env_python_3.12.0_x86_64-pc-windows-msvc",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12.0_x86_64-pc-windows-msvc_config",
+        name = "_env_python_3.12_x86_64-pc-windows-msvc",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12_x86_64-pc-windows-msvc_config",
     )
 
     native.alias(
-        name = "_env_python_3.12.0_x86_64-unknown-linux-gnu",
-        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12.0_x86_64-unknown-linux-gnu_config",
+        name = "_env_python_3.12_x86_64-unknown-linux-gnu",
+        actual = "@@rules_pycross~override~environments~pycross_environments//:python_3.12_x86_64-unknown-linux-gnu_config",
     )
 
     # buildifier: disable=unused-variable
     _target = select({
-        ":_env_python_3.11.5_aarch64-apple-darwin": "@rules_pycross~override~environments~pycross_environments//:python_3.11.5_aarch64-apple-darwin.json",
-        ":_env_python_3.11.5_aarch64-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.11.5_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.11.5_ppc64le-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.11.5_ppc64le-unknown-linux-gnu.json",
-        ":_env_python_3.11.5_s390x-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.11.5_s390x-unknown-linux-gnu.json",
-        ":_env_python_3.11.5_x86_64-apple-darwin": "@rules_pycross~override~environments~pycross_environments//:python_3.11.5_x86_64-apple-darwin.json",
-        ":_env_python_3.11.5_x86_64-pc-windows-msvc": "@rules_pycross~override~environments~pycross_environments//:python_3.11.5_x86_64-pc-windows-msvc.json",
-        ":_env_python_3.11.5_x86_64-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.11.5_x86_64-unknown-linux-gnu.json",
-        ":_env_python_3.11.6_aarch64-apple-darwin": "@rules_pycross~override~environments~pycross_environments//:python_3.11.6_aarch64-apple-darwin.json",
-        ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.11.6_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.11.6_ppc64le-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.11.6_ppc64le-unknown-linux-gnu.json",
-        ":_env_python_3.11.6_s390x-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.11.6_s390x-unknown-linux-gnu.json",
-        ":_env_python_3.11.6_x86_64-apple-darwin": "@rules_pycross~override~environments~pycross_environments//:python_3.11.6_x86_64-apple-darwin.json",
-        ":_env_python_3.11.6_x86_64-pc-windows-msvc": "@rules_pycross~override~environments~pycross_environments//:python_3.11.6_x86_64-pc-windows-msvc.json",
-        ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.11.6_x86_64-unknown-linux-gnu.json",
-        ":_env_python_3.12.0_aarch64-apple-darwin": "@rules_pycross~override~environments~pycross_environments//:python_3.12.0_aarch64-apple-darwin.json",
-        ":_env_python_3.12.0_aarch64-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.12.0_aarch64-unknown-linux-gnu.json",
-        ":_env_python_3.12.0_ppc64le-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.12.0_ppc64le-unknown-linux-gnu.json",
-        ":_env_python_3.12.0_s390x-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.12.0_s390x-unknown-linux-gnu.json",
-        ":_env_python_3.12.0_x86_64-apple-darwin": "@rules_pycross~override~environments~pycross_environments//:python_3.12.0_x86_64-apple-darwin.json",
-        ":_env_python_3.12.0_x86_64-pc-windows-msvc": "@rules_pycross~override~environments~pycross_environments//:python_3.12.0_x86_64-pc-windows-msvc.json",
-        ":_env_python_3.12.0_x86_64-unknown-linux-gnu": "@rules_pycross~override~environments~pycross_environments//:python_3.12.0_x86_64-unknown-linux-gnu.json",
+        ":_env_python_3.11.5_aarch64-apple-darwin": "@@rules_pycross~override~environments~pycross_environments//:python_3.11.5_aarch64-apple-darwin.json",
+        ":_env_python_3.11.5_aarch64-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.11.5_aarch64-unknown-linux-gnu.json",
+        ":_env_python_3.11.5_ppc64le-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.11.5_ppc64le-unknown-linux-gnu.json",
+        ":_env_python_3.11.5_s390x-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.11.5_s390x-unknown-linux-gnu.json",
+        ":_env_python_3.11.5_x86_64-apple-darwin": "@@rules_pycross~override~environments~pycross_environments//:python_3.11.5_x86_64-apple-darwin.json",
+        ":_env_python_3.11.5_x86_64-pc-windows-msvc": "@@rules_pycross~override~environments~pycross_environments//:python_3.11.5_x86_64-pc-windows-msvc.json",
+        ":_env_python_3.11.5_x86_64-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.11.5_x86_64-unknown-linux-gnu.json",
+        ":_env_python_3.11_aarch64-apple-darwin": "@@rules_pycross~override~environments~pycross_environments//:python_3.11_aarch64-apple-darwin.json",
+        ":_env_python_3.11_aarch64-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.11_aarch64-unknown-linux-gnu.json",
+        ":_env_python_3.11_ppc64le-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.11_ppc64le-unknown-linux-gnu.json",
+        ":_env_python_3.11_s390x-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.11_s390x-unknown-linux-gnu.json",
+        ":_env_python_3.11_x86_64-apple-darwin": "@@rules_pycross~override~environments~pycross_environments//:python_3.11_x86_64-apple-darwin.json",
+        ":_env_python_3.11_x86_64-pc-windows-msvc": "@@rules_pycross~override~environments~pycross_environments//:python_3.11_x86_64-pc-windows-msvc.json",
+        ":_env_python_3.11_x86_64-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.11_x86_64-unknown-linux-gnu.json",
+        ":_env_python_3.12_aarch64-apple-darwin": "@@rules_pycross~override~environments~pycross_environments//:python_3.12_aarch64-apple-darwin.json",
+        ":_env_python_3.12_aarch64-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.12_aarch64-unknown-linux-gnu.json",
+        ":_env_python_3.12_ppc64le-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.12_ppc64le-unknown-linux-gnu.json",
+        ":_env_python_3.12_s390x-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.12_s390x-unknown-linux-gnu.json",
+        ":_env_python_3.12_x86_64-apple-darwin": "@@rules_pycross~override~environments~pycross_environments//:python_3.12_x86_64-apple-darwin.json",
+        ":_env_python_3.12_x86_64-pc-windows-msvc": "@@rules_pycross~override~environments~pycross_environments//:python_3.12_x86_64-pc-windows-msvc.json",
+        ":_env_python_3.12_x86_64-unknown-linux-gnu": "@@rules_pycross~override~environments~pycross_environments//:python_3.12_x86_64-unknown-linux-gnu.json",
     })
 
     _asttokens_2_4_1_deps = [
@@ -164,6 +164,12 @@ def targets():
         name = "asttokens@2.4.1",
         deps = _asttokens_2_4_1_deps,
         wheel = ":_wheel_asttokens@2.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -174,6 +180,12 @@ def targets():
     pycross_wheel_library(
         name = "colorama@0.4.6",
         wheel = ":_wheel_colorama@0.4.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -184,6 +196,12 @@ def targets():
     pycross_wheel_library(
         name = "decorator@5.1.1",
         wheel = ":_wheel_decorator@5.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -194,6 +212,12 @@ def targets():
     pycross_wheel_library(
         name = "executing@2.0.1",
         wheel = ":_wheel_executing@2.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ipython_8_19_0_deps = [
@@ -226,46 +250,46 @@ def targets():
         ":_env_python_3.11.5_x86_64-unknown-linux-gnu": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.11.6_aarch64-apple-darwin": [
+        ":_env_python_3.11_aarch64-apple-darwin": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.11.6_aarch64-unknown-linux-gnu": [
+        ":_env_python_3.11_aarch64-unknown-linux-gnu": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.11.6_ppc64le-unknown-linux-gnu": [
+        ":_env_python_3.11_ppc64le-unknown-linux-gnu": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.11.6_s390x-unknown-linux-gnu": [
+        ":_env_python_3.11_s390x-unknown-linux-gnu": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.11.6_x86_64-apple-darwin": [
+        ":_env_python_3.11_x86_64-apple-darwin": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.11.6_x86_64-pc-windows-msvc": [
+        ":_env_python_3.11_x86_64-pc-windows-msvc": [
             ":colorama@0.4.6",
         ],
-        ":_env_python_3.11.6_x86_64-unknown-linux-gnu": [
+        ":_env_python_3.11_x86_64-unknown-linux-gnu": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.12.0_aarch64-apple-darwin": [
+        ":_env_python_3.12_aarch64-apple-darwin": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.12.0_aarch64-unknown-linux-gnu": [
+        ":_env_python_3.12_aarch64-unknown-linux-gnu": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.12.0_ppc64le-unknown-linux-gnu": [
+        ":_env_python_3.12_ppc64le-unknown-linux-gnu": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.12.0_s390x-unknown-linux-gnu": [
+        ":_env_python_3.12_s390x-unknown-linux-gnu": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.12.0_x86_64-apple-darwin": [
+        ":_env_python_3.12_x86_64-apple-darwin": [
             ":pexpect@4.9.0",
         ],
-        ":_env_python_3.12.0_x86_64-pc-windows-msvc": [
+        ":_env_python_3.12_x86_64-pc-windows-msvc": [
             ":colorama@0.4.6",
         ],
-        ":_env_python_3.12.0_x86_64-unknown-linux-gnu": [
+        ":_env_python_3.12_x86_64-unknown-linux-gnu": [
             ":pexpect@4.9.0",
         ],
         "//conditions:default": [],
@@ -280,6 +304,12 @@ def targets():
         name = "ipython@8.19.0",
         deps = _ipython_8_19_0_deps,
         wheel = ":_wheel_ipython@8.19.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jedi_0_19_1_deps = [
@@ -295,6 +325,12 @@ def targets():
         name = "jedi@0.19.1",
         deps = _jedi_0_19_1_deps,
         wheel = ":_wheel_jedi@0.19.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _matplotlib_inline_0_1_6_deps = [
@@ -310,6 +346,12 @@ def targets():
         name = "matplotlib-inline@0.1.6",
         deps = _matplotlib_inline_0_1_6_deps,
         wheel = ":_wheel_matplotlib-inline@0.1.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -320,6 +362,12 @@ def targets():
     pycross_wheel_library(
         name = "parso@0.8.3",
         wheel = ":_wheel_parso@0.8.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pexpect_4_9_0_deps = [
@@ -335,6 +383,12 @@ def targets():
         name = "pexpect@4.9.0",
         deps = _pexpect_4_9_0_deps,
         wheel = ":_wheel_pexpect@4.9.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _prompt_toolkit_3_0_43_deps = [
@@ -350,6 +404,12 @@ def targets():
         name = "prompt-toolkit@3.0.43",
         deps = _prompt_toolkit_3_0_43_deps,
         wheel = ":_wheel_prompt-toolkit@3.0.43",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -360,6 +420,12 @@ def targets():
     pycross_wheel_library(
         name = "ptyprocess@0.7.0",
         wheel = ":_wheel_ptyprocess@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -370,6 +436,12 @@ def targets():
     pycross_wheel_library(
         name = "pure-eval@0.2.2",
         wheel = ":_wheel_pure-eval@0.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -380,6 +452,12 @@ def targets():
     pycross_wheel_library(
         name = "pygments@2.17.2",
         wheel = ":_wheel_pygments@2.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -390,6 +468,12 @@ def targets():
     pycross_wheel_library(
         name = "setuptools@69.0.3",
         wheel = ":_wheel_setuptools@69.0.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -400,6 +484,12 @@ def targets():
     pycross_wheel_library(
         name = "six@1.16.0",
         wheel = ":_wheel_six@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _stack_data_0_6_3_deps = [
@@ -417,6 +507,12 @@ def targets():
         name = "stack-data@0.6.3",
         deps = _stack_data_0_6_3_deps,
         wheel = ":_wheel_stack-data@0.6.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -427,6 +523,12 @@ def targets():
     pycross_wheel_library(
         name = "traitlets@5.14.1",
         wheel = ":_wheel_traitlets@5.14.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -437,6 +539,12 @@ def targets():
     pycross_wheel_library(
         name = "wcwidth@0.2.12",
         wheel = ":_wheel_wcwidth@0.2.12",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -447,6 +555,12 @@ def targets():
     pycross_wheel_library(
         name = "wheel@0.42.0",
         wheel = ":_wheel_wheel@0.42.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
 # buildifier: disable=unnamed-macro

--- a/examples/external_linking/example_lock.bzl
+++ b/examples/external_linking/example_lock.bzl
@@ -94,6 +94,12 @@ def targets():
     pycross_wheel_library(
         name = "appnope@0.1.3",
         wheel = ":_wheel_appnope@0.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _asttokens_2_4_1_deps = [
@@ -109,6 +115,12 @@ def targets():
         name = "asttokens@2.4.1",
         deps = _asttokens_2_4_1_deps,
         wheel = ":_wheel_asttokens@2.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -124,6 +136,12 @@ def targets():
     pycross_wheel_library(
         name = "cython@0.29.36",
         wheel = ":_wheel_cython@0.29.36",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -134,6 +152,12 @@ def targets():
     pycross_wheel_library(
         name = "decorator@5.1.1",
         wheel = ":_wheel_decorator@5.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -144,6 +168,12 @@ def targets():
     pycross_wheel_library(
         name = "exceptiongroup@1.1.3",
         wheel = ":_wheel_exceptiongroup@1.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -154,6 +184,12 @@ def targets():
     pycross_wheel_library(
         name = "executing@2.0.1",
         wheel = ":_wheel_executing@2.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ipython_8_17_2_deps = [
@@ -185,6 +221,12 @@ def targets():
         name = "ipython@8.17.2",
         deps = _ipython_8_17_2_deps,
         wheel = ":_wheel_ipython@8.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jedi_0_19_1_deps = [
@@ -200,6 +242,12 @@ def targets():
         name = "jedi@0.19.1",
         deps = _jedi_0_19_1_deps,
         wheel = ":_wheel_jedi@0.19.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _matplotlib_inline_0_1_6_deps = [
@@ -215,6 +263,12 @@ def targets():
         name = "matplotlib-inline@0.1.6",
         deps = _matplotlib_inline_0_1_6_deps,
         wheel = ":_wheel_matplotlib-inline@0.1.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -230,6 +284,12 @@ def targets():
     pycross_wheel_library(
         name = "numpy@1.23.5",
         wheel = ":_wheel_numpy@1.23.5",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pandas_1_5_2_deps = [
@@ -266,6 +326,12 @@ def targets():
         name = "pandas@1.5.2",
         deps = _pandas_1_5_2_deps,
         wheel = ":_wheel_pandas@1.5.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -276,6 +342,12 @@ def targets():
     pycross_wheel_library(
         name = "parso@0.8.3",
         wheel = ":_wheel_parso@0.8.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pexpect_4_8_0_deps = [
@@ -291,6 +363,12 @@ def targets():
         name = "pexpect@4.8.0",
         deps = _pexpect_4_8_0_deps,
         wheel = ":_wheel_pexpect@4.8.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _prompt_toolkit_3_0_39_deps = [
@@ -306,6 +384,12 @@ def targets():
         name = "prompt-toolkit@3.0.39",
         deps = _prompt_toolkit_3_0_39_deps,
         wheel = ":_wheel_prompt-toolkit@3.0.39",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -321,6 +405,12 @@ def targets():
     pycross_wheel_library(
         name = "psycopg2@2.9.5",
         wheel = ":_wheel_psycopg2@2.9.5",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -331,6 +421,12 @@ def targets():
     pycross_wheel_library(
         name = "ptyprocess@0.7.0",
         wheel = ":_wheel_ptyprocess@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -341,6 +437,12 @@ def targets():
     pycross_wheel_library(
         name = "pure-eval@0.2.2",
         wheel = ":_wheel_pure-eval@0.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -351,6 +453,12 @@ def targets():
     pycross_wheel_library(
         name = "pygments@2.16.1",
         wheel = ":_wheel_pygments@2.16.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _python_dateutil_2_8_2_deps = [
@@ -366,6 +474,12 @@ def targets():
         name = "python-dateutil@2.8.2",
         deps = _python_dateutil_2_8_2_deps,
         wheel = ":_wheel_python-dateutil@2.8.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -376,6 +490,12 @@ def targets():
     pycross_wheel_library(
         name = "pytz@2023.3.post1",
         wheel = ":_wheel_pytz@2023.3.post1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -404,6 +524,12 @@ def targets():
     pycross_wheel_library(
         name = "setproctitle@1.3.2",
         wheel = ":_wheel_setproctitle@1.3.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -414,6 +540,12 @@ def targets():
     pycross_wheel_library(
         name = "setuptools@59.2.0",
         wheel = ":_wheel_setuptools@59.2.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -424,6 +556,12 @@ def targets():
     pycross_wheel_library(
         name = "six@1.16.0",
         wheel = ":_wheel_six@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _stack_data_0_6_3_deps = [
@@ -441,6 +579,12 @@ def targets():
         name = "stack-data@0.6.3",
         deps = _stack_data_0_6_3_deps,
         wheel = ":_wheel_stack-data@0.6.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -451,6 +595,12 @@ def targets():
     pycross_wheel_library(
         name = "traitlets@5.13.0",
         wheel = ":_wheel_traitlets@5.13.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -461,6 +611,12 @@ def targets():
     pycross_wheel_library(
         name = "wcwidth@0.2.9",
         wheel = ":_wheel_wcwidth@0.2.9",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -471,6 +627,12 @@ def targets():
     pycross_wheel_library(
         name = "wheel@0.37.0",
         wheel = ":_wheel_wheel@0.37.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
 # buildifier: disable=unnamed-macro

--- a/examples/pdm/example_lock.bzl
+++ b/examples/pdm/example_lock.bzl
@@ -200,6 +200,12 @@ def targets():
         name = "aiohttp@3.9.5",
         deps = _aiohttp_3_9_5_deps,
         wheel = ":_wheel_aiohttp@3.9.5",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _aiosignal_1_3_1_deps = [
@@ -215,6 +221,12 @@ def targets():
         name = "aiosignal@1.3.1",
         deps = _aiosignal_1_3_1_deps,
         wheel = ":_wheel_aiosignal@1.3.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -225,6 +237,12 @@ def targets():
     pycross_wheel_library(
         name = "alabaster@0.7.13",
         wheel = ":_wheel_alabaster@0.7.13",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _amqp_mock_0_6_1_deps = [
@@ -244,6 +262,12 @@ def targets():
         install_exclude_globs = [
             "tests/**",
         ],
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -254,6 +278,12 @@ def targets():
     pycross_wheel_library(
         name = "annotated-types@0.6.0",
         wheel = ":_wheel_annotated-types@0.6.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -264,6 +294,12 @@ def targets():
     pycross_wheel_library(
         name = "appnope@0.1.3",
         wheel = ":_wheel_appnope@0.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -274,6 +310,12 @@ def targets():
     pycross_wheel_library(
         name = "asgiref@3.7.2",
         wheel = ":_wheel_asgiref@3.7.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _asttokens_2_4_1_deps = [
@@ -289,6 +331,12 @@ def targets():
         name = "asttokens@2.4.1",
         deps = _asttokens_2_4_1_deps,
         wheel = ":_wheel_asttokens@2.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -299,6 +347,12 @@ def targets():
     pycross_wheel_library(
         name = "attrs@23.1.0",
         wheel = ":_wheel_attrs@23.1.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _aws_sam_translator_1_79_0_deps = [
@@ -317,6 +371,12 @@ def targets():
         name = "aws-sam-translator@1.79.0",
         deps = _aws_sam_translator_1_79_0_deps,
         wheel = ":_wheel_aws-sam-translator@1.79.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _aws_xray_sdk_2_12_1_deps = [
@@ -333,6 +393,12 @@ def targets():
         name = "aws-xray-sdk@2.12.1",
         deps = _aws_xray_sdk_2_12_1_deps,
         wheel = ":_wheel_aws-xray-sdk@2.12.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -343,6 +409,12 @@ def targets():
     pycross_wheel_library(
         name = "babel@2.13.1",
         wheel = ":_wheel_babel@2.13.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _black_23_11_0_deps = [
@@ -366,6 +438,12 @@ def targets():
         name = "black@23.11.0",
         deps = _black_23_11_0_deps,
         wheel = ":_wheel_black@23.11.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -376,6 +454,12 @@ def targets():
     pycross_wheel_library(
         name = "blinker@1.7.0",
         wheel = ":_wheel_blinker@1.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _boto3_1_28_80_deps = [
@@ -393,6 +477,12 @@ def targets():
         name = "boto3@1.28.80",
         deps = _boto3_1_28_80_deps,
         wheel = ":_wheel_boto3@1.28.80",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _botocore_1_31_80_deps = [
@@ -410,6 +500,12 @@ def targets():
         name = "botocore@1.31.80",
         deps = _botocore_1_31_80_deps,
         wheel = ":_wheel_botocore@1.31.80",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -420,6 +516,12 @@ def targets():
     pycross_wheel_library(
         name = "certifi@2023.7.22",
         wheel = ":_wheel_certifi@2023.7.22",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _cffi_1_16_0_deps = [
@@ -439,6 +541,12 @@ def targets():
         name = "cffi@1.16.0",
         deps = _cffi_1_16_0_deps,
         wheel = ":_wheel_cffi@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _cfn_lint_0_83_1_deps = [
@@ -463,6 +571,12 @@ def targets():
         name = "cfn-lint@0.83.1",
         deps = _cfn_lint_0_83_1_deps,
         wheel = ":_wheel_cfn-lint@0.83.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -477,6 +591,12 @@ def targets():
     pycross_wheel_library(
         name = "charset-normalizer@3.3.2",
         wheel = ":_wheel_charset-normalizer@3.3.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -487,6 +607,12 @@ def targets():
     pycross_wheel_library(
         name = "click@8.1.7",
         wheel = ":_wheel_click@8.1.7",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _cognitojwt_1_4_1_deps = [
@@ -502,6 +628,12 @@ def targets():
         name = "cognitojwt@1.4.1",
         deps = _cognitojwt_1_4_1_deps,
         wheel = ":_wheel_cognitojwt@1.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -512,6 +644,12 @@ def targets():
     pycross_wheel_library(
         name = "cowsay@6.1",
         wheel = ":_wheel_cowsay@6.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _cryptography_41_0_5_deps = [
@@ -531,6 +669,12 @@ def targets():
         name = "cryptography@41.0.5",
         deps = _cryptography_41_0_5_deps,
         wheel = ":_wheel_cryptography@41.0.5",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -545,6 +689,12 @@ def targets():
     pycross_wheel_library(
         name = "cython@0.29.36",
         wheel = ":_wheel_cython@0.29.36",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -555,6 +705,12 @@ def targets():
     pycross_wheel_library(
         name = "decorator@5.1.1",
         wheel = ":_wheel_decorator@5.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -565,6 +721,12 @@ def targets():
     pycross_wheel_library(
         name = "defusedxml@0.7.1",
         wheel = ":_wheel_defusedxml@0.7.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _django_4_2_7_deps = [
@@ -581,6 +743,12 @@ def targets():
         name = "django@4.2.7",
         deps = _django_4_2_7_deps,
         wheel = ":_wheel_django@4.2.7",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _django_allauth_0_58_2_deps = [
@@ -618,6 +786,12 @@ def targets():
         name = "django-allauth@0.58.2",
         deps = _django_allauth_0_58_2_deps,
         wheel = ":_wheel_django-allauth@0.58.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _docker_6_1_3_deps = [
@@ -636,6 +810,12 @@ def targets():
         name = "docker@6.1.3",
         deps = _docker_6_1_3_deps,
         wheel = ":_wheel_docker@6.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -646,6 +826,12 @@ def targets():
     pycross_wheel_library(
         name = "docutils@0.20.1",
         wheel = ":_wheel_docutils@0.20.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ecdsa_0_18_0_deps = [
@@ -661,6 +847,12 @@ def targets():
         name = "ecdsa@0.18.0",
         deps = _ecdsa_0_18_0_deps,
         wheel = ":_wheel_ecdsa@0.18.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -671,6 +863,12 @@ def targets():
     pycross_wheel_library(
         name = "executing@2.0.1",
         wheel = ":_wheel_executing@2.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _flask_3_0_0_deps = [
@@ -690,6 +888,12 @@ def targets():
         name = "flask@3.0.0",
         deps = _flask_3_0_0_deps,
         wheel = ":_wheel_flask@3.0.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _flask_cors_4_0_0_deps = [
@@ -705,6 +909,12 @@ def targets():
         name = "flask-cors@4.0.0",
         deps = _flask_cors_4_0_0_deps,
         wheel = ":_wheel_flask-cors@4.0.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -719,6 +929,12 @@ def targets():
     pycross_wheel_library(
         name = "frozenlist@1.4.1",
         wheel = ":_wheel_frozenlist@1.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -734,6 +950,12 @@ def targets():
     pycross_wheel_library(
         name = "future@0.18.3",
         wheel = ":_wheel_future@0.18.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -744,6 +966,12 @@ def targets():
     pycross_wheel_library(
         name = "graphql-core@3.2.3",
         wheel = ":_wheel_graphql-core@3.2.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -758,6 +986,12 @@ def targets():
     pycross_wheel_library(
         name = "greenlet@3.0.1",
         wheel = ":_wheel_greenlet@3.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -768,6 +1002,12 @@ def targets():
     pycross_wheel_library(
         name = "idna@3.4",
         wheel = ":_wheel_idna@3.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -778,6 +1018,12 @@ def targets():
     pycross_wheel_library(
         name = "imagesize@1.4.1",
         wheel = ":_wheel_imagesize@1.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ipython_8_17_2_deps = [
@@ -808,6 +1054,12 @@ def targets():
         name = "ipython@8.17.2",
         deps = _ipython_8_17_2_deps,
         wheel = ":_wheel_ipython@8.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -818,6 +1070,12 @@ def targets():
     pycross_wheel_library(
         name = "itsdangerous@2.1.2",
         wheel = ":_wheel_itsdangerous@2.1.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jedi_0_19_1_deps = [
@@ -833,6 +1091,12 @@ def targets():
         name = "jedi@0.19.1",
         deps = _jedi_0_19_1_deps,
         wheel = ":_wheel_jedi@0.19.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jinja2_3_1_2_deps = [
@@ -848,6 +1112,12 @@ def targets():
         name = "jinja2@3.1.2",
         deps = _jinja2_3_1_2_deps,
         wheel = ":_wheel_jinja2@3.1.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -858,6 +1128,12 @@ def targets():
     pycross_wheel_library(
         name = "jmespath@1.0.1",
         wheel = ":_wheel_jmespath@1.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jschema_to_python_1_2_3_deps = [
@@ -875,6 +1151,12 @@ def targets():
         name = "jschema-to-python@1.2.3",
         deps = _jschema_to_python_1_2_3_deps,
         wheel = ":_wheel_jschema-to-python@1.2.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -885,6 +1167,12 @@ def targets():
     pycross_wheel_library(
         name = "jsondiff@2.0.0",
         wheel = ":_wheel_jsondiff@2.0.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jsonpatch_1_33_deps = [
@@ -900,6 +1188,12 @@ def targets():
         name = "jsonpatch@1.33",
         deps = _jsonpatch_1_33_deps,
         wheel = ":_wheel_jsonpatch@1.33",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -910,6 +1204,12 @@ def targets():
     pycross_wheel_library(
         name = "jsonpickle@3.0.2",
         wheel = ":_wheel_jsonpickle@3.0.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -920,6 +1220,12 @@ def targets():
     pycross_wheel_library(
         name = "jsonpointer@2.4",
         wheel = ":_wheel_jsonpointer@2.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jsonschema_4_19_2_deps = [
@@ -938,6 +1244,12 @@ def targets():
         name = "jsonschema@4.19.2",
         deps = _jsonschema_4_19_2_deps,
         wheel = ":_wheel_jsonschema@4.19.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jsonschema_path_0_3_1_deps = [
@@ -956,6 +1268,12 @@ def targets():
         name = "jsonschema-path@0.3.1",
         deps = _jsonschema_path_0_3_1_deps,
         wheel = ":_wheel_jsonschema-path@0.3.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jsonschema_specifications_2023_7_1_deps = [
@@ -971,6 +1289,12 @@ def targets():
         name = "jsonschema-specifications@2023.7.1",
         deps = _jsonschema_specifications_2023_7_1_deps,
         wheel = ":_wheel_jsonschema-specifications@2023.7.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _junit_xml_1_9_deps = [
@@ -986,6 +1310,12 @@ def targets():
         name = "junit-xml@1.9",
         deps = _junit_xml_1_9_deps,
         wheel = ":_wheel_junit-xml@1.9",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1012,6 +1342,12 @@ def targets():
     pycross_wheel_library(
         name = "lazy-object-proxy@1.9.0",
         wheel = ":_wheel_lazy-object-proxy@1.9.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1026,6 +1362,12 @@ def targets():
     pycross_wheel_library(
         name = "markupsafe@2.1.3",
         wheel = ":_wheel_markupsafe@2.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _matplotlib_inline_0_1_6_deps = [
@@ -1041,6 +1383,12 @@ def targets():
         name = "matplotlib-inline@0.1.6",
         deps = _matplotlib_inline_0_1_6_deps,
         wheel = ":_wheel_matplotlib-inline@0.1.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _moto_4_2_7_deps = [
@@ -1080,6 +1428,12 @@ def targets():
         name = "moto@4.2.7",
         deps = _moto_4_2_7_deps,
         wheel = ":_wheel_moto@4.2.7",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1090,6 +1444,12 @@ def targets():
     pycross_wheel_library(
         name = "mpmath@1.3.0",
         wheel = ":_wheel_mpmath@1.3.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1104,6 +1464,12 @@ def targets():
     pycross_wheel_library(
         name = "multidict@6.0.5",
         wheel = ":_wheel_multidict@6.0.5",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1114,6 +1480,12 @@ def targets():
     pycross_wheel_library(
         name = "multipart@0.2.4",
         wheel = ":_wheel_multipart@0.2.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1124,6 +1496,12 @@ def targets():
     pycross_wheel_library(
         name = "mypy-extensions@1.0.0",
         wheel = ":_wheel_mypy-extensions@1.0.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1134,6 +1512,12 @@ def targets():
     pycross_wheel_library(
         name = "networkx@3.2.1",
         wheel = ":_wheel_networkx@3.2.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1148,6 +1532,12 @@ def targets():
     pycross_wheel_library(
         name = "numpy@1.26.1",
         wheel = ":_wheel_numpy@1.26.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1158,6 +1548,12 @@ def targets():
     pycross_wheel_library(
         name = "oauthlib@3.2.2",
         wheel = ":_wheel_oauthlib@3.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _openapi_schema_validator_0_6_2_deps = [
@@ -1175,6 +1571,12 @@ def targets():
         name = "openapi-schema-validator@0.6.2",
         deps = _openapi_schema_validator_0_6_2_deps,
         wheel = ":_wheel_openapi-schema-validator@0.6.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _openapi_spec_validator_0_7_1_deps = [
@@ -1193,6 +1595,12 @@ def targets():
         name = "openapi-spec-validator@0.7.1",
         deps = _openapi_spec_validator_0_7_1_deps,
         wheel = ":_wheel_openapi-spec-validator@0.7.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1203,6 +1611,12 @@ def targets():
     pycross_wheel_library(
         name = "packaging@23.2",
         wheel = ":_wheel_packaging@23.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1213,6 +1627,12 @@ def targets():
     pycross_wheel_library(
         name = "pamqp@3.3.0",
         wheel = ":_wheel_pamqp@3.3.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1223,6 +1643,12 @@ def targets():
     pycross_wheel_library(
         name = "parso@0.8.3",
         wheel = ":_wheel_parso@0.8.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1233,6 +1659,12 @@ def targets():
     pycross_wheel_library(
         name = "pathable@0.4.3",
         wheel = ":_wheel_pathable@0.4.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1243,6 +1675,12 @@ def targets():
     pycross_wheel_library(
         name = "pathspec@0.11.2",
         wheel = ":_wheel_pathspec@0.11.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1271,6 +1709,12 @@ def targets():
     pycross_wheel_library(
         name = "pbr@6.0.0",
         wheel = ":_wheel_pbr@6.0.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pexpect_4_8_0_deps = [
@@ -1286,6 +1730,12 @@ def targets():
         name = "pexpect@4.8.0",
         deps = _pexpect_4_8_0_deps,
         wheel = ":_wheel_pexpect@4.8.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1296,6 +1746,12 @@ def targets():
     pycross_wheel_library(
         name = "platformdirs@3.11.0",
         wheel = ":_wheel_platformdirs@3.11.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _prompt_toolkit_3_0_39_deps = [
@@ -1311,6 +1767,12 @@ def targets():
         name = "prompt-toolkit@3.0.39",
         deps = _prompt_toolkit_3_0_39_deps,
         wheel = ":_wheel_prompt-toolkit@3.0.39",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1321,6 +1783,12 @@ def targets():
     pycross_wheel_library(
         name = "ptyprocess@0.7.0",
         wheel = ":_wheel_ptyprocess@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1331,6 +1799,12 @@ def targets():
     pycross_wheel_library(
         name = "pure-eval@0.2.2",
         wheel = ":_wheel_pure-eval@0.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1341,6 +1815,12 @@ def targets():
     pycross_wheel_library(
         name = "py-partiql-parser@0.4.1",
         wheel = ":_wheel_py-partiql-parser@0.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1351,6 +1831,12 @@ def targets():
     pycross_wheel_library(
         name = "pyasn1@0.5.0",
         wheel = ":_wheel_pyasn1@0.5.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1361,6 +1847,12 @@ def targets():
     pycross_wheel_library(
         name = "pycparser@2.21",
         wheel = ":_wheel_pycparser@2.21",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pydantic_2_4_2_deps = [
@@ -1378,6 +1870,12 @@ def targets():
         name = "pydantic@2.4.2",
         deps = _pydantic_2_4_2_deps,
         wheel = ":_wheel_pydantic@2.4.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pydantic_core_2_10_1_deps = [
@@ -1397,6 +1895,12 @@ def targets():
         name = "pydantic-core@2.10.1",
         deps = _pydantic_core_2_10_1_deps,
         wheel = ":_wheel_pydantic-core@2.10.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1407,6 +1911,12 @@ def targets():
     pycross_wheel_library(
         name = "pygments@2.16.1",
         wheel = ":_wheel_pygments@2.16.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pyjwt_2_8_0_deps = [
@@ -1422,6 +1932,12 @@ def targets():
         name = "pyjwt@2.8.0",
         deps = _pyjwt_2_8_0_deps,
         wheel = ":_wheel_pyjwt@2.8.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1432,6 +1948,12 @@ def targets():
     pycross_wheel_library(
         name = "pyparsing@3.1.1",
         wheel = ":_wheel_pyparsing@3.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _python_dateutil_2_8_2_deps = [
@@ -1447,6 +1969,12 @@ def targets():
         name = "python-dateutil@2.8.2",
         deps = _python_dateutil_2_8_2_deps,
         wheel = ":_wheel_python-dateutil@2.8.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _python_jose_3_3_0_deps = [
@@ -1465,6 +1993,12 @@ def targets():
         name = "python-jose@3.3.0",
         deps = _python_jose_3_3_0_deps,
         wheel = ":_wheel_python-jose@3.3.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _python3_openid_3_2_0_deps = [
@@ -1480,6 +2014,12 @@ def targets():
         name = "python3-openid@3.2.0",
         deps = _python3_openid_3_2_0_deps,
         wheel = ":_wheel_python3-openid@3.2.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1494,6 +2034,12 @@ def targets():
     pycross_wheel_library(
         name = "pyyaml@6.0.1",
         wheel = ":_wheel_pyyaml@6.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _referencing_0_30_2_deps = [
@@ -1510,6 +2056,12 @@ def targets():
         name = "referencing@0.30.2",
         deps = _referencing_0_30_2_deps,
         wheel = ":_wheel_referencing@0.30.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1524,6 +2076,12 @@ def targets():
     pycross_wheel_library(
         name = "regex@2023.10.3",
         wheel = ":_wheel_regex@2023.10.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _requests_2_31_0_deps = [
@@ -1542,6 +2100,12 @@ def targets():
         name = "requests@2.31.0",
         deps = _requests_2_31_0_deps,
         wheel = ":_wheel_requests@2.31.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _requests_oauthlib_1_3_1_deps = [
@@ -1558,6 +2122,12 @@ def targets():
         name = "requests-oauthlib@1.3.1",
         deps = _requests_oauthlib_1_3_1_deps,
         wheel = ":_wheel_requests-oauthlib@1.3.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _responses_0_24_0_deps = [
@@ -1575,6 +2145,12 @@ def targets():
         name = "responses@0.24.0",
         deps = _responses_0_24_0_deps,
         wheel = ":_wheel_responses@0.24.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _rfc3339_validator_0_1_4_deps = [
@@ -1590,6 +2166,12 @@ def targets():
         name = "rfc3339-validator@0.1.4",
         deps = _rfc3339_validator_0_1_4_deps,
         wheel = ":_wheel_rfc3339-validator@0.1.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1604,6 +2186,12 @@ def targets():
     pycross_wheel_library(
         name = "rpds-py@0.12.0",
         wheel = ":_wheel_rpds-py@0.12.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _rsa_4_9_deps = [
@@ -1619,6 +2207,12 @@ def targets():
         name = "rsa@4.9",
         deps = _rsa_4_9_deps,
         wheel = ":_wheel_rsa@4.9",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _s3transfer_0_7_0_deps = [
@@ -1634,6 +2228,12 @@ def targets():
         name = "s3transfer@0.7.0",
         deps = _s3transfer_0_7_0_deps,
         wheel = ":_wheel_s3transfer@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sarif_om_1_0_4_deps = [
@@ -1650,6 +2250,12 @@ def targets():
         name = "sarif-om@1.0.4",
         deps = _sarif_om_1_0_4_deps,
         wheel = ":_wheel_sarif-om@1.0.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1678,6 +2284,12 @@ def targets():
     pycross_wheel_library(
         name = "setproctitle@1.3.3",
         wheel = ":_wheel_setproctitle@1.3.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1688,6 +2300,12 @@ def targets():
     pycross_wheel_library(
         name = "setuptools@68.2.2",
         wheel = ":_wheel_setuptools@68.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1698,6 +2316,12 @@ def targets():
     pycross_wheel_library(
         name = "six@1.16.0",
         wheel = ":_wheel_six@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1708,6 +2332,12 @@ def targets():
     pycross_wheel_library(
         name = "snowballstemmer@2.2.0",
         wheel = ":_wheel_snowballstemmer@2.2.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sphinx_7_2_6_deps = [
@@ -1737,6 +2367,12 @@ def targets():
         name = "sphinx@7.2.6",
         deps = _sphinx_7_2_6_deps,
         wheel = ":_wheel_sphinx@7.2.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1747,6 +2383,12 @@ def targets():
     pycross_wheel_library(
         name = "sphinxcontrib-applehelp@1.0.7",
         wheel = ":_wheel_sphinxcontrib-applehelp@1.0.7",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1757,6 +2399,12 @@ def targets():
     pycross_wheel_library(
         name = "sphinxcontrib-devhelp@1.0.5",
         wheel = ":_wheel_sphinxcontrib-devhelp@1.0.5",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1767,6 +2415,12 @@ def targets():
     pycross_wheel_library(
         name = "sphinxcontrib-htmlhelp@2.0.4",
         wheel = ":_wheel_sphinxcontrib-htmlhelp@2.0.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1777,6 +2431,12 @@ def targets():
     pycross_wheel_library(
         name = "sphinxcontrib-jsmath@1.0.1",
         wheel = ":_wheel_sphinxcontrib-jsmath@1.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1787,6 +2447,12 @@ def targets():
     pycross_wheel_library(
         name = "sphinxcontrib-qthelp@1.0.6",
         wheel = ":_wheel_sphinxcontrib-qthelp@1.0.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1797,6 +2463,12 @@ def targets():
     pycross_wheel_library(
         name = "sphinxcontrib-serializinghtml@1.1.9",
         wheel = ":_wheel_sphinxcontrib-serializinghtml@1.1.9",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sqlalchemy_2_0_23_deps = [
@@ -1824,6 +2496,12 @@ def targets():
         name = "sqlalchemy@2.0.23",
         deps = _sqlalchemy_2_0_23_deps,
         wheel = ":_wheel_sqlalchemy@2.0.23",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sqlalchemy_utils_0_41_1_deps = [
@@ -1839,6 +2517,12 @@ def targets():
         name = "sqlalchemy-utils@0.41.1",
         deps = _sqlalchemy_utils_0_41_1_deps,
         wheel = ":_wheel_sqlalchemy-utils@0.41.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1849,6 +2533,12 @@ def targets():
     pycross_wheel_library(
         name = "sqlparse@0.4.4",
         wheel = ":_wheel_sqlparse@0.4.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sshpubkeys_3_3_1_deps = [
@@ -1865,6 +2555,12 @@ def targets():
         name = "sshpubkeys@3.3.1",
         deps = _sshpubkeys_3_3_1_deps,
         wheel = ":_wheel_sshpubkeys@3.3.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _stack_data_0_6_3_deps = [
@@ -1882,6 +2578,12 @@ def targets():
         name = "stack-data@0.6.3",
         deps = _stack_data_0_6_3_deps,
         wheel = ":_wheel_stack-data@0.6.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sympy_1_12_deps = [
@@ -1897,6 +2599,12 @@ def targets():
         name = "sympy@1.12",
         deps = _sympy_1_12_deps,
         wheel = ":_wheel_sympy@1.12",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1907,6 +2615,12 @@ def targets():
     pycross_wheel_library(
         name = "traitlets@5.13.0",
         wheel = ":_wheel_traitlets@5.13.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1921,6 +2635,12 @@ def targets():
     pycross_wheel_library(
         name = "tree-sitter@0.20.2",
         wheel = ":_wheel_tree-sitter@0.20.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1931,6 +2651,12 @@ def targets():
     pycross_wheel_library(
         name = "typing-extensions@4.8.0",
         wheel = ":_wheel_typing-extensions@4.8.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1941,6 +2667,12 @@ def targets():
     pycross_wheel_library(
         name = "urllib3@2.0.7",
         wheel = ":_wheel_urllib3@2.0.7",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1951,6 +2683,12 @@ def targets():
     pycross_wheel_library(
         name = "wcwidth@0.2.9",
         wheel = ":_wheel_wcwidth@0.2.9",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1961,6 +2699,12 @@ def targets():
     pycross_wheel_library(
         name = "websocket-client@1.6.4",
         wheel = ":_wheel_websocket-client@1.6.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _werkzeug_3_0_1_deps = [
@@ -1976,6 +2720,12 @@ def targets():
         name = "werkzeug@3.0.1",
         deps = _werkzeug_3_0_1_deps,
         wheel = ":_wheel_werkzeug@3.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1986,6 +2736,12 @@ def targets():
     pycross_wheel_library(
         name = "wheel@0.41.3",
         wheel = ":_wheel_wheel@0.41.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -2000,6 +2756,12 @@ def targets():
     pycross_wheel_library(
         name = "wrapt@1.15.0",
         wheel = ":_wheel_wrapt@1.15.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -2010,6 +2772,12 @@ def targets():
     pycross_wheel_library(
         name = "xmltodict@0.13.0",
         wheel = ":_wheel_xmltodict@0.13.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _yarl_1_9_4_deps = [
@@ -2030,6 +2798,12 @@ def targets():
         name = "yarl@1.9.4",
         deps = _yarl_1_9_4_deps,
         wheel = ":_wheel_yarl@1.9.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
 # buildifier: disable=unnamed-macro

--- a/examples/poetry/BUILD.bazel
+++ b/examples/poetry/BUILD.bazel
@@ -115,6 +115,11 @@ pycross_lock_file(
                 "wheel",
             ],
         ),
+        "numpy": package_annotation(
+            cc_deps = ["@rules_python//python/cc:current_py_cc_headers"],
+            cc_hdrs_globs = ["numpy/core/include/numpy/*.h"],
+            cc_includes = ["numpy/core/include"],
+        ),
     },
     default_alias_single_version = True,
     local_wheels = [
@@ -166,4 +171,10 @@ sh_binary(
     name = "update_example_lock",
     srcs = ["update.sh"],
     data = _GENERATED.values(),
+)
+
+cc_binary(
+    name = "depend_on_numpy",
+    srcs = ["depend_on_numpy.cc"],
+    deps = ["//deps:numpy"],
 )

--- a/examples/poetry/depend_on_numpy.cc
+++ b/examples/poetry/depend_on_numpy.cc
@@ -1,0 +1,4 @@
+#define NPY_NO_DEPRECATED_API 1
+#include "numpy/ndarrayobject.h"
+
+int main() {}

--- a/examples/poetry/example_lock.bzl
+++ b/examples/poetry/example_lock.bzl
@@ -160,6 +160,12 @@ def targets():
     pycross_wheel_library(
         name = "annotated-types@0.6.0",
         wheel = ":_wheel_annotated-types@0.6.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -170,6 +176,12 @@ def targets():
     pycross_wheel_library(
         name = "appnope@0.1.3",
         wheel = ":_wheel_appnope@0.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _asttokens_2_4_1_deps = [
@@ -185,6 +197,12 @@ def targets():
         name = "asttokens@2.4.1",
         deps = _asttokens_2_4_1_deps,
         wheel = ":_wheel_asttokens@2.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -195,6 +213,12 @@ def targets():
     pycross_wheel_library(
         name = "attrs@23.1.0",
         wheel = ":_wheel_attrs@23.1.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _aws_sam_translator_1_79_0_deps = [
@@ -213,6 +237,12 @@ def targets():
         name = "aws-sam-translator@1.79.0",
         deps = _aws_sam_translator_1_79_0_deps,
         wheel = ":_wheel_aws-sam-translator@1.79.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _aws_xray_sdk_2_12_1_deps = [
@@ -229,6 +259,12 @@ def targets():
         name = "aws-xray-sdk@2.12.1",
         deps = _aws_xray_sdk_2_12_1_deps,
         wheel = ":_wheel_aws-xray-sdk@2.12.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -239,6 +275,12 @@ def targets():
     pycross_wheel_library(
         name = "blinker@1.7.0",
         wheel = ":_wheel_blinker@1.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _boto3_1_28_80_deps = [
@@ -256,6 +298,12 @@ def targets():
         name = "boto3@1.28.80",
         deps = _boto3_1_28_80_deps,
         wheel = ":_wheel_boto3@1.28.80",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _botocore_1_31_80_deps = [
@@ -273,6 +321,12 @@ def targets():
         name = "botocore@1.31.80",
         deps = _botocore_1_31_80_deps,
         wheel = ":_wheel_botocore@1.31.80",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -283,6 +337,12 @@ def targets():
     pycross_wheel_library(
         name = "certifi@2023.7.22",
         wheel = ":_wheel_certifi@2023.7.22",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _cffi_1_16_0_deps = [
@@ -302,6 +362,12 @@ def targets():
         name = "cffi@1.16.0",
         deps = _cffi_1_16_0_deps,
         wheel = ":_wheel_cffi@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _cfn_lint_0_83_1_deps = [
@@ -326,6 +392,12 @@ def targets():
         name = "cfn-lint@0.83.1",
         deps = _cfn_lint_0_83_1_deps,
         wheel = ":_wheel_cfn-lint@0.83.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -340,6 +412,12 @@ def targets():
     pycross_wheel_library(
         name = "charset-normalizer@3.3.2",
         wheel = ":_wheel_charset-normalizer@3.3.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -350,6 +428,12 @@ def targets():
     pycross_wheel_library(
         name = "click@8.1.7",
         wheel = ":_wheel_click@8.1.7",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _cognitojwt_1_4_1_deps = [
@@ -365,6 +449,12 @@ def targets():
         name = "cognitojwt@1.4.1",
         deps = _cognitojwt_1_4_1_deps,
         wheel = ":_wheel_cognitojwt@1.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _cryptography_41_0_5_deps = [
@@ -384,6 +474,12 @@ def targets():
         name = "cryptography@41.0.5",
         deps = _cryptography_41_0_5_deps,
         wheel = ":_wheel_cryptography@41.0.5",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -398,6 +494,12 @@ def targets():
     pycross_wheel_library(
         name = "cython@0.29.36",
         wheel = ":_wheel_cython@0.29.36",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -408,6 +510,12 @@ def targets():
     pycross_wheel_library(
         name = "decorator@5.1.1",
         wheel = ":_wheel_decorator@5.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _docker_6_1_3_deps = [
@@ -426,6 +534,12 @@ def targets():
         name = "docker@6.1.3",
         deps = _docker_6_1_3_deps,
         wheel = ":_wheel_docker@6.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ecdsa_0_18_0_deps = [
@@ -441,6 +555,12 @@ def targets():
         name = "ecdsa@0.18.0",
         deps = _ecdsa_0_18_0_deps,
         wheel = ":_wheel_ecdsa@0.18.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -451,6 +571,12 @@ def targets():
     pycross_wheel_library(
         name = "executing@2.0.1",
         wheel = ":_wheel_executing@2.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _flask_3_0_0_deps = [
@@ -470,6 +596,12 @@ def targets():
         name = "flask@3.0.0",
         deps = _flask_3_0_0_deps,
         wheel = ":_wheel_flask@3.0.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _flask_cors_4_0_0_deps = [
@@ -485,6 +617,12 @@ def targets():
         name = "flask-cors@4.0.0",
         deps = _flask_cors_4_0_0_deps,
         wheel = ":_wheel_flask-cors@4.0.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -500,6 +638,12 @@ def targets():
     pycross_wheel_library(
         name = "future@0.18.2",
         wheel = ":_wheel_future@0.18.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -510,6 +654,12 @@ def targets():
     pycross_wheel_library(
         name = "graphql-core@3.2.3",
         wheel = ":_wheel_graphql-core@3.2.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -524,6 +674,12 @@ def targets():
     pycross_wheel_library(
         name = "greenlet@3.0.1",
         wheel = ":_wheel_greenlet@3.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -534,6 +690,12 @@ def targets():
     pycross_wheel_library(
         name = "idna@3.4",
         wheel = ":_wheel_idna@3.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _ipython_8_17_2_deps = [
@@ -564,6 +726,12 @@ def targets():
         name = "ipython@8.17.2",
         deps = _ipython_8_17_2_deps,
         wheel = ":_wheel_ipython@8.17.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -574,6 +742,12 @@ def targets():
     pycross_wheel_library(
         name = "itsdangerous@2.1.2",
         wheel = ":_wheel_itsdangerous@2.1.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jaraco_classes_3_3_0_deps = [
@@ -589,6 +763,12 @@ def targets():
         name = "jaraco-classes@3.3.0",
         deps = _jaraco_classes_3_3_0_deps,
         wheel = ":_wheel_jaraco-classes@3.3.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jedi_0_19_1_deps = [
@@ -604,6 +784,12 @@ def targets():
         name = "jedi@0.19.1",
         deps = _jedi_0_19_1_deps,
         wheel = ":_wheel_jedi@0.19.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -614,6 +800,12 @@ def targets():
     pycross_wheel_library(
         name = "jeepney@0.8.0",
         wheel = ":_wheel_jeepney@0.8.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jinja2_3_1_2_deps = [
@@ -629,6 +821,12 @@ def targets():
         name = "jinja2@3.1.2",
         deps = _jinja2_3_1_2_deps,
         wheel = ":_wheel_jinja2@3.1.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -639,6 +837,12 @@ def targets():
     pycross_wheel_library(
         name = "jmespath@1.0.1",
         wheel = ":_wheel_jmespath@1.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jschema_to_python_1_2_3_deps = [
@@ -656,6 +860,12 @@ def targets():
         name = "jschema-to-python@1.2.3",
         deps = _jschema_to_python_1_2_3_deps,
         wheel = ":_wheel_jschema-to-python@1.2.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -666,6 +876,12 @@ def targets():
     pycross_wheel_library(
         name = "jsondiff@2.0.0",
         wheel = ":_wheel_jsondiff@2.0.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jsonpatch_1_33_deps = [
@@ -681,6 +897,12 @@ def targets():
         name = "jsonpatch@1.33",
         deps = _jsonpatch_1_33_deps,
         wheel = ":_wheel_jsonpatch@1.33",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -691,6 +913,12 @@ def targets():
     pycross_wheel_library(
         name = "jsonpickle@3.0.2",
         wheel = ":_wheel_jsonpickle@3.0.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -701,6 +929,12 @@ def targets():
     pycross_wheel_library(
         name = "jsonpointer@2.4",
         wheel = ":_wheel_jsonpointer@2.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jsonschema_4_19_2_deps = [
@@ -719,6 +953,12 @@ def targets():
         name = "jsonschema@4.19.2",
         deps = _jsonschema_4_19_2_deps,
         wheel = ":_wheel_jsonschema@4.19.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jsonschema_path_0_3_1_deps = [
@@ -737,6 +977,12 @@ def targets():
         name = "jsonschema-path@0.3.1",
         deps = _jsonschema_path_0_3_1_deps,
         wheel = ":_wheel_jsonschema-path@0.3.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _jsonschema_specifications_2023_7_1_deps = [
@@ -752,6 +998,12 @@ def targets():
         name = "jsonschema-specifications@2023.7.1",
         deps = _jsonschema_specifications_2023_7_1_deps,
         wheel = ":_wheel_jsonschema-specifications@2023.7.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _junit_xml_1_9_deps = [
@@ -767,6 +1019,12 @@ def targets():
         name = "junit-xml@1.9",
         deps = _junit_xml_1_9_deps,
         wheel = ":_wheel_junit-xml@1.9",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _keyring_23_9_1_deps = [
@@ -788,6 +1046,12 @@ def targets():
         name = "keyring@23.9.1",
         deps = _keyring_23_9_1_deps,
         wheel = ":_wheel_keyring@23.9.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -814,6 +1078,12 @@ def targets():
     pycross_wheel_library(
         name = "lazy-object-proxy@1.9.0",
         wheel = ":_wheel_lazy-object-proxy@1.9.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -828,6 +1098,12 @@ def targets():
     pycross_wheel_library(
         name = "markupsafe@2.1.3",
         wheel = ":_wheel_markupsafe@2.1.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _matplotlib_inline_0_1_6_deps = [
@@ -843,6 +1119,12 @@ def targets():
         name = "matplotlib-inline@0.1.6",
         deps = _matplotlib_inline_0_1_6_deps,
         wheel = ":_wheel_matplotlib-inline@0.1.6",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -853,6 +1135,12 @@ def targets():
     pycross_wheel_library(
         name = "more-itertools@10.1.0",
         wheel = ":_wheel_more-itertools@10.1.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _moto_4_2_7_deps = [
@@ -892,6 +1180,12 @@ def targets():
         name = "moto@4.2.7",
         deps = _moto_4_2_7_deps,
         wheel = ":_wheel_moto@4.2.7",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -902,6 +1196,12 @@ def targets():
     pycross_wheel_library(
         name = "mpmath@1.3.0",
         wheel = ":_wheel_mpmath@1.3.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -912,6 +1212,12 @@ def targets():
     pycross_wheel_library(
         name = "multipart@0.2.4",
         wheel = ":_wheel_multipart@0.2.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -922,6 +1228,12 @@ def targets():
     pycross_wheel_library(
         name = "networkx@3.2.1",
         wheel = ":_wheel_networkx@3.2.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -936,6 +1248,15 @@ def targets():
     pycross_wheel_library(
         name = "numpy@1.26.1",
         wheel = ":_wheel_numpy@1.26.1",
+        cc_hdrs_globs = [
+            "numpy/core/include/numpy/*.h",
+        ],
+        cc_deps = [
+            "@rules_python//python/cc:current_py_cc_headers",
+        ],
+        cc_includes = [
+            "numpy/core/include",
+        ],
     )
 
     _openapi_schema_validator_0_6_2_deps = [
@@ -953,6 +1274,12 @@ def targets():
         name = "openapi-schema-validator@0.6.2",
         deps = _openapi_schema_validator_0_6_2_deps,
         wheel = ":_wheel_openapi-schema-validator@0.6.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _openapi_spec_validator_0_7_1_deps = [
@@ -971,6 +1298,12 @@ def targets():
         name = "openapi-spec-validator@0.7.1",
         deps = _openapi_spec_validator_0_7_1_deps,
         wheel = ":_wheel_openapi-spec-validator@0.7.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _opencv_python_4_6_0_66_deps = [
@@ -990,6 +1323,12 @@ def targets():
         name = "opencv-python@4.6.0.66",
         deps = _opencv_python_4_6_0_66_deps,
         wheel = ":_wheel_opencv-python@4.6.0.66",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1000,6 +1339,12 @@ def targets():
     pycross_wheel_library(
         name = "packaging@23.2",
         wheel = ":_wheel_packaging@23.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1010,6 +1355,12 @@ def targets():
     pycross_wheel_library(
         name = "parso@0.8.3",
         wheel = ":_wheel_parso@0.8.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1020,6 +1371,12 @@ def targets():
     pycross_wheel_library(
         name = "pathable@0.4.3",
         wheel = ":_wheel_pathable@0.4.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1048,6 +1405,12 @@ def targets():
     pycross_wheel_library(
         name = "pbr@6.0.0",
         wheel = ":_wheel_pbr@6.0.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pexpect_4_8_0_deps = [
@@ -1063,6 +1426,12 @@ def targets():
         name = "pexpect@4.8.0",
         deps = _pexpect_4_8_0_deps,
         wheel = ":_wheel_pexpect@4.8.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _prompt_toolkit_3_0_39_deps = [
@@ -1078,6 +1447,12 @@ def targets():
         name = "prompt-toolkit@3.0.39",
         deps = _prompt_toolkit_3_0_39_deps,
         wheel = ":_wheel_prompt-toolkit@3.0.39",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1088,6 +1463,12 @@ def targets():
     pycross_wheel_library(
         name = "ptyprocess@0.7.0",
         wheel = ":_wheel_ptyprocess@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1098,6 +1479,12 @@ def targets():
     pycross_wheel_library(
         name = "pure-eval@0.2.2",
         wheel = ":_wheel_pure-eval@0.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1108,6 +1495,12 @@ def targets():
     pycross_wheel_library(
         name = "py-partiql-parser@0.4.1",
         wheel = ":_wheel_py-partiql-parser@0.4.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1118,6 +1511,12 @@ def targets():
     pycross_wheel_library(
         name = "pyasn1@0.5.0",
         wheel = ":_wheel_pyasn1@0.5.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1128,6 +1527,12 @@ def targets():
     pycross_wheel_library(
         name = "pycparser@2.21",
         wheel = ":_wheel_pycparser@2.21",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pydantic_2_4_2_deps = [
@@ -1145,6 +1550,12 @@ def targets():
         name = "pydantic@2.4.2",
         deps = _pydantic_2_4_2_deps,
         wheel = ":_wheel_pydantic@2.4.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _pydantic_core_2_10_1_deps = [
@@ -1164,6 +1575,12 @@ def targets():
         name = "pydantic-core@2.10.1",
         deps = _pydantic_core_2_10_1_deps,
         wheel = ":_wheel_pydantic-core@2.10.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1174,6 +1591,12 @@ def targets():
     pycross_wheel_library(
         name = "pygments@2.16.1",
         wheel = ":_wheel_pygments@2.16.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1184,6 +1607,12 @@ def targets():
     pycross_wheel_library(
         name = "pyparsing@3.1.1",
         wheel = ":_wheel_pyparsing@3.1.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _python_dateutil_2_8_2_deps = [
@@ -1199,6 +1628,12 @@ def targets():
         name = "python-dateutil@2.8.2",
         deps = _python_dateutil_2_8_2_deps,
         wheel = ":_wheel_python-dateutil@2.8.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _python_jose_3_3_0_deps = [
@@ -1217,6 +1652,12 @@ def targets():
         name = "python-jose@3.3.0",
         deps = _python_jose_3_3_0_deps,
         wheel = ":_wheel_python-jose@3.3.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1231,6 +1672,12 @@ def targets():
     pycross_wheel_library(
         name = "pyyaml@6.0.1",
         wheel = ":_wheel_pyyaml@6.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _referencing_0_30_2_deps = [
@@ -1247,6 +1694,12 @@ def targets():
         name = "referencing@0.30.2",
         deps = _referencing_0_30_2_deps,
         wheel = ":_wheel_referencing@0.30.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1261,6 +1714,12 @@ def targets():
     pycross_wheel_library(
         name = "regex@2023.10.3",
         wheel = ":_wheel_regex@2023.10.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _requests_2_31_0_deps = [
@@ -1279,6 +1738,12 @@ def targets():
         name = "requests@2.31.0",
         deps = _requests_2_31_0_deps,
         wheel = ":_wheel_requests@2.31.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _responses_0_24_0_deps = [
@@ -1296,6 +1761,12 @@ def targets():
         name = "responses@0.24.0",
         deps = _responses_0_24_0_deps,
         wheel = ":_wheel_responses@0.24.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _rfc3339_validator_0_1_4_deps = [
@@ -1311,6 +1782,12 @@ def targets():
         name = "rfc3339-validator@0.1.4",
         deps = _rfc3339_validator_0_1_4_deps,
         wheel = ":_wheel_rfc3339-validator@0.1.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1325,6 +1802,12 @@ def targets():
     pycross_wheel_library(
         name = "rpds-py@0.12.0",
         wheel = ":_wheel_rpds-py@0.12.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _rsa_4_9_deps = [
@@ -1340,6 +1823,12 @@ def targets():
         name = "rsa@4.9",
         deps = _rsa_4_9_deps,
         wheel = ":_wheel_rsa@4.9",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _s3transfer_0_7_0_deps = [
@@ -1355,6 +1844,12 @@ def targets():
         name = "s3transfer@0.7.0",
         deps = _s3transfer_0_7_0_deps,
         wheel = ":_wheel_s3transfer@0.7.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sarif_om_1_0_4_deps = [
@@ -1371,6 +1866,12 @@ def targets():
         name = "sarif-om@1.0.4",
         deps = _sarif_om_1_0_4_deps,
         wheel = ":_wheel_sarif-om@1.0.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _secretstorage_3_3_3_deps = [
@@ -1387,6 +1888,12 @@ def targets():
         name = "secretstorage@3.3.3",
         deps = _secretstorage_3_3_3_deps,
         wheel = ":_wheel_secretstorage@3.3.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1415,6 +1922,12 @@ def targets():
     pycross_wheel_library(
         name = "setproctitle@1.3.3",
         wheel = ":_wheel_setproctitle@1.3.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1425,6 +1938,12 @@ def targets():
     pycross_wheel_library(
         name = "setuptools@68.2.2",
         wheel = ":_wheel_setuptools@68.2.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1435,6 +1954,12 @@ def targets():
     pycross_wheel_library(
         name = "six@1.16.0",
         wheel = ":_wheel_six@1.16.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sqlalchemy_2_0_23_deps = [
@@ -1462,6 +1987,12 @@ def targets():
         name = "sqlalchemy@2.0.23",
         deps = _sqlalchemy_2_0_23_deps,
         wheel = ":_wheel_sqlalchemy@2.0.23",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sqlalchemy_utils_0_41_1_deps = [
@@ -1477,6 +2008,12 @@ def targets():
         name = "sqlalchemy-utils@0.41.1",
         deps = _sqlalchemy_utils_0_41_1_deps,
         wheel = ":_wheel_sqlalchemy-utils@0.41.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sshpubkeys_3_3_1_deps = [
@@ -1493,6 +2030,12 @@ def targets():
         name = "sshpubkeys@3.3.1",
         deps = _sshpubkeys_3_3_1_deps,
         wheel = ":_wheel_sshpubkeys@3.3.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _stack_data_0_6_3_deps = [
@@ -1510,6 +2053,12 @@ def targets():
         name = "stack-data@0.6.3",
         deps = _stack_data_0_6_3_deps,
         wheel = ":_wheel_stack-data@0.6.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _sympy_1_12_deps = [
@@ -1525,6 +2074,12 @@ def targets():
         name = "sympy@1.12",
         deps = _sympy_1_12_deps,
         wheel = ":_wheel_sympy@1.12",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1535,6 +2090,12 @@ def targets():
     pycross_wheel_library(
         name = "traitlets@5.13.0",
         wheel = ":_wheel_traitlets@5.13.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1549,6 +2110,12 @@ def targets():
     pycross_wheel_library(
         name = "tree-sitter@0.20.2",
         wheel = ":_wheel_tree-sitter@0.20.2",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1559,6 +2126,12 @@ def targets():
     pycross_wheel_library(
         name = "typing-extensions@4.8.0",
         wheel = ":_wheel_typing-extensions@4.8.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1569,6 +2142,12 @@ def targets():
     pycross_wheel_library(
         name = "urllib3@2.0.7",
         wheel = ":_wheel_urllib3@2.0.7",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1579,6 +2158,12 @@ def targets():
     pycross_wheel_library(
         name = "wcwidth@0.2.9",
         wheel = ":_wheel_wcwidth@0.2.9",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1589,6 +2174,12 @@ def targets():
     pycross_wheel_library(
         name = "websocket-client@1.6.4",
         wheel = ":_wheel_websocket-client@1.6.4",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     _werkzeug_3_0_1_deps = [
@@ -1604,6 +2195,12 @@ def targets():
         name = "werkzeug@3.0.1",
         deps = _werkzeug_3_0_1_deps,
         wheel = ":_wheel_werkzeug@3.0.1",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1614,6 +2211,12 @@ def targets():
     pycross_wheel_library(
         name = "wheel@0.41.3",
         wheel = ":_wheel_wheel@0.41.3",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1628,6 +2231,12 @@ def targets():
     pycross_wheel_library(
         name = "wrapt@1.15.0",
         wheel = ":_wheel_wrapt@1.15.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
     native.alias(
@@ -1638,6 +2247,12 @@ def targets():
     pycross_wheel_library(
         name = "xmltodict@0.13.0",
         wheel = ":_wheel_xmltodict@0.13.0",
+        cc_hdrs_globs = [
+        ],
+        cc_deps = [
+        ],
+        cc_includes = [
+        ],
     )
 
 # buildifier: disable=unnamed-macro

--- a/pycross/private/bzlmod/lock_import.bzl
+++ b/pycross/private/bzlmod/lock_import.bzl
@@ -27,6 +27,9 @@ def _generate_resolved_lock_repo(lock_info, serialized_lock_model):
             build_target = str(package.build_target) if package.build_target else None,
             ignore_dependencies = package.ignore_dependencies,
             install_exclude_globs = package.install_exclude_globs,
+            cc_hdrs_globs = package.cc_hdrs_globs,
+            cc_deps = package.cc_deps,
+            cc_includes = package.cc_includes,
         )
 
     resolved_lock_repo(**args)

--- a/pycross/private/bzlmod/tag_attrs.bzl
+++ b/pycross/private/bzlmod/tag_attrs.bzl
@@ -58,6 +58,16 @@ PACKAGE_ATTRS = dict(
     install_exclude_globs = attr.string_list(
         doc = "A list of globs for files to exclude during installation.",
     ),
+    cc_hdrs_globs = attr.string_list(
+        doc = "A list of globs for files to use as C/C++ header files.",
+    ),
+    cc_deps = attr.label_list(
+        doc = "Dependencies for the C/C++ files.",
+        providers = [CcInfo],
+    ),
+    cc_includes = attr.string_list(
+        doc = "C/C++ include directories.",
+    ),
 )
 
 CREATE_ENVIRONMENTS_ATTRS = _CREATE_ENVIRONMENTS_ATTRS

--- a/pycross/private/lock_attrs.bzl
+++ b/pycross/private/lock_attrs.bzl
@@ -230,7 +230,10 @@ def package_annotation(
         build_dependencies = [],
         build_target = None,
         ignore_dependencies = [],
-        install_exclude_globs = []):
+        install_exclude_globs = [],
+        cc_hdrs_globs = [],
+        cc_deps = [],
+        cc_includes = []):
     """Annotations to apply to individual packages.
 
     Args:
@@ -239,6 +242,9 @@ def package_annotation(
       build_target (str, optional): An optional override build target to use when and if this package needs to be built from source.
       ignore_dependencies (list, optional): A list of package keys (name or name@version) to drop from this package's set of declared dependencies.
       install_exclude_globs (list, optional): A list of globs for files to exclude during installation.
+      cc_hdrs_globs (list, optional): A list of globs for files to use as C/C++ header files.
+      cc_deps (list, optional): Dependencies for the C/C++ files.
+      cc_includes (list, optional): C/C++ include directories.
 
     Returns:
       str: A json encoded string of the provided content.
@@ -249,4 +255,7 @@ def package_annotation(
         build_target = build_target,
         ignore_dependencies = ignore_dependencies,
         install_exclude_globs = install_exclude_globs,
+        cc_hdrs_globs = cc_hdrs_globs,
+        cc_deps = cc_deps,
+        cc_includes = cc_includes,
     ))

--- a/pycross/private/tools/lock_model.py
+++ b/pycross/private/tools/lock_model.py
@@ -230,6 +230,9 @@ class ResolvedPackage:
     environment_files: Dict[str, FileReference] = field(default_factory=dict)
     sdist_file: Optional[FileReference] = None
     install_exclude_globs: List[str] = field(default_factory=list)
+    cc_hdrs_globs: List[str] = field(default_factory=list)
+    cc_deps: List[str] = field(default_factory=list)
+    cc_includes: List[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/pycross/private/tools/raw_lock_resolver.py
+++ b/pycross/private/tools/raw_lock_resolver.py
@@ -195,6 +195,9 @@ class PackageAnnotations:
     always_build: bool = False
     ignore_dependencies: Set[str] = field(default_factory=set)
     install_exclude_globs: Set[str] = field(default_factory=set)
+    cc_hdrs_globs: Set[str] = field(default_factory=set)
+    cc_deps: Set[str] = field(default_factory=set)
+    cc_includes: Set[str] = field(default_factory=set)
 
 
 class PackageResolver:
@@ -213,6 +216,9 @@ class PackageResolver:
         self._build_deps = annotations.build_dependencies
         self._build_target = annotations.build_target
         self._install_exclude_globs = annotations.install_exclude_globs
+        self._cc_hdrs_globs = annotations.cc_hdrs_globs
+        self._cc_deps = annotations.cc_deps
+        self._cc_includes = annotations.cc_includes
 
         deps_by_env = context.get_dependencies_by_environment(
             package,
@@ -267,6 +273,9 @@ class PackageResolver:
             build_target=self._build_target,
             sdist_file=self.sdist_file,
             install_exclude_globs=list(self._install_exclude_globs),
+            cc_hdrs_globs=list(self._cc_hdrs_globs),
+            cc_deps=list(self._cc_deps),
+            cc_includes=list(self._cc_includes),
         )
 
 
@@ -344,6 +353,15 @@ def collect_package_annotations(args: Any, lock_model: RawLockSet) -> Dict[Packa
 
         for glob in annotation.get("install_exclude_globs", []):
             annotations[resolved_pkg].install_exclude_globs.add(glob)
+
+        for glob in annotation.get("cc_hdrs_globs", []):
+            annotations[resolved_pkg].cc_hdrs_globs.add(glob)
+
+        for dep in annotation.get("cc_deps", []):
+            annotations[resolved_pkg].cc_deps.add(dep)
+
+        for include in annotation.get("cc_includes", []):
+            annotations[resolved_pkg].cc_includes.add(include)
 
     # Return as a non-default dict
     return dict(annotations)

--- a/pycross/private/tools/resolved_lock_renderer.py
+++ b/pycross/private/tools/resolved_lock_renderer.py
@@ -357,6 +357,24 @@ class PackageTarget:
                 lines.append(ind(f'"{install_exclude_glob}",', 2))
             lines.append(ind("],"))
 
+        if self.package.cc_hdrs_globs is not None:
+            lines.append(ind("cc_hdrs_globs = ["))
+            for cc_hdrs_glob in self.package.cc_hdrs_globs:
+                lines.append(ind(f'"{cc_hdrs_glob}",', 2))
+            lines.append(ind("],"))
+
+        if self.package.cc_deps is not None:
+            lines.append(ind("cc_deps = ["))
+            for cc_dep in self.package.cc_deps:
+                lines.append(ind(f'"{cc_dep}",', 2))
+            lines.append(ind("],"))
+
+        if self.package.cc_includes is not None:
+            lines.append(ind("cc_includes = ["))
+            for cc_include in self.package.cc_includes:
+                lines.append(ind(f'"{cc_include}",', 2))
+            lines.append(ind("],"))
+
         lines.append(")")
 
         return "\n".join(lines)


### PR DESCRIPTION
Some Python libraries (`numpy` is the most common example) support C/C++ code depending on them directly. To build this C/C++ code with Bazel, we need to expose the header files.

Typically C/C++ code depending on headers from Python packages is going to be imported as other Python packages, so it does not link directly to any definitions for the APIs declared in the header files it uses. `cc_srcs` could be added alongside `cc_hdrs_globs` to enable this if there's a use case in the future.