### PR TITLE
fix(tools): pdm_translator whitespace bug

### DIFF
--- a/pycross/private/tools/pdm_translator.py
+++ b/pycross/private/tools/pdm_translator.py
@@ -260,10 +260,10 @@ def translate(
                     )
                     package.resolved_dependencies.add(resolved)
                     break
-            else:
-                raise MismatchedVersionException(
-                    f"Found no packages to satisfy dependency (name={dep.name}, spec={dep.specifier})"
-                )
+                else:
+                    raise MismatchedVersionException(
+                        f"Found no packages to satisfy dependency (name={dep.name}, spec={dep.specifier})"
+                    )
 
     pinned_keys: Dict[NormalizedName, PackageKey] = {}
     for pin, pin_spec in pinned_package_specs.items():


### PR DESCRIPTION
Fixes a dangling `else` off of a `for` loop. I think this was meant to be attached to [the inner `if` clause](https://github.com/jvolkman/rules_pycross/blob/d04a132ccffe6de04e00c5dee6c577ce90f04b90/pycross/private/tools/pdm_translator.py#L255).

Originally introduced in aaa6873cd0ede9219ae054cc0b29a31a1f555713

Python is the best :^)