### PR TITLE
fix: int() is not callable, better error message

### DIFF
--- a/pycross/private/repo_venv_utils.bzl
+++ b/pycross/private/repo_venv_utils.bzl
@@ -96,7 +96,7 @@ def create_venv(rctx, python_executable, venv_path, path_entries = []):
     ]
     result = rctx.execute(venv_args)
     if result.return_code:
-        fail("venv creation exited with {}".format(result.return_code()))
+        fail("venv creation exited with {}\n{}".format(result.return_code, result.stderr))
 
     if not venv_path.exists:
         fail("Failed to create virtual environment.")


### PR DESCRIPTION
`result.return_code` is an int

Also interpolate stderr from the subprocess