### PR TITLE
bugfix/issue-134-skip-path-dependencies

### DIFF
--- a/pycross/private/tools/poetry_translator.py
+++ b/pycross/private/tools/poetry_translator.py
@@ -121,6 +121,9 @@ def translate(project_file: Path, lock_file: Path) -> RawLockSet:
         if isinstance(pin_info, str):
             pinned_package_specs[pin] = parse_constraint(pin_info)
         else:
+            if "path" in pin_info:
+                # Skip path dependencies.
+                continue
             pinned_package_specs[pin] = parse_constraint(pin_info["version"])
 
     def parse_file_info(file_info) -> PackageFile:


### PR DESCRIPTION
Skip path dependencies in Poetry.

For example:

```toml
abc = { path = "../packages/abc" }
```

These don't make sense in a Bazel context anyway. 

Closes https://github.com/jvolkman/rules_pycross/issues/134