### PR TITLE
fix: Obtain default Python version for Python hub repo from versions.bzl file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Fixed
+
+- Obtain default Python version for Python hub repo from `versions.bzl` file, falling back to `interpreters.bzl` for backwards compatibility. `DEFAULT_PYTHON_VERSION` was [removed](https://github.com/bazelbuild/rules_python/blob/6a04d3832e82fec0a7b0675e9964b360bc358554/CHANGELOG.md?plain=1#L211) from `interpreters.bzl` in rules_python version 1.0.0.
+
 ## [0.6.1]
 
 ### Added


### PR DESCRIPTION
# Issue

`rules_python` 1.0.0 [removes](https://github.com/bazelbuild/rules_python/blob/6a04d3832e82fec0a7b0675e9964b360bc358554/CHANGELOG.md?plain=1#L211) the `DEFAULT_PYTHON_VERSION` constant from the Python hub repo's `interpreters.bzl` file. Instead, the version must be read from the `versions.bzl` file, introduced in `rules_python` 0.37.0.

As a result, creating a Python environment with `rules_pycross` (main branch) and `rules_python` 1.0.0 leads to the following error.
```text
INFO: Repository rules_pycross++environments+pycross_environments_myproject instantiated at:
  <builtin>: in <toplevel>
Repository rule pycross_environments_repo defined at:
  /private/var/tmp/_bazel_gabriel/17eb730aec70ae18dde0e6ba1d906dff/external/rules_pycross+/pycross/private/toolchain_helpers.bzl:430:44: in <toplevel>
ERROR: /private/var/tmp/_bazel_gabriel/17eb730aec70ae18dde0e6ba1d906dff/external/rules_pycross+/pycross/private/toolchain_helpers.bzl:221:9: An error occurred during the fetch of repository 'rules_pycross++environments+pycross_environments_myproject':
   Traceback (most recent call last):
        File "/private/var/tmp/_bazel_gabriel/17eb730aec70ae18dde0e6ba1d906dff/external/rules_pycross+/pycross/private/toolchain_helpers.bzl", line 390, column 44, in _pycross_environment_repo_impl
                version_info = _get_python_version_info(rctx)
        File "/private/var/tmp/_bazel_gabriel/17eb730aec70ae18dde0e6ba1d906dff/external/rules_pycross+/pycross/private/toolchain_helpers.bzl", line 350, column 65, in _get_python_version_info
                default_version = _get_default_python_version_bzlmod(rctx, rctx.attr.pythons_hub_repo)
        File "/private/var/tmp/_bazel_gabriel/17eb730aec70ae18dde0e6ba1d906dff/external/rules_pycross+/pycross/private/toolchain_helpers.bzl", line 221, column 9, in _get_default_python_version_bzlmod
                fail("Unable to determine default version for python hub repo '{}'".format(pythons_hub_repo))
Error in fail: Unable to determine default version for python hub repo '@@rules_python++python+pythons_hub//:pythons_hub'
ERROR: Error loading '@@rules_pycross+//pycross/extensions:lock_repos.bzl' for module extensions, requested by /Users/gabriel/Desktop/projects/myproject/MODULE.bazel:49:27: at /private/var/tmp/_bazel_gabriel/17eb730aec70ae18dde0e6ba1d906dff/external/rules_pycross+/pycross/extensions/lock_repos.bzl:3:6: at /private/var/tmp/_bazel_gabriel/17eb730aec70ae18dde0e6ba1d906dff/external/rules_pycross+/pycross/private/bzlmod/lock_repos.bzl:5:6: Encountered error while reading extension file 'locks.bzl': no such package '@@rules_pycross++lock_import+lock_import_repos_hub//': no such package '@@rules_pycross++environments+pycross_environments_myproject//': Unable to determine default version for python hub repo '@@rules_python++python+pythons_hub//:pythons_hub': at /private/var/tmp/_bazel_gabriel/17eb730aec70ae18dde0e6ba1d906dff/external/rules_pycross+/pycross/extensions/lock_repos.bzl:3:6: at /private/var/tmp/_bazel_gabriel/17eb730aec70ae18dde0e6ba1d906dff/external/rules_pycross+/pycross/private/bzlmod/lock_repos.bzl:5:6: Encountered error while reading extension file 'locks.bzl': no such package '@@rules_pycross++lock_import+lock_import_repos_hub//': no such package '@@rules_pycross++environments+pycross_environments_myproject//': Unable to determine default version for python hub repo '@@rules_python++python+pythons_hub//:pythons_hub'
INFO: Elapsed time: 2.988s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
FAILED: 
    Fetching module extension lock_import in @@rules_pycross+//pycross/extensions:lock_import.bzl; starting
```

# Solution
Read default Python version from `versions.bzl` file, if it exists, and fall back to `interpreters.bzl` otherwise.