### PR TITLE
feat: only consider Python versions that match a lock file's requires-python set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- When importing a lock file, only consider Python versions that match the lock file's
+  `requires-python` (or equivalent) set.
+
 ## [0.7.1]
 
 ### Added

--- a/e2e/pdm/always_build/MODULE.bazel
+++ b/e2e/pdm/always_build/MODULE.bazel
@@ -35,12 +35,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/pdm/build_wheel/MODULE.bazel
+++ b/e2e/pdm/build_wheel/MODULE.bazel
@@ -37,12 +37,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/pdm/local_wheel/MODULE.bazel
+++ b/e2e/pdm/local_wheel/MODULE.bazel
@@ -34,12 +34,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/pdm/requirements/MODULE.bazel
+++ b/e2e/pdm/requirements/MODULE.bazel
@@ -34,12 +34,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/poetry/always_build/MODULE.bazel
+++ b/e2e/poetry/always_build/MODULE.bazel
@@ -35,12 +35,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/poetry/build_wheel/MODULE.bazel
+++ b/e2e/poetry/build_wheel/MODULE.bazel
@@ -37,12 +37,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/poetry/local_wheel/MODULE.bazel
+++ b/e2e/poetry/local_wheel/MODULE.bazel
@@ -34,12 +34,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/poetry/requirements/MODULE.bazel
+++ b/e2e/poetry/requirements/MODULE.bazel
@@ -34,12 +34,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/uv/always_build/MODULE.bazel
+++ b/e2e/uv/always_build/MODULE.bazel
@@ -35,12 +35,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/uv/build_wheel/MODULE.bazel
+++ b/e2e/uv/build_wheel/MODULE.bazel
@@ -37,12 +37,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/uv/local_wheel/MODULE.bazel
+++ b/e2e/uv/local_wheel/MODULE.bazel
@@ -34,12 +34,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/e2e/uv/requirements/MODULE.bazel
+++ b/e2e/uv/requirements/MODULE.bazel
@@ -34,12 +34,6 @@ environments.create_for_python_toolchains(
         "aarch64-unknown-linux-gnu",
         "x86_64-unknown-linux-gnu",
     ],
-    python_versions = [
-        "3.10.11",
-        "3.11.6",
-        "3.12.0",
-        "3.12",
-    ],
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 

--- a/pycross/tests/uv/lock_0_2_35/expected.json
+++ b/pycross/tests/uv/lock_0_2_35/expected.json
@@ -712,5 +712,6 @@
   },
   "pins": {
     "regex": "regex@2024.11.6"
-  }
+  },
+  "python_versions": "<3.13,>=3.9"
 }

--- a/pycross/tests/uv/lock_0_4_0_virtual/expected.json
+++ b/pycross/tests/uv/lock_0_4_0_virtual/expected.json
@@ -712,5 +712,6 @@
   },
   "pins": {
     "regex": "regex@2024.11.6"
-  }
+  },
+  "python_versions": "<3.13,>=3.9"
 }

--- a/pycross/tests/uv/lock_0_4_27_legacy_dev_dependencies/expected.json
+++ b/pycross/tests/uv/lock_0_4_27_legacy_dev_dependencies/expected.json
@@ -577,5 +577,6 @@
   },
   "pins": {
     "regex": "regex@2024.11.6"
-  }
+  },
+  "python_versions": "<3.13,>=3.9"
 }

--- a/pycross/tests/uv/lock_0_4_27_pep735/expected.json
+++ b/pycross/tests/uv/lock_0_4_27_pep735/expected.json
@@ -577,5 +577,6 @@
   },
   "pins": {
     "regex": "regex@2024.11.6"
-  }
+  },
+  "python_versions": "<3.13,>=3.9"
 }

--- a/pycross/tests/uv/lock_pre_0_2_35/expected.json
+++ b/pycross/tests/uv/lock_pre_0_2_35/expected.json
@@ -712,5 +712,6 @@
   },
   "pins": {
     "regex": "regex@2024.11.6"
-  }
+  },
+  "python_versions": "<3.13,>=3.9"
 }


### PR DESCRIPTION
With this change, pycross will use an imported lock file's `requires-python` (or equivalent) specifier set to further filter the list of target Python environments. For example, if Python 3.8 is in the full list of target environments, but the imported lock file specifies '>=3.9', Python 3.8 environments will be filtered out.