### PR TITLE
Fix for: "Error in fail: Unknown platform: aarch64-apple-darwin-freethreaded"

### DIFF
--- a/pycross/private/toolchain_helpers.bzl
+++ b/pycross/private/toolchain_helpers.bzl
@@ -42,7 +42,7 @@ def _get_env_platforms(py_platform, glibc_version, musl_version, macos_version):
 
     platform_info = PLATFORMS[py_platform]
     arch = platform_info.arch
-    if py_platform.endswith("linux-gnu"):
+    if py_platform.endswith("linux-gnu") or py_platform.endswith("linux-gnu-freethreaded"):
         return ["linux_{}".format(arch)] + [
             "manylinux_2_{}_{}".format(i, arch)
             for i in range(5, glibc_micro + 1)
@@ -52,11 +52,11 @@ def _get_env_platforms(py_platform, glibc_version, musl_version, macos_version):
             "musllinux_{}_{}_{}".format(musl_major, micro, arch)
             for micro in range(musl_micro, -1, -1)
         ]
-    elif py_platform.endswith("darwin"):
+    elif py_platform.endswith("darwin") or py_platform.endswith("darwin-freethreaded"):
         if arch == "aarch64":
             arch = "arm64"
         return ["macosx_{}_{}_{}".format(macos_major, macos_micro, arch)]
-    elif py_platform.endswith("windows-msvc"):
+    elif py_platform.endswith("windows-msvc") or py_platform.endswith("windows-msvc-freethreaded"):
         return ["win_amd64"]
 
     fail("Unknown platform: {}".format(py_platform))


### PR DESCRIPTION
As seen here:
https://github.com/bazelbuild/rules_python/blob/b5729b41ef18393c2609aa1633607695175a7419/python/versions.bzl#L625-L696

some of the python platforms now end with `-freethreaded`. This makes my project [error](https://github.com/jvolkman/rules_pycross/blob/20fba49f17655c45f51e1bc293a329c8e1785abf/pycross/private/toolchain_helpers.bzl#L62) with:
```
Error in fail: Unknown platform: aarch64-apple-darwin-freethreaded
```
With the changes in this PR, the error goes away.

I'm not yet confident in my bazel and pycross skills to know if this is the best solution to the problem.