### PR TITLE
Passing pypi_index from pycross_lock_repo to package_repo

### DIFF
--- a/pycross/private/lock_repo.bzl
+++ b/pycross/private/lock_repo.bzl
@@ -28,4 +28,4 @@ def pycross_lock_repo(*, name, lock_model, **kwargs):
     resolved_lock_label = "@{}//:lock.json".format(resolved_repo_name)
 
     resolved_lock_repo(name = resolved_repo_name, **resolve_args)
-    package_repo(name = name, resolved_lock_file = resolved_lock_label, write_install_deps = True)
+    package_repo(name = name, resolved_lock_file = resolved_lock_label, write_install_deps = True, **render_args)


### PR DESCRIPTION
`render_args` was created in lock_repo to contain `CREATE_REPOS_ATTRS`, which includes `pypi_index`, but it was not passed to `package_repo`. Passing it to `package_repo` so we can configure `pypi_index`