### PR TITLE
fix: Check for existence of sdist wheel

### DIFF
--- a/pycross/private/package_repo.bzl
+++ b/pycross/private/package_repo.bzl
@@ -94,14 +94,15 @@ def _sdist_build(packages):
         "",
     ]
     for pkg in packages:
-        package_key = pkg["key"]
-        lines.extend([
-            "alias(",
-            '    name = "{}",'.format(package_key),
-            '    actual = "//_lock:_sdist_{}",'.format(package_key),
-            ")",
-            "",
-        ])
+        if pkg.get("sdist_file", {}).get("key"):
+            package_key = pkg["key"]
+            lines.extend([
+                "alias(",
+                '    name = "{}",'.format(package_key),
+                '    actual = "//_lock:_sdist_{}",'.format(package_key),
+                ")",
+                "",
+            ])
 
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
Some packages don't have sdist wheels. There are other places that check for this
(https://github.com/jvolkman/rules_pycross/blob/3e9e105d9d8a0853469be3c87067730322ceb34b/pycross/private/package_repo.bzl#L63) but it was missing here.