### PR TITLE
fix: Watch imported lockfiles for changes

### DIFF
--- a/pycross/private/pdm_lock_model.bzl
+++ b/pycross/private/pdm_lock_model.bzl
@@ -94,6 +94,7 @@ def repo_create_pdm_model(rctx, project_file, lock_file, lock_model, output):
         lock_model: a struct containing the same attrs as the pycross_pdm_lock_model rule.
         output: the output file.
     """
+    rctx.watch(lock_file)
     args = _handle_args(
         lock_model,
         str(rctx.path(project_file)),

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -79,6 +79,7 @@ def repo_create_poetry_model(rctx, project_file, lock_file, lock_model, output):
         lock_model: a struct containing the same attrs as the pycross_poetry_lock_model rule.
         output: the output file.
     """
+    rctx.watch(lock_file)
     args = _handle_args(
         lock_model,
         str(rctx.path(project_file)),

--- a/pycross/private/uv_lock_model.bzl
+++ b/pycross/private/uv_lock_model.bzl
@@ -95,6 +95,7 @@ def repo_create_uv_model(rctx, project_file, lock_file, lock_model, output):
         output: the output file.
     """
 
+    rctx.watch(lock_file)
     args = _handle_args(
         lock_model,
         str(rctx.path(project_file)),


### PR DESCRIPTION
In Bazel 8, --incompatible_no_implicit_watch_label[^1] was flipped on, meaning that Labels used in repository rules are not automatically watched for changes.

Lock files for lockfile imports should be watched for changes, so that the resulting pycross locks can get updated. Because project files aren't where the actual deps are pulled from, I chose to only add lock files.

[^1]: https://bazel.build/reference/command-line-reference#common_options-flag--incompatible_no_implicit_watch_label