### PR TITLE
fix: stringify keys when reporting sdist-only packages

### DIFF
--- a/pycross/private/tools/raw_lock_resolver.py
+++ b/pycross/private/tools/raw_lock_resolver.py
@@ -456,7 +456,7 @@ def resolve(args: Any) -> ResolvedLockSet:
         if builds:
             raise Exception(
                 "Builds are disallowed, but the following would include pycross_wheel_build targets: "
-                f"{', '.join(builds)}"
+                f"{', '.join(str(key) for key in builds)}"
             )
 
     repos: Dict[FileKey, PackageFile] = {}


### PR DESCRIPTION
Unfortunately `str.join` won't stringify elements in its argument, even when they have a `__str__`; we have to do it ourselves. Otherwise an exception is raised:

```
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_peter/dfecb8ec3f6f433d8509be7ebe017232/external/rules_pycross~/pycross/private/tools/raw_lock_resolver.py", line 579, in <module>
    main(parse_flags())
  File "/private/var/tmp/_bazel_peter/dfecb8ec3f6f433d8509be7ebe017232/external/rules_pycross~/pycross/private/tools/raw_lock_resolver.py", line 569, in main
    result = resolve(args)
             ^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_peter/dfecb8ec3f6f433d8509be7ebe017232/external/rules_pycross~/pycross/private/tools/raw_lock_resolver.py", line 455, in resolve
    f"{', '.join(builds)}"
       ^^^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, PackageKey found
```

Unlike other similar callsites in this file, there is no need to sort the builds; they're already sorted.