### PR TITLE
Mark more extensions as reproducible

### DIFF
--- a/pycross/private/bzlmod/BUILD.bazel
+++ b/pycross/private/bzlmod/BUILD.bazel
@@ -9,6 +9,7 @@ bzl_library(
     deps = [
         ":tag_attrs",
         "//pycross/private:toolchain_helpers",
+        "@bazel_features//:features",
         "@rules_pycross_internal//:defaults.bzl",
     ],
 )
@@ -21,6 +22,7 @@ bzl_library(
         "//pycross/private:internal_repo",
         "//pycross/private:pycross_deps.lock",
         "//pycross/private:pycross_deps_core.lock",
+        "@bazel_features//:features",
     ],
 )
 
@@ -53,6 +55,7 @@ bzl_library(
     srcs = ["toolchains.bzl"],
     deps = [
         "//pycross/private:toolchain_helpers",
+        "@bazel_features//:features",
     ],
 )
 
@@ -75,6 +78,7 @@ bzl_library(
         "//pycross/private:internal_repo",
         "//pycross/private:lock_file_repo",
         "//pycross/private:pypi_file",
+        "@bazel_features//:features",
     ] + REPO_HTTP_DEPS,
 )
 

--- a/pycross/private/bzlmod/environments.bzl
+++ b/pycross/private/bzlmod/environments.bzl
@@ -1,5 +1,6 @@
 """The environments extension creates target environment definitions."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load(
     "@rules_pycross_internal//:defaults.bzl",
     default_glibc_version = "glibc_version",
@@ -24,6 +25,10 @@ def _environments_impl(module_ctx):
                 musl_version = tag.musl_version or default_musl_version,
                 macos_version = tag.macos_version or default_macos_version,
             )
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    return module_ctx.extension_metadata()
 
 environments = module_extension(
     doc = "Create target environments.",

--- a/pycross/private/bzlmod/lock_file.bzl
+++ b/pycross/private/bzlmod/lock_file.bzl
@@ -1,5 +1,6 @@
 """The lock_file_repo extension creates repositories for an original-style Pycross .bzl lock."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("//pycross/private:internal_repo.bzl", "exec_internal_tool")
 load("//pycross/private:lock_file_repo.bzl", "pycross_lock_file_repo")
@@ -30,6 +31,10 @@ def _lock_file_impl(module_ctx):
 
             # Create the packages repo
             pycross_lock_file_repo(name = tag.name, lock_file = tag.lock_file)
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    return module_ctx.extension_metadata()
 
 # Tag classes
 _instantiate_tag = tag_class(

--- a/pycross/private/bzlmod/pycross.bzl
+++ b/pycross/private/bzlmod/pycross.bzl
@@ -1,5 +1,6 @@
 """Pycross internal deps."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//pycross/private:internal_repo.bzl", "create_internal_repo")
 load("//pycross/private:pycross_deps.lock.bzl", pypi_all_repositories = "repositories")
 load("//pycross/private:pycross_deps_core.lock.bzl", core_files = "FILES")
@@ -59,6 +60,10 @@ def _pycross_impl(module_ctx):
         wheels = core_files,
         **(environments_attrs | toolchains_attrs)
     )
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    return module_ctx.extension_metadata()
 
 pycross = module_extension(
     doc = "Configure rules_pycross.",

--- a/pycross/private/bzlmod/toolchains.bzl
+++ b/pycross/private/bzlmod/toolchains.bzl
@@ -1,5 +1,6 @@
 """Internal extension to create pycross toolchains."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load(
     "@rules_pycross_internal//:defaults.bzl",
     "register_toolchains",
@@ -27,6 +28,10 @@ def _toolchains_impl(module_ctx):
                 )
             else:
                 _empty_repo(name = tag.name)
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    return module_ctx.extension_metadata()
 
 toolchains = module_extension(
     doc = "Create toolchains.",


### PR DESCRIPTION
As far as I can tell these should be reproducible so this removes tons
from the MODULE.bazel.lock, in our case ~12k lines / 800k
