### PR TITLE
Set LDCXXSHARED

### DIFF
--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -339,6 +339,9 @@ def generate_cross_sysconfig_vars(
     sysconfig_vars["LDSHARED"] = " ".join([sysconfig_vars["CC"], sysconfig_vars["LDSHAREDFLAGS"]])
     del sysconfig_vars["LDSHAREDFLAGS"]
 
+    # https://github.com/pypa/distutils/issues/283
+    sysconfig_vars["LDCXXSHARED"] = sysconfig_vars["LDSHARED"]
+
     # Add search paths for listed native deps
     for include_path in include_paths:
         sysconfig_vars["CFLAGS"] += f" -I{include_path}"


### PR DESCRIPTION
Seems like aarch64 linux python 3.12 doesn't set this correctly with the latest setuptools so you end up hitting the issue linked in the comment