### PR TITLE
Add more module_ctx.watch calls

### DIFF
--- a/pycross/private/bzlmod/lock_file.bzl
+++ b/pycross/private/bzlmod/lock_file.bzl
@@ -16,6 +16,8 @@ def _lock_file_impl(module_ctx):
     for module in module_ctx.modules:
         for tag in module.tags.instantiate:
             path = module_ctx.path(tag.lock_file)
+            if hasattr(module_ctx, "watch"):
+                module_ctx.watch(tag.lock_file)
             result = exec_internal_tool(module_ctx, tool, [path], quiet = True)
             repos = json.decode(result.stdout)
 

--- a/pycross/private/lock_file_repo.bzl
+++ b/pycross/private/lock_file_repo.bzl
@@ -2,6 +2,8 @@
 
 def _pycross_lock_file_repo_impl(rctx):
     lock_file_label = rctx.attr.lock_file
+    if hasattr(rctx, "watch"):
+        rctx.watch(lock_file_label)
 
     rctx.file(rctx.path("requirements.bzl"), """\
 load("{lock_file}", "PINS", "repositories")


### PR DESCRIPTION
It seems like without these changing the generated bzl lockfile can
result in not reruning these rules and getting failures like:

```
ERROR: no such package '@@[unknown repo 'pycross_lock_file_wheel_mypy_1.16.1_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64' requested from @@rules_pycross++lock_file+modular_pip_lock_file_repo (did you mean 'pycross_lock_file_wheel_mypy_1.13.0_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64'?)]//file': The repository '@@[unknown repo 'pycross_lock_file_wheel_mypy_1.16.1_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64' requested from @@rules_pycross++lock_file+modular_pip_lock_file_repo (did you mean 'pycross_lock_file_wheel_mypy_1.13.0_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64'?)]' could not be resolved: No repository visible as '@pycross_lock_file_wheel_mypy_1.16.1_cp312_cp312_manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64' from repository '@@rules_pycross++lock_file+modular_pip_lock_file_repo'
```

Right after you introduced the new repo that should satisfy this error
