### PR TITLE
Add rctx.watch to python_interpreter target

### DIFF
--- a/pycross/private/internal_repo.bzl
+++ b/pycross/private/internal_repo.bzl
@@ -114,6 +114,8 @@ def _resolve_python_interpreter(rctx):
 
     if rctx.attr.python_interpreter_target != None:
         python_interpreter = rctx.path(rctx.attr.python_interpreter_target)
+        if hasattr(rctx, "watch"):
+            rctx.watch(python_interpreter)
     elif "/" not in python_interpreter:
         found_python_interpreter = rctx.which(python_interpreter)
         if not found_python_interpreter:


### PR DESCRIPTION
If you update rules_python this target can change, so it needs to be
watched with 8.x+
