### PR TITLE
Use File Alias Target for installer_whl Retrieval

### DIFF
--- a/pycross/private/internal_repo.bzl
+++ b/pycross/private/internal_repo.bzl
@@ -127,7 +127,8 @@ def _resolve_python_interpreter(rctx):
 def _installer_whl(wheels):
     for label, name in wheels.items():
         if name.startswith("installer-"):
-            return label
+            # use the exported alias label
+            return Label("@@" + label.repo_name + "//" + label.package)
     fail("Unable to find `installer` wheel in lock file.")
 
 def _pip_whl(wheels):


### PR DESCRIPTION
This change uses the exported alias :file instead of the unexported file (e.g. :installer-0.7.0-py3-none-any.whl) when retrieving the installer wheel. Currently the associated rules in this repo are not compatible with the `--incompatible_no_implicit_file_export` bazel flag due to this file reference.

Addresses issue - https://github.com/jvolkman/rules_pycross/issues/165 