### PR TITLE
Feat: Python version support for pycross_wheel_builder

### DIFF
--- a/pycross/private/wheel_build.bzl
+++ b/pycross/private/wheel_build.bzl
@@ -15,6 +15,7 @@ load(
 load(":providers.bzl", "PycrossWheelInfo")
 
 PYTHON_TOOLCHAIN_TYPE = Label("@rules_python//python:toolchain_type")
+PYTHON_VERSION_FLAG = "@rules_python//python/config_settings:python_version"
 PYCROSS_TOOLCHAIN_TYPE = Label("//pycross:toolchain_type")
 
 def _absolute_tool_value(workspace_name, value):
@@ -364,6 +365,19 @@ def _pycross_toolchains():
     else:
         return [PYTHON_TOOLCHAIN_TYPE] + use_cpp_toolchain()
 
+def _python_version_transition_impl(_, attr):
+    if attr.python_version:
+        return {
+            PYTHON_VERSION_FLAG: attr.python_version,
+        }
+    return {}
+
+python_version_transition = transition(
+    implementation = _python_version_transition_impl,
+    inputs = [],
+    outputs = [PYTHON_VERSION_FLAG],
+)
+
 pycross_wheel_build = rule(
     implementation = _pycross_wheel_build_impl,
     attrs = {
@@ -419,6 +433,10 @@ pycross_wheel_build = rule(
             ),
             cfg = "exec",
         ),
+        "python_version": attr.string(
+            doc = "The python version to use for building the wheel in X.Y or X.Y.Z format. " +
+                  "There must be a configured toolchain that matches the requested Python version.",
+        ),
         "copts": attr.string_list(
             doc = "Additional C compiler options.",
             default = [],
@@ -439,4 +457,5 @@ pycross_wheel_build = rule(
     toolchains = _pycross_toolchains(),
     fragments = ["cpp"],
     host_fragments = ["cpp"],
+    cfg = python_version_transition,
 )


### PR DESCRIPTION
**Context**

My team is looking to build wheels with multiple version of Python. We've been using the transition in this PR to add python_version support to the pycross_wheel_build rule. It uses the rules_python flag so that Bazel resolves the correct toolchain for the corresponding python_version. This only works for toolchains of type `@rules_python//python:toolchain_type` and not `//pycross:toolchain_type`.

Happy to add some tests and update the docs for this if it's something folks would be interested in.