### PR TITLE
Improve bin scripts shebangs

### DIFF
--- a/pycross/private/tools/wheel_installer.py
+++ b/pycross/private/tools/wheel_installer.py
@@ -86,7 +86,7 @@ def main(args: Any) -> None:
             "scripts": str(dest_dir / "bin"),
             "data": str(dest_dir / "data"),
         },
-        interpreter="/usr/bin/env python3",  # Generic; it's not feasible to run these scripts directly.
+        interpreter="python",  # Generic; it's not feasible to run these scripts directly.
         script_kind="posix",
         bytecode_optimization_levels=[],  # Setting to empty list to disable generation of .pyc files.
     )


### PR DESCRIPTION
This makes it easier to post process these scripts to make them actually
work with the correct interpreter, which is useful when copying them to
venvs. This new value follows pep-491

before:

```
#!/bin/sh
'''exec' '/usr/bin/env python3' "$0" "$@"
' '''
# -*- coding: utf-8 -*-
import re
import sys
from httpx import main
if __name__ == "__main__":
    sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
    sys.exit(main())
```

after:

```
#!python
# -*- coding: utf-8 -*-
import re
import sys
from httpx import main
if __name__ == "__main__":
    sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
    sys.exit(main())
```