### PR TITLE
Enable using the bazel resolved python interpreter for internal tools

### DIFF
--- a/docs/ext_pycross.md
+++ b/docs/ext_pycross.md
@@ -10,7 +10,7 @@ The lock_import extension.
 pycross = use_extension("@rules_pycross//pycross/extensions:pycross.bzl", "pycross")
 pycross.configure_environments(<a href="#pycross.configure_environments-glibc_version">glibc_version</a>, <a href="#pycross.configure_environments-macos_version">macos_version</a>, <a href="#pycross.configure_environments-musl_version">musl_version</a>, <a href="#pycross.configure_environments-platforms">platforms</a>,
                                <a href="#pycross.configure_environments-python_versions">python_versions</a>)
-pycross.configure_interpreter(<a href="#pycross.configure_interpreter-python_defs_file">python_defs_file</a>, <a href="#pycross.configure_interpreter-python_interpreter_target">python_interpreter_target</a>)
+pycross.configure_interpreter(<a href="#pycross.configure_interpreter-python_defs_file">python_defs_file</a>, <a href="#pycross.configure_interpreter-python_interpreter_target">python_interpreter_target</a>, <a href="#pycross.configure_interpreter-use_default">use_default</a>)
 pycross.configure_toolchains(<a href="#pycross.configure_toolchains-register_toolchains">register_toolchains</a>)
 </pre>
 
@@ -43,6 +43,7 @@ Configure rules_pycross.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="pycross.configure_interpreter-python_defs_file"></a>python_defs_file |  A label to a .bzl file that provides py_binary and py_test.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="pycross.configure_interpreter-python_interpreter_target"></a>python_interpreter_target |  The label to a python executable to use for invoking internal tools.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="pycross.configure_interpreter-use_default"></a>use_default |  Internal tools will use the default resolved Python toolchain when enabled.   | Boolean | optional |  `False`  |
 
 <a id="pycross.configure_toolchains"></a>
 

--- a/pycross/private/bzlmod/pycross.bzl
+++ b/pycross/private/bzlmod/pycross.bzl
@@ -38,16 +38,22 @@ def _pycross_impl(module_ctx):
     python_interpreter_target = None
     python_defs_file = None
 
-    if interpreter_tag.python_interpreter_target:
-        python_interpreter_target = interpreter_tag.python_interpreter_target
+    if interpreter_tag.use_default:
+        if interpreter_tag.python_interpreter_target or interpreter_tag.python_defs_file:
+            fail(
+                "When use_default is true, python_interpreter_target and python_defs_file must not be set",
+            )
+    else:
+        if interpreter_tag.python_interpreter_target:
+            python_interpreter_target = interpreter_tag.python_interpreter_target
 
-    if interpreter_tag.python_defs_file:
-        python_defs_file = interpreter_tag.python_defs_file
+        if interpreter_tag.python_defs_file:
+            python_defs_file = interpreter_tag.python_defs_file
 
-    if not python_interpreter_target or not python_defs_file:
-        fail(
-            "Both python_interpreter_target and python_defs_file must be set",
-        )
+        if not python_interpreter_target or not python_defs_file:
+            fail(
+                "Both python_interpreter_target and python_defs_file must be set",
+            )
 
     pypi_all_repositories()
 
@@ -80,6 +86,7 @@ pycross = module_extension(
                 "python_defs_file": attr.label(
                     doc = "A label to a .bzl file that provides py_binary and py_test.",
                 ),
+                "use_default": attr.bool(doc = "Internal tools will use the default resolved Python toolchain when enabled."),
             },
         ),
         "configure_toolchains": tag_class(


### PR DESCRIPTION
Currently when configuring rules_pycross with bzlmod, users have two choices. Either specify a valid python interpreter and defs.bzl file, or fallback to using python 3.12 as defined in MODULE.bazel. This introduces the option to opt out (this is already possible when using Workspaces), and instead let bazel resolve the correct python toolchain when invoking internal tools. 

This is useful when the user is specifying python_version, or if they are using a custom Python toolchain.