### PR TITLE
Update pycross internal build deps and internal Python version

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,11 @@
 [metadata]
 groups = ["default", "build", "core", "repairwheel"]
 strategy = ["cross_platform", "static_urls"]
-lock_version = "4.4.1"
-content_hash = "sha256:58210034e1d6e749f0a0d1e8670a6c7cb706a794bdb7d9ebcee61df42a3d29fc"
+lock_version = "4.5.0"
+content_hash = "sha256:fd3f7fdd842b82f541e4ddb7faec056f09217aeb6f541185021a1764befc1563"
+
+[[metadata.targets]]
+requires_python = ">=3.9"
 
 [[package]]
 name = "altgraph"
@@ -18,19 +21,19 @@ files = [
 
 [[package]]
 name = "build"
-version = "1.0.3"
-requires_python = ">= 3.7"
+version = "1.3.0"
+requires_python = ">=3.9"
 summary = "A simple, correct Python build frontend"
 dependencies = [
     "colorama; os_name == \"nt\"",
-    "importlib-metadata>=4.6; python_version < \"3.10\"",
-    "packaging>=19.0",
+    "importlib-metadata>=4.6; python_full_version < \"3.10.2\"",
+    "packaging>=19.1",
     "pyproject-hooks",
     "tomli>=1.1.0; python_version < \"3.11\"",
 ]
 files = [
-    {url = "https://files.pythonhosted.org/packages/93/dd/b464b728b866aaa62785a609e0dd8c72201d62c5f7c53e7c20f4dceb085f/build-1.0.3-py3-none-any.whl", hash = "sha256:589bf99a67df7c9cf07ec0ac0e5e2ea5d4b37ac63301c4986d1acb126aa83f8f"},
-    {url = "https://files.pythonhosted.org/packages/98/e3/83a89a9d338317f05a68c86a2bbc9af61235bc55a0c6a749d37598fb2af1/build-1.0.3.tar.gz", hash = "sha256:538aab1b64f9828977f84bc63ae570b060a8ed1be419e7870b8b4fc5e6ea553b"},
+    {url = "https://files.pythonhosted.org/packages/25/1c/23e33405a7c9eac261dff640926b8b5adaed6a6eb3e1767d441ed611d0c0/build-1.3.0.tar.gz", hash = "sha256:698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397"},
+    {url = "https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl", hash = "sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4"},
 ]
 
 [[package]]
@@ -55,28 +58,28 @@ files = [
 
 [[package]]
 name = "delvewheel"
-version = "1.6.0"
-requires_python = ">=3.7"
+version = "1.11.1"
+requires_python = ">=3.9"
 summary = "Self-contained wheels for Windows"
 dependencies = [
-    "pefile",
+    "pefile>=2024.8.26",
 ]
 files = [
-    {url = "https://files.pythonhosted.org/packages/24/f7/35e5657954452f6c221969e67a7c69433b1f230dc076cf49e5a9186a7fd4/delvewheel-1.6.0-py3-none-any.whl", hash = "sha256:15be02e749caacafdd51c283175a041a3f467484a1a96fc2d36340ced6869bff"},
-    {url = "https://files.pythonhosted.org/packages/78/20/c62d194a3ad524d2f26687a908d5cb621d4f0695af23778a1d65f314050e/delvewheel-1.6.0.tar.gz", hash = "sha256:fb2bfc91183330297898992a6b25bde8b1c542f73c4242b73cbef9c747ebcd9b"},
+    {url = "https://files.pythonhosted.org/packages/6f/fb/50b5449234125677fb137ff9cf58a0945914a90888652d086b7a9a279233/delvewheel-1.11.1.tar.gz", hash = "sha256:1d0f0b9f2a8970ed1aa85b833768e05793f1ec3c53ab75b3e7d6400ea5b9b356"},
+    {url = "https://files.pythonhosted.org/packages/74/fb/f0a368040e51079d6e2827ce5dd8c27cc3a1182cfd5b7db2d9f9c7c0a834/delvewheel-1.11.1-py3-none-any.whl", hash = "sha256:dcb9e16cea3fa9df86e992c43c975e86ac8f64bce903968bc4dbfb197b673bab"},
 ]
 
 [[package]]
 name = "importlib-metadata"
-version = "7.1.0"
-requires_python = ">=3.8"
+version = "8.7.0"
+requires_python = ">=3.9"
 summary = "Read metadata from Python packages"
 dependencies = [
-    "zipp>=0.5",
+    "zipp>=3.20",
 ]
 files = [
-    {url = "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
-    {url = "https://files.pythonhosted.org/packages/a0/fc/c4e6078d21fc4fa56300a241b87eae76766aa380a23fc450fc85bb7bf547/importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
+    {url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
+    {url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
 ]
 
 [[package]]
@@ -113,12 +116,12 @@ files = [
 
 [[package]]
 name = "pefile"
-version = "2023.2.7"
+version = "2024.8.26"
 requires_python = ">=3.6.0"
 summary = "Python PE parsing module"
 files = [
-    {url = "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl", hash = "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6"},
-    {url = "https://files.pythonhosted.org/packages/78/c5/3b3c62223f72e2360737fd2a57c30e5b2adecd85e70276879609a7403334/pefile-2023.2.7.tar.gz", hash = "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc"},
+    {url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632"},
+    {url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f"},
 ]
 
 [[package]]
@@ -143,21 +146,21 @@ files = [
 
 [[package]]
 name = "pyelftools"
-version = "0.31"
+version = "0.32"
 summary = "Library for analyzing ELF files and DWARF debugging information"
 files = [
-    {url = "https://files.pythonhosted.org/packages/88/56/0f2d69ed9a0060da009f672ddec8a71c041d098a66f6b1d80264bf6bbdc0/pyelftools-0.31.tar.gz", hash = "sha256:c774416b10310156879443b81187d182d8d9ee499660380e645918b50bc88f99"},
-    {url = "https://files.pythonhosted.org/packages/f8/64/711030d9fe9ccaf6ee3ab1bcf4801c6bb3d0e585af18824a50b016b4f39c/pyelftools-0.31-py3-none-any.whl", hash = "sha256:f52de7b3c7e8c64c8abc04a79a1cf37ac5fb0b8a49809827130b858944840607"},
+    {url = "https://files.pythonhosted.org/packages/af/43/700932c4f0638c3421177144a2e86448c0d75dbaee2c7936bda3f9fd0878/pyelftools-0.32-py3-none-any.whl", hash = "sha256:013df952a006db5e138b1edf6d8a68ecc50630adbd0d83a2d41e7f846163d738"},
+    {url = "https://files.pythonhosted.org/packages/b9/ab/33968940b2deb3d92f5b146bc6d4009a5f95d1d06c148ea2f9ee965071af/pyelftools-0.32.tar.gz", hash = "sha256:6de90ee7b8263e740c8715a925382d4099b354f29ac48ea40d840cf7aa14ace5"},
 ]
 
 [[package]]
 name = "pyproject-hooks"
-version = "1.1.0"
+version = "1.2.0"
 requires_python = ">=3.7"
 summary = "Wrappers to call pyproject.toml-based build backend hooks."
 files = [
-    {url = "https://files.pythonhosted.org/packages/ae/f3/431b9d5fe7d14af7a32340792ef43b8a714e7726f1d7b69cc4e8e7a3f1d7/pyproject_hooks-1.1.0-py3-none-any.whl", hash = "sha256:7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2"},
-    {url = "https://files.pythonhosted.org/packages/c7/07/6f63dda440d4abb191b91dc383b472dae3dd9f37e4c1e4a5c3db150531c6/pyproject_hooks-1.1.0.tar.gz", hash = "sha256:4b37730834edbd6bd37f26ece6b44802fb1c1ee2ece0e54ddff8bfc06db86965"},
+    {url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"},
+    {url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"},
 ]
 
 [[package]]
@@ -189,10 +192,10 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.19.2"
-requires_python = ">=3.8"
+version = "3.23.0"
+requires_python = ">=3.9"
 summary = "Backport of pathlib-compatible object wrapper for zip files"
 files = [
-    {url = "https://files.pythonhosted.org/packages/20/38/f5c473fe9b90c8debdd29ea68d5add0289f1936d6f923b6b9cc0b931194c/zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},
-    {url = "https://files.pythonhosted.org/packages/d3/20/b48f58857d98dcb78f9e30ed2cfe533025e2e9827bbd36ea0a64cc00cbc1/zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19"},
+    {url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
+    {url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
 ]

--- a/pycross/private/BUILD.bazel
+++ b/pycross/private/BUILD.bazel
@@ -183,7 +183,7 @@ bzl_library(
 pycross_target_environment(
     name = "rules_pycross_deps_target_env",
     python_compatible_with = [],
-    version = "3.8.0",
+    version = "3.9.0",
     visibility = ["//visibility:public"],
 )
 

--- a/pycross/private/pycross_deps.lock.bzl
+++ b/pycross/private/pycross_deps.lock.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//pycross:defs.bzl", "pycross_wheel_library")
 
 PINS = {
-    "build": "build@1.0.3",
+    "build": "build@1.3.0",
     "dacite": "dacite@1.6.0",
     "installer": "installer@0.7.0",
     "packaging": "packaging@23.2",
@@ -46,22 +46,22 @@ def targets():
         wheel = ":_wheel_altgraph@0.17.4",
     )
 
-    _build_1_0_3_deps = [
-        ":importlib-metadata@7.1.0",
+    _build_1_3_0_deps = [
+        ":importlib-metadata@8.7.0",
         ":packaging@23.2",
-        ":pyproject-hooks@1.1.0",
+        ":pyproject-hooks@1.2.0",
         ":tomli@2.0.1",
     ]
 
     native.alias(
-        name = "_wheel_build@1.0.3",
-        actual = "@rules_pycross_internal_deps_wheel_build_1.0.3_py3_none_any//file",
+        name = "_wheel_build@1.3.0",
+        actual = "@rules_pycross_internal_deps_wheel_build_1.3.0_py3_none_any//file",
     )
 
     pycross_wheel_library(
-        name = "build@1.0.3",
-        deps = _build_1_0_3_deps,
-        wheel = ":_wheel_build@1.0.3",
+        name = "build@1.3.0",
+        deps = _build_1_3_0_deps,
+        wheel = ":_wheel_build@1.3.0",
     )
 
     native.alias(
@@ -74,34 +74,34 @@ def targets():
         wheel = ":_wheel_dacite@1.6.0",
     )
 
-    _delvewheel_1_6_0_deps = [
-        ":pefile@2023.2.7",
+    _delvewheel_1_11_1_deps = [
+        ":pefile@2024.8.26",
     ]
 
     native.alias(
-        name = "_wheel_delvewheel@1.6.0",
-        actual = "@rules_pycross_internal_deps_wheel_delvewheel_1.6.0_py3_none_any//file",
+        name = "_wheel_delvewheel@1.11.1",
+        actual = "@rules_pycross_internal_deps_wheel_delvewheel_1.11.1_py3_none_any//file",
     )
 
     pycross_wheel_library(
-        name = "delvewheel@1.6.0",
-        deps = _delvewheel_1_6_0_deps,
-        wheel = ":_wheel_delvewheel@1.6.0",
+        name = "delvewheel@1.11.1",
+        deps = _delvewheel_1_11_1_deps,
+        wheel = ":_wheel_delvewheel@1.11.1",
     )
 
-    _importlib_metadata_7_1_0_deps = [
-        ":zipp@3.19.2",
+    _importlib_metadata_8_7_0_deps = [
+        ":zipp@3.23.0",
     ]
 
     native.alias(
-        name = "_wheel_importlib-metadata@7.1.0",
-        actual = "@rules_pycross_internal_deps_wheel_importlib_metadata_7.1.0_py3_none_any//file",
+        name = "_wheel_importlib-metadata@8.7.0",
+        actual = "@rules_pycross_internal_deps_wheel_importlib_metadata_8.7.0_py3_none_any//file",
     )
 
     pycross_wheel_library(
-        name = "importlib-metadata@7.1.0",
-        deps = _importlib_metadata_7_1_0_deps,
-        wheel = ":_wheel_importlib-metadata@7.1.0",
+        name = "importlib-metadata@8.7.0",
+        deps = _importlib_metadata_8_7_0_deps,
+        wheel = ":_wheel_importlib-metadata@8.7.0",
     )
 
     native.alias(
@@ -140,13 +140,13 @@ def targets():
     )
 
     native.alias(
-        name = "_wheel_pefile@2023.2.7",
-        actual = "@rules_pycross_internal_deps_wheel_pefile_2023.2.7_py3_none_any//file",
+        name = "_wheel_pefile@2024.8.26",
+        actual = "@rules_pycross_internal_deps_wheel_pefile_2024.8.26_py3_none_any//file",
     )
 
     pycross_wheel_library(
-        name = "pefile@2023.2.7",
-        wheel = ":_wheel_pefile@2023.2.7",
+        name = "pefile@2024.8.26",
+        wheel = ":_wheel_pefile@2024.8.26",
     )
 
     native.alias(
@@ -170,31 +170,31 @@ def targets():
     )
 
     native.alias(
-        name = "_wheel_pyelftools@0.31",
-        actual = "@rules_pycross_internal_deps_wheel_pyelftools_0.31_py3_none_any//file",
+        name = "_wheel_pyelftools@0.32",
+        actual = "@rules_pycross_internal_deps_wheel_pyelftools_0.32_py3_none_any//file",
     )
 
     pycross_wheel_library(
-        name = "pyelftools@0.31",
-        wheel = ":_wheel_pyelftools@0.31",
+        name = "pyelftools@0.32",
+        wheel = ":_wheel_pyelftools@0.32",
     )
 
     native.alias(
-        name = "_wheel_pyproject-hooks@1.1.0",
-        actual = "@rules_pycross_internal_deps_wheel_pyproject_hooks_1.1.0_py3_none_any//file",
+        name = "_wheel_pyproject-hooks@1.2.0",
+        actual = "@rules_pycross_internal_deps_wheel_pyproject_hooks_1.2.0_py3_none_any//file",
     )
 
     pycross_wheel_library(
-        name = "pyproject-hooks@1.1.0",
-        wheel = ":_wheel_pyproject-hooks@1.1.0",
+        name = "pyproject-hooks@1.2.0",
+        wheel = ":_wheel_pyproject-hooks@1.2.0",
     )
 
     _repairwheel_0_3_1_deps = [
-        ":delvewheel@1.6.0",
+        ":delvewheel@1.11.1",
         ":macholib@1.16.3",
         ":packaging@23.2",
-        ":pefile@2023.2.7",
-        ":pyelftools@0.31",
+        ":pefile@2024.8.26",
+        ":pyelftools@0.32",
     ]
 
     native.alias(
@@ -219,13 +219,13 @@ def targets():
     )
 
     native.alias(
-        name = "_wheel_zipp@3.19.2",
-        actual = "@rules_pycross_internal_deps_wheel_zipp_3.19.2_py3_none_any//file",
+        name = "_wheel_zipp@3.23.0",
+        actual = "@rules_pycross_internal_deps_wheel_zipp_3.23.0_py3_none_any//file",
     )
 
     pycross_wheel_library(
-        name = "zipp@3.19.2",
-        wheel = ":_wheel_zipp@3.19.2",
+        name = "zipp@3.23.0",
+        wheel = ":_wheel_zipp@3.23.0",
     )
 
 # buildifier: disable=unnamed-macro
@@ -244,12 +244,12 @@ def repositories():
 
     maybe(
         http_file,
-        name = "rules_pycross_internal_deps_wheel_build_1.0.3_py3_none_any",
+        name = "rules_pycross_internal_deps_wheel_build_1.3.0_py3_none_any",
         urls = [
-            "https://files.pythonhosted.org/packages/93/dd/b464b728b866aaa62785a609e0dd8c72201d62c5f7c53e7c20f4dceb085f/build-1.0.3-py3-none-any.whl",
+            "https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl",
         ],
-        sha256 = "589bf99a67df7c9cf07ec0ac0e5e2ea5d4b37ac63301c4986d1acb126aa83f8f",
-        downloaded_file_path = "build-1.0.3-py3-none-any.whl",
+        sha256 = "7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4",
+        downloaded_file_path = "build-1.3.0-py3-none-any.whl",
     )
 
     maybe(
@@ -264,22 +264,22 @@ def repositories():
 
     maybe(
         http_file,
-        name = "rules_pycross_internal_deps_wheel_delvewheel_1.6.0_py3_none_any",
+        name = "rules_pycross_internal_deps_wheel_delvewheel_1.11.1_py3_none_any",
         urls = [
-            "https://files.pythonhosted.org/packages/24/f7/35e5657954452f6c221969e67a7c69433b1f230dc076cf49e5a9186a7fd4/delvewheel-1.6.0-py3-none-any.whl",
+            "https://files.pythonhosted.org/packages/74/fb/f0a368040e51079d6e2827ce5dd8c27cc3a1182cfd5b7db2d9f9c7c0a834/delvewheel-1.11.1-py3-none-any.whl",
         ],
-        sha256 = "15be02e749caacafdd51c283175a041a3f467484a1a96fc2d36340ced6869bff",
-        downloaded_file_path = "delvewheel-1.6.0-py3-none-any.whl",
+        sha256 = "dcb9e16cea3fa9df86e992c43c975e86ac8f64bce903968bc4dbfb197b673bab",
+        downloaded_file_path = "delvewheel-1.11.1-py3-none-any.whl",
     )
 
     maybe(
         http_file,
-        name = "rules_pycross_internal_deps_wheel_importlib_metadata_7.1.0_py3_none_any",
+        name = "rules_pycross_internal_deps_wheel_importlib_metadata_8.7.0_py3_none_any",
         urls = [
-            "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl",
+            "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl",
         ],
-        sha256 = "30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570",
-        downloaded_file_path = "importlib_metadata-7.1.0-py3-none-any.whl",
+        sha256 = "e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd",
+        downloaded_file_path = "importlib_metadata-8.7.0-py3-none-any.whl",
     )
 
     maybe(
@@ -314,12 +314,12 @@ def repositories():
 
     maybe(
         http_file,
-        name = "rules_pycross_internal_deps_wheel_pefile_2023.2.7_py3_none_any",
+        name = "rules_pycross_internal_deps_wheel_pefile_2024.8.26_py3_none_any",
         urls = [
-            "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl",
+            "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl",
         ],
-        sha256 = "da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6",
-        downloaded_file_path = "pefile-2023.2.7-py3-none-any.whl",
+        sha256 = "76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f",
+        downloaded_file_path = "pefile-2024.8.26-py3-none-any.whl",
     )
 
     maybe(
@@ -344,22 +344,22 @@ def repositories():
 
     maybe(
         http_file,
-        name = "rules_pycross_internal_deps_wheel_pyelftools_0.31_py3_none_any",
+        name = "rules_pycross_internal_deps_wheel_pyelftools_0.32_py3_none_any",
         urls = [
-            "https://files.pythonhosted.org/packages/f8/64/711030d9fe9ccaf6ee3ab1bcf4801c6bb3d0e585af18824a50b016b4f39c/pyelftools-0.31-py3-none-any.whl",
+            "https://files.pythonhosted.org/packages/af/43/700932c4f0638c3421177144a2e86448c0d75dbaee2c7936bda3f9fd0878/pyelftools-0.32-py3-none-any.whl",
         ],
-        sha256 = "f52de7b3c7e8c64c8abc04a79a1cf37ac5fb0b8a49809827130b858944840607",
-        downloaded_file_path = "pyelftools-0.31-py3-none-any.whl",
+        sha256 = "013df952a006db5e138b1edf6d8a68ecc50630adbd0d83a2d41e7f846163d738",
+        downloaded_file_path = "pyelftools-0.32-py3-none-any.whl",
     )
 
     maybe(
         http_file,
-        name = "rules_pycross_internal_deps_wheel_pyproject_hooks_1.1.0_py3_none_any",
+        name = "rules_pycross_internal_deps_wheel_pyproject_hooks_1.2.0_py3_none_any",
         urls = [
-            "https://files.pythonhosted.org/packages/ae/f3/431b9d5fe7d14af7a32340792ef43b8a714e7726f1d7b69cc4e8e7a3f1d7/pyproject_hooks-1.1.0-py3-none-any.whl",
+            "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl",
         ],
-        sha256 = "7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2",
-        downloaded_file_path = "pyproject_hooks-1.1.0-py3-none-any.whl",
+        sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913",
+        downloaded_file_path = "pyproject_hooks-1.2.0-py3-none-any.whl",
     )
 
     maybe(
@@ -384,10 +384,10 @@ def repositories():
 
     maybe(
         http_file,
-        name = "rules_pycross_internal_deps_wheel_zipp_3.19.2_py3_none_any",
+        name = "rules_pycross_internal_deps_wheel_zipp_3.23.0_py3_none_any",
         urls = [
-            "https://files.pythonhosted.org/packages/20/38/f5c473fe9b90c8debdd29ea68d5add0289f1936d6f923b6b9cc0b931194c/zipp-3.19.2-py3-none-any.whl",
+            "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl",
         ],
-        sha256 = "f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c",
-        downloaded_file_path = "zipp-3.19.2-py3-none-any.whl",
+        sha256 = "071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e",
+        downloaded_file_path = "zipp-3.23.0-py3-none-any.whl",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "rules_pycross"
 version = "0.0"
 authors = []
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 # core dependencies are required by repo rules
@@ -15,7 +15,7 @@ core = [
     "tomli==2.0.1",
 ]
 build = [
-    "build==1.0.3",
+    "build==1.3.0",
 ]
 repairwheel = [
     "repairwheel==0.3.1",


### PR DESCRIPTION
* Sets python version and python min version to 3.9 for internal deps
** rules_python is looking to remove 3.8 entirely (https://github.com/bazel-contrib/rules_python/issues/2704)
* Updates internal deps used for building wheels (namely build 1.0.3 -> 1.3.0)
* Certain packages fail to build with the existing pinned set of these deps (e.g. setuptools), but succeed when using the updated deps.