### PR TITLE
Fix patch application failures

### DIFF
--- a/pycross/private/tools/wheel_installer.py
+++ b/pycross/private/tools/wheel_installer.py
@@ -80,8 +80,10 @@ class FilteredWheelFile(WheelFile):
 def apply_patches(lib_dir: Path, patches: List[str]) -> None:
     for patch in patches:
         patch_file = patch_ng.fromfile(patch)
-        assert patch_file
-        patch_file.apply(root=lib_dir)
+        if not patch_file:
+            raise SystemExit(f"error: failed to parse patch file: {patch}")
+        if not patch_file.apply(root=lib_dir):
+            raise SystemExit(f"error: failed to apply patch file: {patch}")
 
 
 def main(args: Any) -> None:


### PR DESCRIPTION
We have to handle the result of `patch.apply` otherwise patches that
don't apply silently do nothing. This also provides a nicer error if the
patch is entirely invalid.
