### PR TITLE
Add Windows specific paths for python executable and site-packages for wheel_builder.py

### DIFF
--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -513,8 +513,9 @@ def check_filename_against_target(wheel_name: str, target_environment: TargetEnv
 
 def find_site_dir(env_dir: Path) -> Path:
     lib_dir = env_dir / "lib"
+    pattern = "site-packages" if "win32" == sys.platform else "python*/site-packages"
     try:
-        return next(lib_dir.glob("python*/site-packages"))
+        return next(lib_dir.glob(pattern))
     except StopIteration:
         raise ValueError(f"Cannot find site-packages under {env_dir}")
 
@@ -628,7 +629,9 @@ def build_wheel(
     config_settings: Dict[str, str],
     debug: bool = False,
 ) -> Path:
-    python_exe = env_dir / "bin" / "python"
+    posix_python_exe = env_dir / "bin" / "python"
+    win_python_exe = env_dir / "scripts" / "python.exe"
+    python_exe = win_python_exe if "win32" == sys.platform else posix_python_exe
 
     def _subprocess_runner(
         cmd: Sequence[str],


### PR DESCRIPTION
I'm working towards adding proper windows support when building wheels/libs. 
There is a 3rd issue that the existing tests get caught up on, which is that `importlib.import_module(sysconfigdata_name).build_time_vars` doesn't work on Windows.  I wondered if `sysconfig.get_config_vars()` could be used instead, which is cross-plat. I didn't see a difference in the resulting `target_sysconfig_vars` values from the testing I did on macOS and linux, but perhaps there's a good reason for using the internal API. 
