### PR TITLE
use absolute replacement paths in wheel builder

### DIFF
--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -202,7 +202,8 @@ def get_default_build_env_vars(path_dirs: List[Path]) -> Dict[str, str]:
 def replace_path_placeholders(
     data: Dict[str, Union[str, List[str]]], placeholder: str, replacement: Path
 ) -> Dict[str, Any]:
-    replacement_str = str(replacement)
+    # Use absolute path for replacements so compiler/linker paths work from temp build dirs
+    replacement_str = str(replacement.resolve())
     if replacement_str.endswith("/"):
         replacement_str = replacement_str[:-1]
     result = {}


### PR DESCRIPTION
Found this when trying to build cffi with our custom hermetic cc toolchain.  

The relative paths generated by execroot_prefix() dont resolve correctly from that directory, causing linker errors when trying to find system libraries like libm and libc in the hermetic toolchains sysroot.