### PR TITLE
poetry: Skip packages with directory source in lockfile

### DIFF
--- a/pycross/private/tools/poetry_translator.py
+++ b/pycross/private/tools/poetry_translator.py
@@ -175,6 +175,20 @@ def translate(
         package_name = package_canonical_name(package_listed_name)
         package_version = lock_pkg["version"]
         package_python_versions = lock_pkg["python-versions"]
+        package_source = lock_pkg.get("source", {})
+        package_source_type = package_source.get("type", None)
+
+        # Poetry records non-index packages in poetry.lock, and path dependencies are represented
+        # as:
+        #
+        #     [package.source]
+        #     type = "directory"
+        #
+        # We skip these as we let the user handle them directly in Bazel.
+        if package_source_type == "directory":
+            continue
+        # FIXME: We should probably warn the user if we encounter a non-index package that's not
+        #        just a directory as it may fail to fetch or resolve later.
 
         dependencies = []
         for name, dep_list in lock_pkg.get("dependencies", {}).items():


### PR DESCRIPTION
Path dependencies are apparently added to poetry.lock as directory-sourced packages, and this was causing issues.

This fixes the following error:

    Traceback (most recent call last):
      File ".../tools/poetry_translator.py", line 333, in <module>
        main(parse_flags())
      File ".../tools/poetry_translator.py", line 274, in main
        lock_set = translate(
                   ^^^^^^^^^^
      File ".../tools/poetry_translator.py", line 204, in translate
        files = files_by_package_name[package_listed_name]
                ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
    KeyError: 'path-dependency'