### PR TITLE
feat: add support for workspaces in pycross

### DIFF
--- a/pycross/private/tools/uv_translator.py
+++ b/pycross/private/tools/uv_translator.py
@@ -374,9 +374,17 @@ def collect_and_process_packages(packages_list: list[Dict[str, Any]]) -> Dict[Pa
 
         files = {parse_file_info(f) for f in files}
 
-        is_local_sdist = lock_pkg.get("sdist") == {"path": "."}
-        is_local_editable = lock_pkg.get("source") == {"editable": "."}
-        is_local_virtual = lock_pkg.get("source") == {"virtual": "."}
+        source = lock_pkg.get("source", {})
+        sdist = lock_pkg.get("sdist", {})
+
+        # Check for editable source (any path value)
+        is_local_editable = "editable" in source and isinstance(source.get("editable"), str)
+
+        # Check for virtual source (any path value)
+        is_local_virtual = "virtual" in source and isinstance(source.get("virtual"), str)
+
+        # Check for sdist with path (not URL-based - local sdists have "path" but not "url")
+        is_local_sdist = isinstance(sdist, dict) and "path" in sdist and "url" not in sdist
 
         is_local = is_local_sdist or is_local_editable or is_local_virtual
 

--- a/pycross/tests/uv/lock_workspace/BUILD.bazel
+++ b/pycross/tests/uv/lock_workspace/BUILD.bazel
@@ -1,0 +1,32 @@
+"""
+Test that uv workspace members with editable dependencies at arbitrary paths
+are correctly detected as local packages and elided from the output.
+
+This test covers:
+- `source = { editable = "./packages/lib-a" }` (workspace member)
+- `source = { editable = "./packages/lib-b" }` (workspace member)
+- `source = { virtual = "." }` (root virtual package)
+"""
+
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_json_matches")
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_file")
+load("//pycross:defs.bzl", "pycross_uv_lock_model")
+
+pycross_uv_lock_model(
+    name = "lock",
+    lock_file = "uv.lock",
+    project_file = "pyproject.toml",
+)
+
+write_source_file(
+    name = "update_expected",
+    diff_test = False,
+    in_file = ":lock",
+    out_file = "expected.json",
+)
+
+assert_json_matches(
+    name = "test",
+    file1 = ":lock",
+    file2 = "expected.json",
+)

--- a/pycross/tests/uv/lock_workspace/expected.json
+++ b/pycross/tests/uv/lock_workspace/expected.json
@@ -1,0 +1,582 @@
+{
+  "packages": {
+    "regex@2024.11.6": {
+      "files": [
+        {
+          "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "ff590880083d60acc0433f9c3f713c51f7ac6ebb9adf889c79a261ecf541aa91",
+          "urls": [
+            "https://files.pythonhosted.org/packages/95/3c/4651f6b130c6842a8f3df82461a8950f923925db8b6961063e82744bddcc/regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "658f90550f38270639e83ce492f27d2c8d2cd63805c65a13a14d36ca126753f0",
+          "urls": [
+            "https://files.pythonhosted.org/packages/15/51/9f35d12da8434b489c7b7bffc205c474a0a9432a889457026e9bc06a297a/regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "164d8b7b3b4bcb2068b97428060b2a53be050085ef94eca7f240e7947f1b080e",
+          "urls": [
+            "https://files.pythonhosted.org/packages/bd/18/b731f5510d1b8fb63c6b6d3484bfa9a59b84cc578ac8b5172970e05ae07c/regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "d3660c82f209655a06b587d55e723f0b813d3a7db2e32e5e7dc64ac2a9e86fde",
+          "urls": [
+            "https://files.pythonhosted.org/packages/78/a2/6dd36e16341ab95e4c6073426561b9bfdeb1a9c9b63ab1b579c2e96cb105/regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "d22326fcdef5e08c154280b71163ced384b428343ae16a5ab2b3354aed12436e",
+          "urls": [
+            "https://files.pythonhosted.org/packages/1b/2b/323e72d5d2fd8de0d9baa443e1ed70363ed7e7b2fb526f5950c5cb99c364/regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "f1ac758ef6aebfc8943560194e9fd0fa18bcb34d89fd8bd2af18183afd8da3a2",
+          "urls": [
+            "https://files.pythonhosted.org/packages/90/30/63373b9ea468fbef8a907fd273e5c329b8c9535fee36fc8dba5fecac475d/regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "997d6a487ff00807ba810e0f8332c18b4eb8d29463cfb7c820dc4b6e7562d0cf",
+          "urls": [
+            "https://files.pythonhosted.org/packages/f2/98/26d3830875b53071f1f0ae6d547f1d98e964dd29ad35cbf94439120bb67a/regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "02a02d2bb04fec86ad61f3ea7f49c015a0681bf76abb9857f945d26159d2968c",
+          "urls": [
+            "https://files.pythonhosted.org/packages/87/55/eb2a068334274db86208ab9d5599ffa63631b9f0f67ed70ea7c82a69bbc8/regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "f02f93b92358ee3f78660e43b4b0091229260c5d5c408d17d60bf26b6c900e86",
+          "urls": [
+            "https://files.pythonhosted.org/packages/74/c0/be707bcfe98254d8f9d2cff55d216e946f4ea48ad2fd8cf1428f8c5332ba/regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "06eb1be98df10e81ebaded73fcd51989dcf534e3c753466e4b60c4697a003b67",
+          "urls": [
+            "https://files.pythonhosted.org/packages/49/dc/bb45572ceb49e0f6509f7596e4ba7031f6819ecb26bc7610979af5a77f45/regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "040df6fe1a5504eb0f04f048e6d09cd7c7110fef851d7c567a6b6e09942feb7d",
+          "urls": [
+            "https://files.pythonhosted.org/packages/5a/db/f43fd75dc4c0c2d96d0881967897926942e935d700863666f3c844a72ce6/regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "fdabbfc59f2c6edba2a6622c647b716e34e8e3867e0ab975412c5c2f79b82da2",
+          "urls": [
+            "https://files.pythonhosted.org/packages/99/d7/f94154db29ab5a89d69ff893159b19ada89e76b915c1293e98603d39838c/regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "8447d2d39b5abe381419319f942de20b7ecd60ce86f16a23b0698f22e1b70008",
+          "urls": [
+            "https://files.pythonhosted.org/packages/f7/17/3cbfab1f23356fbbf07708220ab438a7efa1e0f34195bf857433f79f1788/regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "da8f5fc57d1933de22a9e23eec290a0d8a5927a5370d24bda9a6abe50683fe62",
+          "urls": [
+            "https://files.pythonhosted.org/packages/7e/f2/48b393b51900456155de3ad001900f94298965e1cad1c772b87f9cfea011/regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-win32.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "b489578720afb782f6ccf2840920f3a32e31ba28a4b162e13900c3e6bd3f930e",
+          "urls": [
+            "https://files.pythonhosted.org/packages/45/3f/ef9589aba93e084cd3f8471fded352826dcae8489b650d0b9b27bc5bba8a/regex-2024.11.6-cp310-cp310-win32.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "5071b2093e793357c9d8b2929dfc13ac5f0a6c650559503bb81189d0a3814519",
+          "urls": [
+            "https://files.pythonhosted.org/packages/42/7e/5f1b92c8468290c465fd50c5318da64319133231415a8aa6ea5ab995a815/regex-2024.11.6-cp310-cp310-win_amd64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "5478c6962ad548b54a591778e93cd7c456a7a29f8eca9c49e4f9a806dcc5d638",
+          "urls": [
+            "https://files.pythonhosted.org/packages/58/58/7e4d9493a66c88a7da6d205768119f51af0f684fe7be7bac8328e217a52c/regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "2c89a8cc122b25ce6945f0423dc1352cb9593c68abd19223eebbd4e56612c5b7",
+          "urls": [
+            "https://files.pythonhosted.org/packages/34/4c/8f8e631fcdc2ff978609eaeef1d6994bf2f028b59d9ac67640ed051f1218/regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "94d87b689cdd831934fa3ce16cc15cd65748e6d689f5d2b8f4f4df2065c9fa20",
+          "urls": [
+            "https://files.pythonhosted.org/packages/c5/1b/f0e4d13e6adf866ce9b069e191f303a30ab1277e037037a365c3aad5cc9c/regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "1062b39a0a2b75a9c694f7a08e7183a80c63c0d62b301418ffd9c35f55aaa114",
+          "urls": [
+            "https://files.pythonhosted.org/packages/25/4d/ab21047f446693887f25510887e6820b93f791992994f6498b0318904d4a/regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "167ed4852351d8a750da48712c3930b031f6efdaa0f22fa1933716bfcd6bf4a3",
+          "urls": [
+            "https://files.pythonhosted.org/packages/45/ee/c867e15cd894985cb32b731d89576c41a4642a57850c162490ea34b78c3b/regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "2d548dafee61f06ebdb584080621f3e0c23fff312f0de1afc776e2a2ba99a74f",
+          "urls": [
+            "https://files.pythonhosted.org/packages/b3/12/b0f480726cf1c60f6536fa5e1c95275a77624f3ac8fdccf79e6727499e28/regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "f2a19f302cd1ce5dd01a9099aaa19cae6173306d1302a43b627f62e21cf18ac0",
+          "urls": [
+            "https://files.pythonhosted.org/packages/bf/ce/0d0e61429f603bac433910d99ef1a02ce45a8967ffbe3cbee48599e62d88/regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "bec9931dfb61ddd8ef2ebc05646293812cb6b16b60cf7c9511a832b6f1854b55",
+          "urls": [
+            "https://files.pythonhosted.org/packages/e4/c1/243c83c53d4a419c1556f43777ccb552bccdf79d08fda3980e4e77dd9137/regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "9714398225f299aa85267fd222f7142fcb5c769e73d7733344efc46f2ef5cf89",
+          "urls": [
+            "https://files.pythonhosted.org/packages/c5/f4/75eb0dd4ce4b37f04928987f1d22547ddaf6c4bae697623c1b05da67a8aa/regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "202eb32e89f60fc147a41e55cb086db2a3f8cb82f9a9a88440dcfc5d37faae8d",
+          "urls": [
+            "https://files.pythonhosted.org/packages/16/5d/95c568574e630e141a69ff8a254c2f188b4398e813c40d49228c9bbd9875/regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "4181b814e56078e9b00427ca358ec44333765f5ca1b45597ec7446d3a1ef6e34",
+          "urls": [
+            "https://files.pythonhosted.org/packages/8e/b5/f8495c7917f15cc6fee1e7f395e324ec3e00ab3c665a7dc9d27562fd5290/regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "068376da5a7e4da51968ce4c122a7cd31afaaec4fccc7856c92f63876e57b51d",
+          "urls": [
+            "https://files.pythonhosted.org/packages/1c/80/6dd7118e8cb212c3c60b191b932dc57db93fb2e36fb9e0e92f72a5909af9/regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "ac10f2c4184420d881a3475fb2c6f4d95d53a8d50209a2500723d831036f7c45",
+          "urls": [
+            "https://files.pythonhosted.org/packages/11/9b/5a05d2040297d2d254baf95eeeb6df83554e5e1df03bc1a6687fc4ba1f66/regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-win32.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "c36f9b6f5f8649bb251a5f3f66564438977b7ef8386a52460ae77e6070d309d9",
+          "urls": [
+            "https://files.pythonhosted.org/packages/26/b7/b14e2440156ab39e0177506c08c18accaf2b8932e39fb092074de733d868/regex-2024.11.6-cp311-cp311-win32.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "02e28184be537f0e75c1f9b2f8847dc51e08e6e171c6bde130b2687e0c33cf60",
+          "urls": [
+            "https://files.pythonhosted.org/packages/80/32/763a6cc01d21fb3819227a1cc3f60fd251c13c37c27a73b8ff4315433a8e/regex-2024.11.6-cp311-cp311-win_amd64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "52fb28f528778f184f870b7cf8f225f5eef0a8f6e3778529bdd40c7b3920796a",
+          "urls": [
+            "https://files.pythonhosted.org/packages/ba/30/9a87ce8336b172cc232a0db89a3af97929d06c11ceaa19d97d84fa90a8f8/regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "fdd6028445d2460f33136c55eeb1f601ab06d74cb3347132e1c24250187500d9",
+          "urls": [
+            "https://files.pythonhosted.org/packages/01/e8/00008ad4ff4be8b1844786ba6636035f7ef926db5686e4c0f98093612add/regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "805e6b60c54bf766b251e94526ebad60b7de0c70f70a4e6210ee2891acb70bf2",
+          "urls": [
+            "https://files.pythonhosted.org/packages/60/85/cebcc0aff603ea0a201667b203f13ba75d9fc8668fab917ac5b2de3967bc/regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "b85c2530be953a890eaffde05485238f07029600e8f098cdf1848d414a8b45e4",
+          "urls": [
+            "https://files.pythonhosted.org/packages/94/2b/701a4b0585cb05472a4da28ee28fdfe155f3638f5e1ec92306d924e5faf0/regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "bb26437975da7dc36b7efad18aa9dd4ea569d2357ae6b783bf1118dabd9ea577",
+          "urls": [
+            "https://files.pythonhosted.org/packages/4b/bf/fa87e563bf5fee75db8915f7352e1887b1249126a1be4813837f5dbec965/regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "abfa5080c374a76a251ba60683242bc17eeb2c9818d0d30117b4486be10c59d3",
+          "urls": [
+            "https://files.pythonhosted.org/packages/a1/56/7295e6bad94b047f4d0834e4779491b81216583c00c288252ef625c01d23/regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "70b7fa6606c2881c1db9479b0eaa11ed5dfa11c8d60a474ff0e095099f39d98e",
+          "urls": [
+            "https://files.pythonhosted.org/packages/fb/13/e3b075031a738c9598c51cfbc4c7879e26729c53aa9cca59211c44235314/regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "0c32f75920cf99fe6b6c539c399a4a128452eaf1af27f39bce8909c9a3fd8cbe",
+          "urls": [
+            "https://files.pythonhosted.org/packages/24/56/0b3f1b66d592be6efec23a795b37732682520b47c53da5a32c33ed7d84e3/regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "982e6d21414e78e1f51cf595d7f321dcd14de1f2881c5dc6a6e23bbbbd68435e",
+          "urls": [
+            "https://files.pythonhosted.org/packages/f9/a1/eb378dada8b91c0e4c5f08ffb56f25fcae47bf52ad18f9b2f33b83e6d498/regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "a7c2155f790e2fb448faed6dd241386719802296ec588a8b9051c1f5c481bc29",
+          "urls": [
+            "https://files.pythonhosted.org/packages/83/f2/033e7dec0cfd6dda93390089864732a3409246ffe8b042e9554afa9bff4e/regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "149f5008d286636e48cd0b1dd65018548944e495b0265b45e1bffecce1ef7f39",
+          "urls": [
+            "https://files.pythonhosted.org/packages/83/23/15d4552ea28990a74e7696780c438aadd73a20318c47e527b47a4a5a596d/regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "e5364a4502efca094731680e80009632ad6624084aff9a23ce8c8c6820de3e51",
+          "urls": [
+            "https://files.pythonhosted.org/packages/e3/39/ed4416bc90deedbfdada2568b2cb0bc1fdb98efe11f5378d9892b2a88f8f/regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "0a86e7eeca091c09e021db8eb72d54751e527fa47b8d5787caf96d9831bd02ad",
+          "urls": [
+            "https://files.pythonhosted.org/packages/93/2d/dd56bb76bd8e95bbce684326302f287455b56242a4f9c61f1bc76e28360e/regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-win32.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "32f9a4c643baad4efa81d549c2aadefaeba12249b2adc5af541759237eee1c54",
+          "urls": [
+            "https://files.pythonhosted.org/packages/0b/55/31877a249ab7a5156758246b9c59539abbeba22461b7d8adc9e8475ff73e/regex-2024.11.6-cp312-cp312-win32.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "a93c194e2df18f7d264092dc8539b8ffb86b45b899ab976aa15d48214138e81b",
+          "urls": [
+            "https://files.pythonhosted.org/packages/38/ec/ad2d7de49a600cdb8dd78434a1aeffe28b9d6fc42eb36afab4a27ad23384/regex-2024.11.6-cp312-cp312-win_amd64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "5704e174f8ccab2026bd2f1ab6c510345ae8eac818b613d7d73e785f1310f839",
+          "urls": [
+            "https://files.pythonhosted.org/packages/89/23/c4a86df398e57e26f93b13ae63acce58771e04bdde86092502496fa57f9c/regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "220902c3c5cc6af55d4fe19ead504de80eb91f786dc102fbd74894b1551f095e",
+          "urls": [
+            "https://files.pythonhosted.org/packages/3c/8b/45c24ab7a51a1658441b961b86209c43e6bb9d39caf1e63f46ce6ea03bc7/regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "5e7e351589da0850c125f1600a4c4ba3c722efefe16b297de54300f08d734fbf",
+          "urls": [
+            "https://files.pythonhosted.org/packages/7a/d1/598de10b17fdafc452d11f7dada11c3be4e379a8671393e4e3da3c4070df/regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "5056b185ca113c88e18223183aa1a50e66507769c9640a6ff75859619d73957b",
+          "urls": [
+            "https://files.pythonhosted.org/packages/49/70/c7eaa219efa67a215846766fde18d92d54cb590b6a04ffe43cef30057622/regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "2e34b51b650b23ed3354b5a07aab37034d9f923db2a40519139af34f485f77d0",
+          "urls": [
+            "https://files.pythonhosted.org/packages/89/e5/ef52c7eb117dd20ff1697968219971d052138965a4d3d9b95e92e549f505/regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "5670bce7b200273eee1840ef307bfa07cda90b38ae56e9a6ebcc9f50da9c469b",
+          "urls": [
+            "https://files.pythonhosted.org/packages/5f/3f/9f5da81aff1d4167ac52711acf789df13e789fe6ac9545552e49138e3282/regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "08986dce1339bc932923e7d1232ce9881499a0e02925f7402fb7c982515419ef",
+          "urls": [
+            "https://files.pythonhosted.org/packages/86/44/2101cc0890c3621b90365c9ee8d7291a597c0722ad66eccd6ffa7f1bcc09/regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "93c0b12d3d3bc25af4ebbf38f9ee780a487e8bf6954c115b9f015822d3bb8e48",
+          "urls": [
+            "https://files.pythonhosted.org/packages/ce/2e/3e0668d8d1c7c3c0d397bf54d92fc182575b3a26939aed5000d3cc78760f/regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "764e71f22ab3b305e7f4c21f1a97e1526a25ebdd22513e251cf376760213da13",
+          "urls": [
+            "https://files.pythonhosted.org/packages/a6/49/1bc4584254355e3dba930a3a2fd7ad26ccba3ebbab7d9100db0aff2eedb0/regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "f056bf21105c2515c32372bbc057f43eb02aae2fda61052e2f7622c801f0b4e2",
+          "urls": [
+            "https://files.pythonhosted.org/packages/c8/dd/42879c1fc8a37a887cd08e358af3d3ba9e23038cd77c7fe044a86d9450ba/regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "69ab78f848845569401469da20df3e081e6b5a11cb086de3eed1d48f5ed57c95",
+          "urls": [
+            "https://files.pythonhosted.org/packages/89/96/c05a0fe173cd2acd29d5e13c1adad8b706bcaa71b169e1ee57dcf2e74584/regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "86fddba590aad9208e2fa8b43b4c098bb0ec74f15718bb6a704e3c63e2cef3e9",
+          "urls": [
+            "https://files.pythonhosted.org/packages/b5/f3/a757748066255f97f14506483436c5f6aded7af9e37bca04ec30c90ca683/regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "684d7a212682996d21ca12ef3c17353c021fe9de6049e19ac8481ec35574a70f",
+          "urls": [
+            "https://files.pythonhosted.org/packages/5c/93/c6d2092fd479dcaeea40fc8fa673822829181ded77d294a7f950f1dda6e2/regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "a03e02f48cd1abbd9f3b7e3586d97c8f7a9721c436f51a5245b3b9483044480b",
+          "urls": [
+            "https://files.pythonhosted.org/packages/ff/9c/daa99532c72f25051a90ef90e1413a8d54413a9e64614d9095b0c1c154d0/regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-win32.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "41758407fc32d5c3c5de163888068cfee69cb4c2be844e7ac517a52770f9af57",
+          "urls": [
+            "https://files.pythonhosted.org/packages/13/5d/61a533ccb8c231b474ac8e3a7d70155b00dfc61af6cafdccd1947df6d735/regex-2024.11.6-cp39-cp39-win32.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "b2837718570f95dd41675328e111345f9b7095d821bac435aac173ac80b19983",
+          "urls": [
+            "https://files.pythonhosted.org/packages/dc/7b/e59b7f7c91ae110d154370c24133f947262525b5d6406df65f23422acc17/regex-2024.11.6-cp39-cp39-win_amd64.whl"
+          ]
+        },
+        {
+          "name": "regex-2024.11.6.tar.gz",
+          "package_name": "regex",
+          "package_version": "2024.11.6",
+          "sha256": "7ab159b063c52a0333c884e4679f8d7a85112ee3078fe3d9004b2dd875585519",
+          "urls": [
+            "https://files.pythonhosted.org/packages/8e/5f/bd69653fbfb76cf8604468d3b4ec4c403197144c7bfe0e6a5fc9e02a07cb/regex-2024.11.6.tar.gz"
+          ]
+        }
+      ],
+      "name": "regex",
+      "python_versions": "",
+      "version": "2024.11.6"
+    }
+  },
+  "pins": {
+    "regex": "regex@2024.11.6"
+  },
+  "python_versions": "<3.13,>=3.9"
+}

--- a/pycross/tests/uv/lock_workspace/packages/lib-a/pyproject.toml
+++ b/pycross/tests/uv/lock_workspace/packages/lib-a/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "lib-a"
+version = "0.1.0"
+description = "Workspace member A"
+requires-python = ">=3.9, <3.13"
+dependencies = [
+    "regex>=2024.11.6",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/pycross/tests/uv/lock_workspace/packages/lib-b/pyproject.toml
+++ b/pycross/tests/uv/lock_workspace/packages/lib-b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "lib-b"
+version = "0.1.0"
+description = "Workspace member B"
+requires-python = ">=3.9, <3.13"
+dependencies = [
+    "lib-a",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv.sources]
+lib-a = { workspace = true }

--- a/pycross/tests/uv/lock_workspace/pyproject.toml
+++ b/pycross/tests/uv/lock_workspace/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "workspace-root"
+version = "0.1.0"
+description = "Test workspace with multiple editable packages"
+requires-python = ">=3.9, <3.13"
+dependencies = [
+    "lib-a",
+    "lib-b",
+]
+
+[tool.uv]
+package = false
+
+[tool.uv.workspace]
+members = ["packages/*"]
+
+[tool.uv.sources]
+lib-a = { workspace = true }
+lib-b = { workspace = true }

--- a/pycross/tests/uv/lock_workspace/uv.lock
+++ b/pycross/tests/uv/lock_workspace/uv.lock
@@ -1,0 +1,112 @@
+version = 1
+requires-python = ">=3.9, <3.13"
+
+[options]
+exclude-newer = "2024-12-01T00:00:00Z"
+
+[[package]]
+name = "lib-a"
+version = "0.1.0"
+source = { editable = "./packages/lib-a" }
+dependencies = [
+    { name = "regex" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "regex", specifier = ">=2024.11.6" }]
+
+[[package]]
+name = "lib-b"
+version = "0.1.0"
+source = { editable = "./packages/lib-b" }
+dependencies = [
+    { name = "lib-a" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "lib-a" }]
+
+[[package]]
+name = "regex"
+version = "2024.11.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5f/bd69653fbfb76cf8604468d3b4ec4c403197144c7bfe0e6a5fc9e02a07cb/regex-2024.11.6.tar.gz", hash = "sha256:7ab159b063c52a0333c884e4679f8d7a85112ee3078fe3d9004b2dd875585519", size = 399494 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/3c/4651f6b130c6842a8f3df82461a8950f923925db8b6961063e82744bddcc/regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ff590880083d60acc0433f9c3f713c51f7ac6ebb9adf889c79a261ecf541aa91", size = 482674 },
+    { url = "https://files.pythonhosted.org/packages/15/51/9f35d12da8434b489c7b7bffc205c474a0a9432a889457026e9bc06a297a/regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:658f90550f38270639e83ce492f27d2c8d2cd63805c65a13a14d36ca126753f0", size = 287684 },
+    { url = "https://files.pythonhosted.org/packages/bd/18/b731f5510d1b8fb63c6b6d3484bfa9a59b84cc578ac8b5172970e05ae07c/regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164d8b7b3b4bcb2068b97428060b2a53be050085ef94eca7f240e7947f1b080e", size = 284589 },
+    { url = "https://files.pythonhosted.org/packages/78/a2/6dd36e16341ab95e4c6073426561b9bfdeb1a9c9b63ab1b579c2e96cb105/regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3660c82f209655a06b587d55e723f0b813d3a7db2e32e5e7dc64ac2a9e86fde", size = 782511 },
+    { url = "https://files.pythonhosted.org/packages/1b/2b/323e72d5d2fd8de0d9baa443e1ed70363ed7e7b2fb526f5950c5cb99c364/regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d22326fcdef5e08c154280b71163ced384b428343ae16a5ab2b3354aed12436e", size = 821149 },
+    { url = "https://files.pythonhosted.org/packages/90/30/63373b9ea468fbef8a907fd273e5c329b8c9535fee36fc8dba5fecac475d/regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f1ac758ef6aebfc8943560194e9fd0fa18bcb34d89fd8bd2af18183afd8da3a2", size = 809707 },
+    { url = "https://files.pythonhosted.org/packages/f2/98/26d3830875b53071f1f0ae6d547f1d98e964dd29ad35cbf94439120bb67a/regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:997d6a487ff00807ba810e0f8332c18b4eb8d29463cfb7c820dc4b6e7562d0cf", size = 781702 },
+    { url = "https://files.pythonhosted.org/packages/87/55/eb2a068334274db86208ab9d5599ffa63631b9f0f67ed70ea7c82a69bbc8/regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:02a02d2bb04fec86ad61f3ea7f49c015a0681bf76abb9857f945d26159d2968c", size = 771976 },
+    { url = "https://files.pythonhosted.org/packages/74/c0/be707bcfe98254d8f9d2cff55d216e946f4ea48ad2fd8cf1428f8c5332ba/regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f02f93b92358ee3f78660e43b4b0091229260c5d5c408d17d60bf26b6c900e86", size = 697397 },
+    { url = "https://files.pythonhosted.org/packages/49/dc/bb45572ceb49e0f6509f7596e4ba7031f6819ecb26bc7610979af5a77f45/regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:06eb1be98df10e81ebaded73fcd51989dcf534e3c753466e4b60c4697a003b67", size = 768726 },
+    { url = "https://files.pythonhosted.org/packages/5a/db/f43fd75dc4c0c2d96d0881967897926942e935d700863666f3c844a72ce6/regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:040df6fe1a5504eb0f04f048e6d09cd7c7110fef851d7c567a6b6e09942feb7d", size = 775098 },
+    { url = "https://files.pythonhosted.org/packages/99/d7/f94154db29ab5a89d69ff893159b19ada89e76b915c1293e98603d39838c/regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabbfc59f2c6edba2a6622c647b716e34e8e3867e0ab975412c5c2f79b82da2", size = 839325 },
+    { url = "https://files.pythonhosted.org/packages/f7/17/3cbfab1f23356fbbf07708220ab438a7efa1e0f34195bf857433f79f1788/regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8447d2d39b5abe381419319f942de20b7ecd60ce86f16a23b0698f22e1b70008", size = 843277 },
+    { url = "https://files.pythonhosted.org/packages/7e/f2/48b393b51900456155de3ad001900f94298965e1cad1c772b87f9cfea011/regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:da8f5fc57d1933de22a9e23eec290a0d8a5927a5370d24bda9a6abe50683fe62", size = 773197 },
+    { url = "https://files.pythonhosted.org/packages/45/3f/ef9589aba93e084cd3f8471fded352826dcae8489b650d0b9b27bc5bba8a/regex-2024.11.6-cp310-cp310-win32.whl", hash = "sha256:b489578720afb782f6ccf2840920f3a32e31ba28a4b162e13900c3e6bd3f930e", size = 261714 },
+    { url = "https://files.pythonhosted.org/packages/42/7e/5f1b92c8468290c465fd50c5318da64319133231415a8aa6ea5ab995a815/regex-2024.11.6-cp310-cp310-win_amd64.whl", hash = "sha256:5071b2093e793357c9d8b2929dfc13ac5f0a6c650559503bb81189d0a3814519", size = 274042 },
+    { url = "https://files.pythonhosted.org/packages/58/58/7e4d9493a66c88a7da6d205768119f51af0f684fe7be7bac8328e217a52c/regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5478c6962ad548b54a591778e93cd7c456a7a29f8eca9c49e4f9a806dcc5d638", size = 482669 },
+    { url = "https://files.pythonhosted.org/packages/34/4c/8f8e631fcdc2ff978609eaeef1d6994bf2f028b59d9ac67640ed051f1218/regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2c89a8cc122b25ce6945f0423dc1352cb9593c68abd19223eebbd4e56612c5b7", size = 287684 },
+    { url = "https://files.pythonhosted.org/packages/c5/1b/f0e4d13e6adf866ce9b069e191f303a30ab1277e037037a365c3aad5cc9c/regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:94d87b689cdd831934fa3ce16cc15cd65748e6d689f5d2b8f4f4df2065c9fa20", size = 284589 },
+    { url = "https://files.pythonhosted.org/packages/25/4d/ab21047f446693887f25510887e6820b93f791992994f6498b0318904d4a/regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1062b39a0a2b75a9c694f7a08e7183a80c63c0d62b301418ffd9c35f55aaa114", size = 792121 },
+    { url = "https://files.pythonhosted.org/packages/45/ee/c867e15cd894985cb32b731d89576c41a4642a57850c162490ea34b78c3b/regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:167ed4852351d8a750da48712c3930b031f6efdaa0f22fa1933716bfcd6bf4a3", size = 831275 },
+    { url = "https://files.pythonhosted.org/packages/b3/12/b0f480726cf1c60f6536fa5e1c95275a77624f3ac8fdccf79e6727499e28/regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d548dafee61f06ebdb584080621f3e0c23fff312f0de1afc776e2a2ba99a74f", size = 818257 },
+    { url = "https://files.pythonhosted.org/packages/bf/ce/0d0e61429f603bac433910d99ef1a02ce45a8967ffbe3cbee48599e62d88/regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2a19f302cd1ce5dd01a9099aaa19cae6173306d1302a43b627f62e21cf18ac0", size = 792727 },
+    { url = "https://files.pythonhosted.org/packages/e4/c1/243c83c53d4a419c1556f43777ccb552bccdf79d08fda3980e4e77dd9137/regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bec9931dfb61ddd8ef2ebc05646293812cb6b16b60cf7c9511a832b6f1854b55", size = 780667 },
+    { url = "https://files.pythonhosted.org/packages/c5/f4/75eb0dd4ce4b37f04928987f1d22547ddaf6c4bae697623c1b05da67a8aa/regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9714398225f299aa85267fd222f7142fcb5c769e73d7733344efc46f2ef5cf89", size = 776963 },
+    { url = "https://files.pythonhosted.org/packages/16/5d/95c568574e630e141a69ff8a254c2f188b4398e813c40d49228c9bbd9875/regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:202eb32e89f60fc147a41e55cb086db2a3f8cb82f9a9a88440dcfc5d37faae8d", size = 784700 },
+    { url = "https://files.pythonhosted.org/packages/8e/b5/f8495c7917f15cc6fee1e7f395e324ec3e00ab3c665a7dc9d27562fd5290/regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:4181b814e56078e9b00427ca358ec44333765f5ca1b45597ec7446d3a1ef6e34", size = 848592 },
+    { url = "https://files.pythonhosted.org/packages/1c/80/6dd7118e8cb212c3c60b191b932dc57db93fb2e36fb9e0e92f72a5909af9/regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:068376da5a7e4da51968ce4c122a7cd31afaaec4fccc7856c92f63876e57b51d", size = 852929 },
+    { url = "https://files.pythonhosted.org/packages/11/9b/5a05d2040297d2d254baf95eeeb6df83554e5e1df03bc1a6687fc4ba1f66/regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ac10f2c4184420d881a3475fb2c6f4d95d53a8d50209a2500723d831036f7c45", size = 781213 },
+    { url = "https://files.pythonhosted.org/packages/26/b7/b14e2440156ab39e0177506c08c18accaf2b8932e39fb092074de733d868/regex-2024.11.6-cp311-cp311-win32.whl", hash = "sha256:c36f9b6f5f8649bb251a5f3f66564438977b7ef8386a52460ae77e6070d309d9", size = 261734 },
+    { url = "https://files.pythonhosted.org/packages/80/32/763a6cc01d21fb3819227a1cc3f60fd251c13c37c27a73b8ff4315433a8e/regex-2024.11.6-cp311-cp311-win_amd64.whl", hash = "sha256:02e28184be537f0e75c1f9b2f8847dc51e08e6e171c6bde130b2687e0c33cf60", size = 274052 },
+    { url = "https://files.pythonhosted.org/packages/ba/30/9a87ce8336b172cc232a0db89a3af97929d06c11ceaa19d97d84fa90a8f8/regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:52fb28f528778f184f870b7cf8f225f5eef0a8f6e3778529bdd40c7b3920796a", size = 483781 },
+    { url = "https://files.pythonhosted.org/packages/01/e8/00008ad4ff4be8b1844786ba6636035f7ef926db5686e4c0f98093612add/regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdd6028445d2460f33136c55eeb1f601ab06d74cb3347132e1c24250187500d9", size = 288455 },
+    { url = "https://files.pythonhosted.org/packages/60/85/cebcc0aff603ea0a201667b203f13ba75d9fc8668fab917ac5b2de3967bc/regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:805e6b60c54bf766b251e94526ebad60b7de0c70f70a4e6210ee2891acb70bf2", size = 284759 },
+    { url = "https://files.pythonhosted.org/packages/94/2b/701a4b0585cb05472a4da28ee28fdfe155f3638f5e1ec92306d924e5faf0/regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b85c2530be953a890eaffde05485238f07029600e8f098cdf1848d414a8b45e4", size = 794976 },
+    { url = "https://files.pythonhosted.org/packages/4b/bf/fa87e563bf5fee75db8915f7352e1887b1249126a1be4813837f5dbec965/regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb26437975da7dc36b7efad18aa9dd4ea569d2357ae6b783bf1118dabd9ea577", size = 833077 },
+    { url = "https://files.pythonhosted.org/packages/a1/56/7295e6bad94b047f4d0834e4779491b81216583c00c288252ef625c01d23/regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abfa5080c374a76a251ba60683242bc17eeb2c9818d0d30117b4486be10c59d3", size = 823160 },
+    { url = "https://files.pythonhosted.org/packages/fb/13/e3b075031a738c9598c51cfbc4c7879e26729c53aa9cca59211c44235314/regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b7fa6606c2881c1db9479b0eaa11ed5dfa11c8d60a474ff0e095099f39d98e", size = 796896 },
+    { url = "https://files.pythonhosted.org/packages/24/56/0b3f1b66d592be6efec23a795b37732682520b47c53da5a32c33ed7d84e3/regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c32f75920cf99fe6b6c539c399a4a128452eaf1af27f39bce8909c9a3fd8cbe", size = 783997 },
+    { url = "https://files.pythonhosted.org/packages/f9/a1/eb378dada8b91c0e4c5f08ffb56f25fcae47bf52ad18f9b2f33b83e6d498/regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:982e6d21414e78e1f51cf595d7f321dcd14de1f2881c5dc6a6e23bbbbd68435e", size = 781725 },
+    { url = "https://files.pythonhosted.org/packages/83/f2/033e7dec0cfd6dda93390089864732a3409246ffe8b042e9554afa9bff4e/regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a7c2155f790e2fb448faed6dd241386719802296ec588a8b9051c1f5c481bc29", size = 789481 },
+    { url = "https://files.pythonhosted.org/packages/83/23/15d4552ea28990a74e7696780c438aadd73a20318c47e527b47a4a5a596d/regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:149f5008d286636e48cd0b1dd65018548944e495b0265b45e1bffecce1ef7f39", size = 852896 },
+    { url = "https://files.pythonhosted.org/packages/e3/39/ed4416bc90deedbfdada2568b2cb0bc1fdb98efe11f5378d9892b2a88f8f/regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e5364a4502efca094731680e80009632ad6624084aff9a23ce8c8c6820de3e51", size = 860138 },
+    { url = "https://files.pythonhosted.org/packages/93/2d/dd56bb76bd8e95bbce684326302f287455b56242a4f9c61f1bc76e28360e/regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0a86e7eeca091c09e021db8eb72d54751e527fa47b8d5787caf96d9831bd02ad", size = 787692 },
+    { url = "https://files.pythonhosted.org/packages/0b/55/31877a249ab7a5156758246b9c59539abbeba22461b7d8adc9e8475ff73e/regex-2024.11.6-cp312-cp312-win32.whl", hash = "sha256:32f9a4c643baad4efa81d549c2aadefaeba12249b2adc5af541759237eee1c54", size = 262135 },
+    { url = "https://files.pythonhosted.org/packages/38/ec/ad2d7de49a600cdb8dd78434a1aeffe28b9d6fc42eb36afab4a27ad23384/regex-2024.11.6-cp312-cp312-win_amd64.whl", hash = "sha256:a93c194e2df18f7d264092dc8539b8ffb86b45b899ab976aa15d48214138e81b", size = 273567 },
+    { url = "https://files.pythonhosted.org/packages/89/23/c4a86df398e57e26f93b13ae63acce58771e04bdde86092502496fa57f9c/regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5704e174f8ccab2026bd2f1ab6c510345ae8eac818b613d7d73e785f1310f839", size = 482682 },
+    { url = "https://files.pythonhosted.org/packages/3c/8b/45c24ab7a51a1658441b961b86209c43e6bb9d39caf1e63f46ce6ea03bc7/regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:220902c3c5cc6af55d4fe19ead504de80eb91f786dc102fbd74894b1551f095e", size = 287679 },
+    { url = "https://files.pythonhosted.org/packages/7a/d1/598de10b17fdafc452d11f7dada11c3be4e379a8671393e4e3da3c4070df/regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5e7e351589da0850c125f1600a4c4ba3c722efefe16b297de54300f08d734fbf", size = 284578 },
+    { url = "https://files.pythonhosted.org/packages/49/70/c7eaa219efa67a215846766fde18d92d54cb590b6a04ffe43cef30057622/regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5056b185ca113c88e18223183aa1a50e66507769c9640a6ff75859619d73957b", size = 782012 },
+    { url = "https://files.pythonhosted.org/packages/89/e5/ef52c7eb117dd20ff1697968219971d052138965a4d3d9b95e92e549f505/regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e34b51b650b23ed3354b5a07aab37034d9f923db2a40519139af34f485f77d0", size = 820580 },
+    { url = "https://files.pythonhosted.org/packages/5f/3f/9f5da81aff1d4167ac52711acf789df13e789fe6ac9545552e49138e3282/regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5670bce7b200273eee1840ef307bfa07cda90b38ae56e9a6ebcc9f50da9c469b", size = 809110 },
+    { url = "https://files.pythonhosted.org/packages/86/44/2101cc0890c3621b90365c9ee8d7291a597c0722ad66eccd6ffa7f1bcc09/regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08986dce1339bc932923e7d1232ce9881499a0e02925f7402fb7c982515419ef", size = 780919 },
+    { url = "https://files.pythonhosted.org/packages/ce/2e/3e0668d8d1c7c3c0d397bf54d92fc182575b3a26939aed5000d3cc78760f/regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93c0b12d3d3bc25af4ebbf38f9ee780a487e8bf6954c115b9f015822d3bb8e48", size = 771515 },
+    { url = "https://files.pythonhosted.org/packages/a6/49/1bc4584254355e3dba930a3a2fd7ad26ccba3ebbab7d9100db0aff2eedb0/regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:764e71f22ab3b305e7f4c21f1a97e1526a25ebdd22513e251cf376760213da13", size = 696957 },
+    { url = "https://files.pythonhosted.org/packages/c8/dd/42879c1fc8a37a887cd08e358af3d3ba9e23038cd77c7fe044a86d9450ba/regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f056bf21105c2515c32372bbc057f43eb02aae2fda61052e2f7622c801f0b4e2", size = 768088 },
+    { url = "https://files.pythonhosted.org/packages/89/96/c05a0fe173cd2acd29d5e13c1adad8b706bcaa71b169e1ee57dcf2e74584/regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:69ab78f848845569401469da20df3e081e6b5a11cb086de3eed1d48f5ed57c95", size = 774752 },
+    { url = "https://files.pythonhosted.org/packages/b5/f3/a757748066255f97f14506483436c5f6aded7af9e37bca04ec30c90ca683/regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:86fddba590aad9208e2fa8b43b4c098bb0ec74f15718bb6a704e3c63e2cef3e9", size = 838862 },
+    { url = "https://files.pythonhosted.org/packages/5c/93/c6d2092fd479dcaeea40fc8fa673822829181ded77d294a7f950f1dda6e2/regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:684d7a212682996d21ca12ef3c17353c021fe9de6049e19ac8481ec35574a70f", size = 842622 },
+    { url = "https://files.pythonhosted.org/packages/ff/9c/daa99532c72f25051a90ef90e1413a8d54413a9e64614d9095b0c1c154d0/regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a03e02f48cd1abbd9f3b7e3586d97c8f7a9721c436f51a5245b3b9483044480b", size = 772713 },
+    { url = "https://files.pythonhosted.org/packages/13/5d/61a533ccb8c231b474ac8e3a7d70155b00dfc61af6cafdccd1947df6d735/regex-2024.11.6-cp39-cp39-win32.whl", hash = "sha256:41758407fc32d5c3c5de163888068cfee69cb4c2be844e7ac517a52770f9af57", size = 261756 },
+    { url = "https://files.pythonhosted.org/packages/dc/7b/e59b7f7c91ae110d154370c24133f947262525b5d6406df65f23422acc17/regex-2024.11.6-cp39-cp39-win_amd64.whl", hash = "sha256:b2837718570f95dd41675328e111345f9b7095d821bac435aac173ac80b19983", size = 274110 },
+]
+
+[[package]]
+name = "workspace-root"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "lib-a" },
+    { name = "lib-b" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "lib-a" },
+    { name = "lib-b" },
+]


### PR DESCRIPTION
Expands local package detection in `uv_translator.py` to recognize path-based dependencies at **any path**, not just `"."`. This enables support for **uv workspaces with multiple workspace members**. The previous code only detected local packages at the workspace root:

```python
is_local_editable = lock_pkg.get("source") == {"editable": "."}
````

This missed valid workspace members such as:

```toml
source = { editable = "./packages/foo" }
source = { editable = "../other-package" }
```

Instead of exact-matching `"."`, detect local packages by checking for path-based source keys (`editable`, `virtual`, `path`):

```python
is_local_editable = "editable" in source and isinstance(source.get("editable"), str)
```

Testing: ran `bazel test //pycross/tests/uv/lock_workspace:test` and passed. Currently testing on my own repo to validate.