### PR TITLE
Prefer newest manylinux wheels by sorting expanded platforms

### DIFF
--- a/e2e/pdm/vendored_lock_file_bzlmod/pdm_lock_file.bzl
+++ b/e2e/pdm/vendored_lock_file_bzlmod/pdm_lock_file.bzl
@@ -101,7 +101,7 @@ def targets():
         actual = select({
             ":_env_python_3.10.11_aarch64-apple-darwin": "@pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_macosx_11_0_arm64//file",
             ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@pdm_lock_file_wheel_regex_2024.11.6_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
@@ -145,12 +145,12 @@ def repositories():
 
     maybe(
         http_file,
-        name = "pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64",
+        name = "pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64",
         urls = [
-            "https://files.pythonhosted.org/packages/74/c0/be707bcfe98254d8f9d2cff55d216e946f4ea48ad2fd8cf1428f8c5332ba/regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+            "https://files.pythonhosted.org/packages/f2/98/26d3830875b53071f1f0ae6d547f1d98e964dd29ad35cbf94439120bb67a/regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
         ],
-        sha256 = "f02f93b92358ee3f78660e43b4b0091229260c5d5c408d17d60bf26b6c900e86",
-        downloaded_file_path = "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+        sha256 = "997d6a487ff00807ba810e0f8332c18b4eb8d29463cfb7c820dc4b6e7562d0cf",
+        downloaded_file_path = "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     )
 
     maybe(

--- a/e2e/pdm/vendored_lock_file_workspace/pdm_lock_file.bzl
+++ b/e2e/pdm/vendored_lock_file_workspace/pdm_lock_file.bzl
@@ -83,7 +83,7 @@ def targets():
         actual = select({
             ":_env_python_3.10.11_aarch64-apple-darwin": "@pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_macosx_11_0_arm64//file",
             ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@pdm_lock_file_wheel_regex_2024.11.6_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@pdm_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
@@ -124,12 +124,12 @@ def repositories():
 
     maybe(
         http_file,
-        name = "pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64",
+        name = "pdm_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64",
         urls = [
-            "https://files.pythonhosted.org/packages/74/c0/be707bcfe98254d8f9d2cff55d216e946f4ea48ad2fd8cf1428f8c5332ba/regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+            "https://files.pythonhosted.org/packages/f2/98/26d3830875b53071f1f0ae6d547f1d98e964dd29ad35cbf94439120bb67a/regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
         ],
-        sha256 = "f02f93b92358ee3f78660e43b4b0091229260c5d5c408d17d60bf26b6c900e86",
-        downloaded_file_path = "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+        sha256 = "997d6a487ff00807ba810e0f8332c18b4eb8d29463cfb7c820dc4b6e7562d0cf",
+        downloaded_file_path = "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     )
 
     maybe(

--- a/e2e/poetry/vendored_lock_file_bzlmod/poetry_lock_file.bzl
+++ b/e2e/poetry/vendored_lock_file_bzlmod/poetry_lock_file.bzl
@@ -100,7 +100,7 @@ def targets():
         actual = select({
             ":_env_python_3.10.11_aarch64-apple-darwin": "@poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_macosx_11_0_arm64//file",
             ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@poetry_lock_file_wheel_regex_2024.11.6_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
@@ -142,11 +142,11 @@ def repositories():
 
     maybe(
         pypi_file,
-        name = "poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64",
+        name = "poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64",
         package_name = "regex",
         package_version = "2024.11.6",
-        filename = "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
-        sha256 = "f02f93b92358ee3f78660e43b4b0091229260c5d5c408d17d60bf26b6c900e86",
+        filename = "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "997d6a487ff00807ba810e0f8332c18b4eb8d29463cfb7c820dc4b6e7562d0cf",
     )
 
     maybe(

--- a/e2e/poetry/vendored_lock_file_workspace/poetry_lock_file.bzl
+++ b/e2e/poetry/vendored_lock_file_workspace/poetry_lock_file.bzl
@@ -82,7 +82,7 @@ def targets():
         actual = select({
             ":_env_python_3.10.11_aarch64-apple-darwin": "@poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_macosx_11_0_arm64//file",
             ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@poetry_lock_file_wheel_regex_2024.11.6_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@poetry_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
@@ -121,11 +121,11 @@ def repositories():
 
     maybe(
         pypi_file,
-        name = "poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64",
+        name = "poetry_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64",
         package_name = "regex",
         package_version = "2024.11.6",
-        filename = "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
-        sha256 = "f02f93b92358ee3f78660e43b4b0091229260c5d5c408d17d60bf26b6c900e86",
+        filename = "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        sha256 = "997d6a487ff00807ba810e0f8332c18b4eb8d29463cfb7c820dc4b6e7562d0cf",
     )
 
     maybe(

--- a/e2e/uv/vendored_lock_file_bzlmod/uv_lock_file.bzl
+++ b/e2e/uv/vendored_lock_file_bzlmod/uv_lock_file.bzl
@@ -101,7 +101,7 @@ def targets():
         actual = select({
             ":_env_python_3.10.11_aarch64-apple-darwin": "@uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_macosx_11_0_arm64//file",
             ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@uv_lock_file_wheel_regex_2024.11.6_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
@@ -145,12 +145,12 @@ def repositories():
 
     maybe(
         http_file,
-        name = "uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64",
+        name = "uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64",
         urls = [
-            "https://files.pythonhosted.org/packages/74/c0/be707bcfe98254d8f9d2cff55d216e946f4ea48ad2fd8cf1428f8c5332ba/regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+            "https://files.pythonhosted.org/packages/f2/98/26d3830875b53071f1f0ae6d547f1d98e964dd29ad35cbf94439120bb67a/regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
         ],
-        sha256 = "f02f93b92358ee3f78660e43b4b0091229260c5d5c408d17d60bf26b6c900e86",
-        downloaded_file_path = "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+        sha256 = "997d6a487ff00807ba810e0f8332c18b4eb8d29463cfb7c820dc4b6e7562d0cf",
+        downloaded_file_path = "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     )
 
     maybe(

--- a/e2e/uv/vendored_lock_file_workspace/uv_lock_file.bzl
+++ b/e2e/uv/vendored_lock_file_workspace/uv_lock_file.bzl
@@ -83,7 +83,7 @@ def targets():
         actual = select({
             ":_env_python_3.10.11_aarch64-apple-darwin": "@uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_macosx_11_0_arm64//file",
             ":_env_python_3.10.11_aarch64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
-            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64//file",
+            ":_env_python_3.10.11_x86_64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
             ":_env_python_3.11.6_aarch64-apple-darwin": "@uv_lock_file_wheel_regex_2024.11.6_cp311_cp311_macosx_11_0_arm64//file",
             ":_env_python_3.11.6_aarch64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_aarch64.manylinux2014_aarch64//file",
             ":_env_python_3.11.6_x86_64-unknown-linux-gnu": "@uv_lock_file_wheel_regex_2024.11.6_cp311_cp311_manylinux_2_17_x86_64.manylinux2014_x86_64//file",
@@ -124,12 +124,12 @@ def repositories():
 
     maybe(
         http_file,
-        name = "uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64",
+        name = "uv_lock_file_wheel_regex_2024.11.6_cp310_cp310_manylinux_2_17_x86_64.manylinux2014_x86_64",
         urls = [
-            "https://files.pythonhosted.org/packages/74/c0/be707bcfe98254d8f9d2cff55d216e946f4ea48ad2fd8cf1428f8c5332ba/regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+            "https://files.pythonhosted.org/packages/f2/98/26d3830875b53071f1f0ae6d547f1d98e964dd29ad35cbf94439120bb67a/regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
         ],
-        sha256 = "f02f93b92358ee3f78660e43b4b0091229260c5d5c408d17d60bf26b6c900e86",
-        downloaded_file_path = "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
+        sha256 = "997d6a487ff00807ba810e0f8332c18b4eb8d29463cfb7c820dc4b6e7562d0cf",
+        downloaded_file_path = "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     )
 
     maybe(

--- a/pycross/private/toolchain_helpers.bzl
+++ b/pycross/private/toolchain_helpers.bzl
@@ -43,9 +43,12 @@ def _get_env_platforms(py_platform, glibc_version, musl_version, macos_version):
     platform_info = PLATFORMS[py_platform]
     arch = platform_info.arch
     if py_platform.endswith("linux-gnu") or py_platform.endswith("linux-gnu-freethreaded"):
+        # Emit modern manylinux tags newest-first; the target environment
+        # generator will insert legacy aliases (e.g. manylinux2014_x86_64)
+        # immediately after their modern equivalents.
         return ["linux_{}".format(arch)] + [
             "manylinux_2_{}_{}".format(i, arch)
-            for i in range(5, glibc_micro + 1)
+            for i in range(glibc_micro, 4, -1)
         ]
     elif py_platform.endswith("linux-musl"):
         return [

--- a/pycross/private/tools/target_environment_generator.py
+++ b/pycross/private/tools/target_environment_generator.py
@@ -5,6 +5,7 @@ marker overrides and outputs the result of guessed markers with overrides.
 from __future__ import annotations
 
 import json
+import re
 from argparse import Namespace
 from dataclasses import dataclass
 from dataclasses import field
@@ -56,6 +57,14 @@ class Input:
         return from_dict(Input, data, config=Config(cast=[Path]))
 
 
+def _platform_sort_key(platform: str) -> tuple:
+    if platform.startswith("manylinux_2_"):
+        m = re.match(r"manylinux_2_(\d+)_", platform)
+        n = int(m.group(1)) if m else 0
+        return (0, -n, platform)
+    return (1, 0, platform)
+
+
 def _expand_manylinux_platforms(platforms: Iterable[str]) -> List[str]:
     extra_platforms = set()
     platforms = set(platforms)
@@ -63,7 +72,7 @@ def _expand_manylinux_platforms(platforms: Iterable[str]) -> List[str]:
         if platform in _MANYLINUX_ALIASES:
             extra_platforms.add(_MANYLINUX_ALIASES[platform])
     platforms.update(extra_platforms)
-    return sorted(platforms)
+    return sorted(platforms, key=_platform_sort_key)
 
 
 def create(input: Input) -> None:

--- a/pycross/private/tools/target_environment_generator.py
+++ b/pycross/private/tools/target_environment_generator.py
@@ -5,7 +5,6 @@ marker overrides and outputs the result of guessed markers with overrides.
 from __future__ import annotations
 
 import json
-import re
 from argparse import Namespace
 from dataclasses import dataclass
 from dataclasses import field
@@ -57,22 +56,21 @@ class Input:
         return from_dict(Input, data, config=Config(cast=[Path]))
 
 
-def _platform_sort_key(platform: str) -> tuple:
-    if platform.startswith("manylinux_2_"):
-        m = re.match(r"manylinux_2_(\d+)_", platform)
-        n = int(m.group(1)) if m else 0
-        return (0, -n, platform)
-    return (1, 0, platform)
-
-
 def _expand_manylinux_platforms(platforms: Iterable[str]) -> List[str]:
-    extra_platforms = set()
-    platforms = set(platforms)
+    # Preserve the input order, inserting each platform's legacy alias (if any)
+    # immediately after it. Callers (e.g. toolchain_helpers.bzl) are responsible
+    # for providing platforms in the desired priority order.
+    expanded: List[str] = []
+    seen: set = set()
     for platform in platforms:
-        if platform in _MANYLINUX_ALIASES:
-            extra_platforms.add(_MANYLINUX_ALIASES[platform])
-    platforms.update(extra_platforms)
-    return sorted(platforms, key=_platform_sort_key)
+        if platform not in seen:
+            expanded.append(platform)
+            seen.add(platform)
+        alias = _MANYLINUX_ALIASES.get(platform)
+        if alias and alias not in seen:
+            expanded.append(alias)
+            seen.add(alias)
+    return expanded
 
 
 def create(input: Input) -> None:


### PR DESCRIPTION
## Problem
After switching to rules_pycross, we discovered that some packages (e.g. XGBoost) were resolving to the manylinux2014 wheel instead of the manylinux_2_28 wheel on Linux, which led to slower or less optimal builds when the newer wheel is preferred.

- In [_expand_manylinux_platforms()](https://github.com/jvolkman/rules_pycross/blob/main/pycross/private/tools/target_environment_generator.py#L59), the expanded platform list was ordered with a regular [sorted(platforms) ](https://github.com/jvolkman/rules_pycross/blob/main/pycross/private/tools/target_environment_generator.py#L66). 
- So in the environment’s tag list, manylinux2014_x86_64 appeared before manylinux_2_28_x86_64. 
- Then pip’s CandidateEvaluator.[compute_best_candidate()](https://github.com/jvolkman/rules_pycross/blob/main/pycross/private/tools/raw_lock_resolver.py#L182) ranks wheels by Wheel.support_index_min(self._supported_tags): the first compatible tag in the list wins. 
- Because manylinux2014 came first, pip always chose the manylinux2014 wheel when both manylinux2014 and manylinux_2_28 wheels were compatible.

## Solution 
Sort the expanded platforms so newer manylinux variants come first, and use this key in _expand_manylinux_platforms() instead of sorted(platforms).

## Example
With some print debugging while building `xgboost`
**Before**
`compute_best_candidate` filters manylinux_2_28 out of being the "best candidate" 
```console
Candidates for xgboost: [<InstallationCandidate('xgboost', <Version('3.0.1')>, <Link xgboost-3.0.1-py3-none-manylinux2014_x86_64.whl>)>, <InstallationCandidate('xgboost', <Version('3.0.1')>, <Link xgboost-3.0.1-py3-none-manylinux_2_28_x86_64.whl>)>, <InstallationCandidate('xgboost', <Version('3.0.1')>, <Link xgboost-3.0.1.tar.gz>)>]

Best candidate for xgboost: 'xgboost' candidate (version 3.0.1 at xgboost-3.0.1-py3-none-manylinux2014_x86_64.whl)
```

**After**
`compute_best_candidate` chooses manylinux_2_28 as the "best candidate" 
```console
Candidates for xgboost: [<InstallationCandidate('xgboost', <Version('3.0.1')>, <Link xgboost-3.0.1-py3-none-manylinux2014_x86_64.whl>)>, <InstallationCandidate('xgboost', <Version('3.0.1')>, <Link xgboost-3.0.1-py3-none-manylinux_2_28_x86_64.whl>)>, <InstallationCandidate('xgboost', <Version('3.0.1')>, <Link xgboost-3.0.1.tar.gz>)>]

Best candidate for xgboost: 'xgboost' candidate (version 3.0.1 at xgboost-3.0.1-py3-none-manylinux_2_28_x86_64.whl)
```

## Note
I'm not sure if something like this covers all edge cases