### PR TITLE
Fix pypi_index attr name passed to pypi_file rule

### DIFF
--- a/pycross/private/bzlmod/lock_repos.bzl
+++ b/pycross/private/bzlmod/lock_repos.bzl
@@ -70,7 +70,7 @@ def _lock_repos_impl(module_ctx):
                     sha256 = file["sha256"],
                 )
                 if create_tag.pypi_index:
-                    pypi_file_attrs["pypi_index"] = create_tag.pypi_index
+                    pypi_file_attrs["index"] = create_tag.pypi_index
 
                 pypi_file(**pypi_file_attrs)
 


### PR DESCRIPTION
pypi_file's attribute is named 'index', not 'pypi_index'. The wrong key caused an error whenever `lock_repos.create(pypi_index=...)` was set to a non-empty value.