### PR TITLE
Resolve relative wheel URLs returned by PyPI-compatible indexes

### DIFF
--- a/pycross/private/pypi_file.bzl
+++ b/pycross/private/pypi_file.bzl
@@ -48,6 +48,19 @@ def _pypi_file_impl(ctx):
             ),
         )
 
+    # Resolve relative URLs. Artifactory anchors relative URLs to the simple
+    # index path (simple/{package}/), not to the JSON API path, so use that
+    # as the base rather than index_url.
+    if not url.startswith("http://") and not url.startswith("https://"):
+        simple_base = ctx.attr.index.rstrip("/") + "/simple/" + ctx.attr.package_name
+        base_parts = simple_base.split("/")
+        for part in url.split("/"):
+            if part == "..":
+                base_parts = base_parts[:-1]
+            elif part != ".":
+                base_parts.append(part)
+        url = "/".join(base_parts)
+
     download_info = ctx.download(
         url,
         "file/" + ctx.attr.filename,

--- a/pycross/private/pypi_file.bzl
+++ b/pycross/private/pypi_file.bzl
@@ -48,9 +48,9 @@ def _pypi_file_impl(ctx):
             ),
         )
 
-    # Resolve relative URLs. Artifactory anchors relative URLs to the simple
-    # index path (simple/{package}/), not to the JSON API path, so use that
-    # as the base rather than index_url.
+    # Resolve relative URLs. These relative paths return by JSON API are the same as
+    # those returned by HTML index paths. So they are relative to the simple index path,
+    # not the JSON API path.
     if not url.startswith("http://") and not url.startswith("https://"):
         simple_base = ctx.attr.index.rstrip("/") + "/simple/" + ctx.attr.package_name
         base_parts = simple_base.split("/")


### PR DESCRIPTION
Some indexes (e.g. Artifactory) return relative URLs in the JSON API response instead of absolute ones. Resolve them against the HTML index URL before downloading.