### PR TITLE
fix: avoid sort_key values when creating pycross internal repo

### DIFF
--- a/pycross/private/bzlmod/pycross.bzl
+++ b/pycross/private/bzlmod/pycross.bzl
@@ -51,8 +51,14 @@ def _pycross_impl(module_ctx):
 
     pypi_all_repositories()
 
-    environments_attrs = {k: getattr(environments_tag, k) for k in dir(environments_tag)}
-    toolchains_attrs = {k: getattr(toolchains_tag, k) for k in dir(toolchains_tag)}
+    environments_attrs = {
+        k: getattr(environments_tag, k)
+        for k in CREATE_ENVIRONMENTS_ATTRS.keys()
+    }
+    toolchains_attrs = {
+        k: getattr(toolchains_tag, k)
+        for k in REGISTER_TOOLCHAINS_ATTRS.keys()
+    }
 
     create_internal_repo(
         python_interpreter_target = python_interpreter_target,


### PR DESCRIPTION
### Summary
Fixes Bazel rolling failures caused by non-serializable sort_key values being passed into repository_rule attributes.

Fixes https://github.com/jvolkman/rules_pycross/issues/225

### What Changed
- Replaced dynamic tag attribute collection via dir(...) with explicit schema keys for environment and toolchain attrs.
- Kept wheel path sorting deterministic without relying on key-based sorting behavior that can produce sort_key values.

### Why
Bazel rolling enforces stricter serialization of Starlark values, and sort_key objects are rejected during module extension evaluation.

https://github.com/bazelbuild/bazel/pull/27883

### Validation
`bazel test //... --keep_going` (remaining failures are outside this specific sort_key path).