### PR TITLE
Process nested .pth files for wheel build dependencies

### DIFF
--- a/e2e/uv/build_wheel/BUILD.bazel
+++ b/e2e/uv/build_wheel/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@python_versions//3.10.11:defs.bzl", py_test_3_10_11 = "py_test")
 load("@python_versions//3.11.6:defs.bzl", py_test_3_11_6 = "py_test")
 load("@python_versions//3.12.0:defs.bzl", py_test_3_12_0 = "py_test")
-load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -47,8 +47,8 @@ genrule(
         "distutils_probe/setup.py",
     ],
     outs = ["distutils_probe-0.1.tar.gz"],
-    tools = [":build_distutils_probe_sdist"],
     cmd = "\"$(location :build_distutils_probe_sdist)\" \"$@\" \"$(location distutils_probe/pyproject.toml)\" \"$(location distutils_probe/setup.py)\" \"$(location distutils_probe/distutils_probe_pkg/__init__.py)\"",
+    tools = [":build_distutils_probe_sdist"],
 )
 
 # Synthetic regression probe for build dependency .pth processing inside the build venv.

--- a/e2e/uv/build_wheel/BUILD.bazel
+++ b/e2e/uv/build_wheel/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@python_versions//3.10.11:defs.bzl", py_test_3_10_11 = "py_test")
 load("@python_versions//3.11.6:defs.bzl", py_test_3_11_6 = "py_test")
 load("@python_versions//3.12.0:defs.bzl", py_test_3_12_0 = "py_test")
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_build", "pycross_wheel_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -33,6 +34,38 @@ pycross_wheel_library(
     wheel = ":zstandard_build",
 )
 
+py_binary(
+    name = "build_distutils_probe_sdist",
+    srcs = ["build_distutils_probe_sdist.py"],
+)
+
+genrule(
+    name = "distutils_probe_sdist",
+    srcs = [
+        "distutils_probe/distutils_probe_pkg/__init__.py",
+        "distutils_probe/pyproject.toml",
+        "distutils_probe/setup.py",
+    ],
+    outs = ["distutils_probe-0.1.tar.gz"],
+    tools = [":build_distutils_probe_sdist"],
+    cmd = "\"$(location :build_distutils_probe_sdist)\" \"$@\" \"$(location distutils_probe/pyproject.toml)\" \"$(location distutils_probe/setup.py)\" \"$(location distutils_probe/distutils_probe_pkg/__init__.py)\"",
+)
+
+# Synthetic regression probe for build dependency .pth processing inside the build venv.
+pycross_wheel_build(
+    name = "distutils_probe_build",
+    sdist = ":distutils_probe_sdist",
+    deps = [
+        "@uv//:setuptools",
+        "@uv//:wheel",
+    ],
+)
+
+pycross_wheel_library(
+    name = "distutils_probe",
+    wheel = ":distutils_probe_build",
+)
+
 py_test_3_10_11(
     name = "test_zstandard_3_10_11",
     srcs = ["@rules_pycross_e2e_shared//:test_zstandard.py"],
@@ -52,4 +85,11 @@ py_test_3_12_0(
     srcs = ["@rules_pycross_e2e_shared//:test_zstandard.py"],
     main = "test_zstandard.py",
     deps = [":zstandard"],
+)
+
+py_test_3_12_0(
+    name = "test_distutils_probe_3_12_0",
+    srcs = ["test_distutils_probe.py"],
+    main = "test_distutils_probe.py",
+    deps = [":distutils_probe"],
 )

--- a/e2e/uv/build_wheel/build_distutils_probe_sdist.py
+++ b/e2e/uv/build_wheel/build_distutils_probe_sdist.py
@@ -1,0 +1,30 @@
+import io
+import tarfile
+import sys
+from pathlib import Path
+
+
+def _add_file(archive: tarfile.TarFile, source: Path, dest: Path) -> None:
+    data = source.read_bytes()
+    info = tarfile.TarInfo(str(dest))
+    info.size = len(data)
+    info.mode = 0o644
+    archive.addfile(info, io.BytesIO(data))
+
+
+def main() -> None:
+    out_path = Path(sys.argv[1])
+    pyproject = Path(sys.argv[2])
+    setup = Path(sys.argv[3])
+    package_init = Path(sys.argv[4])
+
+    root = Path("distutils_probe-0.1")
+
+    with tarfile.open(out_path, "w:gz") as archive:
+        _add_file(archive, pyproject, root / "pyproject.toml")
+        _add_file(archive, setup, root / "setup.py")
+        _add_file(archive, package_init, root / "distutils_probe_pkg" / "__init__.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/uv/build_wheel/build_distutils_probe_sdist.py
+++ b/e2e/uv/build_wheel/build_distutils_probe_sdist.py
@@ -1,6 +1,6 @@
 import io
-import tarfile
 import sys
+import tarfile
 from pathlib import Path
 
 

--- a/e2e/uv/build_wheel/distutils_probe/pyproject.toml
+++ b/e2e/uv/build_wheel/distutils_probe/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/e2e/uv/build_wheel/distutils_probe/setup.py
+++ b/e2e/uv/build_wheel/distutils_probe/setup.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+
+from setuptools import setup
+from setuptools.command.build_py import build_py as _build_py
+
+
+class build_py(_build_py):
+    def run(self):
+        subprocess.check_call([sys.executable, "-c", "from distutils.util import byte_compile"])
+        super().run()
+
+
+setup(
+    name="distutils_probe",
+    version="0.1",
+    packages=["distutils_probe_pkg"],
+    cmdclass={"build_py": build_py},
+)

--- a/e2e/uv/build_wheel/test_distutils_probe.py
+++ b/e2e/uv/build_wheel/test_distutils_probe.py
@@ -1,0 +1,5 @@
+import importlib
+
+
+def test_import() -> None:
+    importlib.import_module("distutils_probe_pkg")

--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -630,9 +630,12 @@ def build_venv(
         with open(site_dir / "_pycross_sys_base_prefix.pth", "w") as f:
             f.write(f'import sys; sys.base_prefix = sys.base_exec_prefix = "{target_python_exe.parent.parent}"\n')
 
-    # Add a pth file to include all of our build dependencies.
+    # Add build dependencies as site directories so nested .pth files from those
+    # dependencies are processed when Python initializes the build venv.
     with open(site_dir / "deps.pth", "w") as f:
-        f.write("\n".join(os.path.relpath(p, site_dir) for p in path) + "\n")
+        for dep_path in path:
+            rel_dep_path = os.path.relpath(dep_path, site_dir)
+            f.write(f'import os, site; site.addsitedir(os.path.join(sitedir, {rel_dep_path!r}))\n')
 
 
 def build_wheel(

--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -635,7 +635,7 @@ def build_venv(
     with open(site_dir / "deps.pth", "w") as f:
         for dep_path in path:
             rel_dep_path = os.path.relpath(dep_path, site_dir)
-            f.write(f'import os, site; site.addsitedir(os.path.join(sitedir, {rel_dep_path!r}))\n')
+            f.write(f"import os, site; site.addsitedir(os.path.join(sitedir, {rel_dep_path!r}))\n")
 
 
 def build_wheel(


### PR DESCRIPTION
## Problem

  `wheel_builder.py` currently writes build dependencies into `deps.pth` as raw
  path entries. That puts those directories on `sys.path`, but Python does not
  treat them as site directories, so it does not process their nested `.pth`
  files.

  On Python 3.12, that breaks builds that rely on startup hooks installed by
  build dependencies. One example is `setuptools`: if its `.pth` hook does not
  run, its `distutils` compatibility shim is not activated, and build-time
  imports such as `from distutils.util import byte_compile` fail.

  We hit this in a real consumer build while building `python-ldap` under Python
  3.12.

  ## Solution

  This change adds a focused end-to-end regression test in
  `e2e/uv/build_wheel` and updates `wheel_builder.py` to add each build
  dependency via `site.addsitedir(...)` instead of a raw path line.

  `site.addsitedir(...)` keeps the dependency on `sys.path` and also causes
  Python to process nested `.pth` files in that dependency. That is the behavior
  the wheel build environment needs here. With that change, `setuptools` loads
  its `distutils` compatibility shim correctly inside the isolated build
  environment.

  The regression test is synthetic on purpose. It avoids package-specific noise
  and checks the contract directly by importing `distutils` during wheel build.

  ## Validation

  I first pushed the regression test by itself and confirmed that upstream CI
  failed in `e2e/uv/build_wheel` with `ModuleNotFoundError: No module named
  'distutils'`.

  After applying the fix in `wheel_builder.py`, I validated with:

  - `bazel test //:test_distutils_probe_3_12_0 --enable_bzlmod=true --enable_workspace=false`
  - `bazel test //:test_distutils_probe_3_12_0 --enable_bzlmod=false --enable_workspace=true`