### PR TITLE
Fix Darwin compiler wrapper shebangs

### DIFF
--- a/pycross/private/tools/BUILD.bazel
+++ b/pycross/private/tools/BUILD.bazel
@@ -167,6 +167,25 @@ py_binary(
     ],
 )
 
+py_test(
+    name = "wheel_builder_shebang_test",
+    size = "small",
+    srcs = [
+        "wheel_builder.py",
+        "wheel_builder_shebang_test.py",
+    ],
+    imports = ["../../.."],
+    tags = ["unit"],
+    deps = [
+        ":args",
+        ":target_environment",
+        "//pycross/private/tools/crossenv",
+        "@rules_pycross_internal//deps:build",
+        "@rules_pycross_internal//deps:packaging",
+        "@rules_pycross_internal//deps:tomli",
+    ],
+)
+
 py_binary(
     name = "wheel_installer",
     srcs = ["wheel_installer.py"],

--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -266,6 +266,21 @@ def get_wrapper_flags(cflags: str) -> List[str]:
     return result
 
 
+def _is_script(path: Path) -> bool:
+    try:
+        with open(path, "rb") as f:
+            return f.read(2) == b"#!"
+    except OSError:
+        return False
+
+
+def _python_wrapper_shebang(python_exe: Path) -> str:
+    python_path = python_exe.absolute()
+    if sys.platform == "darwin" and _is_script(python_path):
+        return f"#!/usr/bin/env {python_path}"
+    return f"#!{python_path}"
+
+
 def wrap_cc(lang: str, cc_exe: Path, cflags: str, python_exe: Path, bin_dir: Path) -> Path:
     assert lang in ("cc", "cxx")
     version_str = subprocess.check_output([cc_exe, "--version"]).decode("utf-8")
@@ -292,12 +307,13 @@ def wrap_cc(lang: str, cc_exe: Path, cflags: str, python_exe: Path, bin_dir: Pat
         return cc_exe
 
     wrapper_path = bin_dir / wrapper_name
+    shebang = _python_wrapper_shebang(python_exe)
 
     with open(wrapper_path, "w") as f:
         f.write(
             textwrap.dedent(
                 f"""\
-                #!{python_exe.absolute()}
+                {shebang}
                 import os
                 import sys
 

--- a/pycross/private/tools/wheel_builder_shebang_test.py
+++ b/pycross/private/tools/wheel_builder_shebang_test.py
@@ -1,0 +1,50 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pycross.private.tools import wheel_builder
+
+
+class WheelBuilderShebangTest(unittest.TestCase):
+    def test_darwin_script_python_uses_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            python_exe = Path(tmp) / "python_wrapper"
+            python_exe.write_bytes(b'#!/bin/sh\nexec python3 "$@"\n')
+
+            with mock.patch.object(wheel_builder.sys, "platform", "darwin"):
+                shebang = wheel_builder._python_wrapper_shebang(python_exe)
+
+            self.assertEqual(shebang, f"#!/usr/bin/env {python_exe.absolute()}")
+
+    def test_darwin_non_script_python_uses_direct_shebang(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            python_exe = Path(tmp) / "python"
+            python_exe.write_bytes(b"\xcf\xfa\xed\xfe")
+
+            with mock.patch.object(wheel_builder.sys, "platform", "darwin"):
+                shebang = wheel_builder._python_wrapper_shebang(python_exe)
+
+            self.assertEqual(shebang, f"#!{python_exe.absolute()}")
+
+    def test_linux_script_python_uses_direct_shebang(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            python_exe = Path(tmp) / "python_wrapper"
+            python_exe.write_bytes(b'#!/bin/sh\nexec python3 "$@"\n')
+
+            with mock.patch.object(wheel_builder.sys, "platform", "linux"):
+                shebang = wheel_builder._python_wrapper_shebang(python_exe)
+
+            self.assertEqual(shebang, f"#!{python_exe.absolute()}")
+
+    def test_missing_python_uses_direct_shebang(self) -> None:
+        python_exe = Path("/missing/python_wrapper")
+
+        with mock.patch.object(wheel_builder.sys, "platform", "darwin"):
+            shebang = wheel_builder._python_wrapper_shebang(python_exe)
+
+        self.assertEqual(shebang, f"#!{python_exe.absolute()}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
pycross generates compiler wrappers such as bin/clang as Python scripts. Those wrappers currently use the selected exec Python directly in the shebang:

    #!/path/to/python

That works when /path/to/python is a native executable. It fails on Darwin when /path/to/python is itself a script wrapper:

    bin/clang -> #!/path/to/python-wrapper

    python-wrapper -> #!/bin/sh ...

When extension builds execute bin/clang via execve(), Darwin tries to treat the script wrapper as the kernel-visible interpreter for another script and returns ENOEXEC. In Python build output this appears as:

    command '../bin/clang' failed: Exec format error

The fix is to make wrapper shebang generation inspect the selected exec Python. On Darwin, if that path points to a script, pycross now writes the compiler wrapper shebang as:

    #!/usr/bin/env /path/to/python-wrapper

For every other case, pycross keeps the existing direct shebang:

    #!/path/to/python

This keeps native Python executables and non-Darwin platforms unchanged while making the Darwin script-wrapper case executable. /usr/bin/env is a native executable, so Darwin accepts it as the shebang interpreter; env then dispatches to the selected Python wrapper.

This does introduce one small Darwin-only hermeticity tradeoff: the generated wrapper now depends on /usr/bin/env as a trampoline when the selected Python is a script. The actual Python runtime is still the selected toolchain executable; env is only used to get Darwin past the kernel-level nested-script restriction.

Apple's execve(2) documentation describes interpreter scripts and ENOEXEC:

https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/execve.2.html

Linux permits recursive script interpreters, which is why this fallback is Darwin-specific:

https://man.archlinux.org/man/execve.2.en

This is required after introducing the ability to use FilesToRunProvider (where the executable can be a wrapper) in https://github.com/jvolkman/rules_pycross/pull/236.