### PR TITLE
Support uv URL sources with #subdirectory= (lock translation + wheel build)

### DIFF
--- a/pycross/private/tools/uv_translator.py
+++ b/pycross/private/tools/uv_translator.py
@@ -367,14 +367,36 @@ def collect_and_process_packages(packages_list: list[Dict[str, Any]]) -> Dict[Pa
 
             dependencies.add(Requirement(dep_string))
 
-        files = lock_pkg.get("wheels", [])
-        if lock_pkg.get("sdist"):
-            files.append(lock_pkg.get("sdist"))
-
-        files = {parse_file_info(f) for f in files}
-
         source = lock_pkg.get("source", {})
         sdist = lock_pkg.get("sdist", {})
+
+        files = {parse_file_info(f) for f in lock_pkg.get("wheels", [])}
+        if sdist:
+            if "url" in sdist or "file" in sdist:
+                files.add(parse_file_info(sdist))
+            elif "url" in source:
+                # URL-based sources (e.g. an archive referenced with a
+                # `#subdirectory=` fragment) put the download URL on the
+                # `source` entry rather than the `sdist` entry. The archive
+                # file name (e.g. a git ref tarball) is not a PEP 503 sdist
+                # name, which both PackageFile and pip's link evaluator
+                # reject, so synthesise a canonical `{name}-{version}.tar.gz`
+                # file name while keeping the real download URL.
+                url = source["url"]
+                file_hash = sdist["hash"]
+                assert file_hash.startswith("sha256:")
+                file_name = f"{package_name}-{package_version}.tar.gz"
+                files.add(
+                    PackageFile(
+                        name=file_name,
+                        sha256=file_hash[7:],
+                        urls=(url,),
+                        package_name=package_name,
+                        package_version=Version(package_version),
+                    )
+                )
+            else:
+                files.add(parse_file_info(sdist))
 
         # Check for editable source (any path value)
         is_local_editable = "editable" in source and isinstance(source.get("editable"), str)

--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -810,6 +810,18 @@ def main(args: Any, temp_dir: Path, is_debug: bool) -> None:
     # Extract the sdist and rename it to 'sdist'
     sdist_dir = temp_dir / "sdist"
     _sdist_extracted_dir = extract_sdist(args.sdist, temp_dir)
+    if args.sdist_subdirectory:
+        # The sdist is an archive whose buildable package lives in a
+        # subdirectory (e.g. a monorepo referenced via a `#subdirectory=`
+        # URL dep). Descend into it before the rename so the subdirectory
+        # becomes the build root and all the `..`-relative path handling
+        # below is unchanged.
+        subdirectory = Path(args.sdist_subdirectory)
+        if subdirectory.is_absolute() or ".." in subdirectory.parts:
+            _error(f"sdist subdirectory must be a relative path within the sdist: {args.sdist_subdirectory}")
+        _sdist_extracted_dir = _sdist_extracted_dir / subdirectory
+        if not _sdist_extracted_dir.is_dir():
+            _error(f"sdist subdirectory does not exist: {args.sdist_subdirectory}")
     _sdist_extracted_dir.rename(sdist_dir)
 
     # Change into the new directory
@@ -1016,6 +1028,13 @@ def parse_flags() -> Any:
         type=Path,
         required=True,
         help="The sdist path.",
+    )
+
+    parser.add_argument(
+        "--sdist-subdirectory",
+        type=str,
+        default=None,
+        help="A subdirectory within the extracted sdist to build from.",
     )
 
     parser.add_argument(

--- a/pycross/private/wheel_build.bzl
+++ b/pycross/private/wheel_build.bzl
@@ -212,6 +212,9 @@ def _handle_sdist(ctx, args, inputs):  # -> PycrossWheelInfo
     inputs.append(ctx.file.sdist)
     args.add("--sdist", ctx.file.sdist)
 
+    if ctx.attr.sdist_subdirectory:
+        args.add("--sdist-subdirectory", ctx.attr.sdist_subdirectory)
+
     sdist_name = ctx.file.sdist.basename
     if sdist_name.lower().endswith(".tar.gz"):
         wheel_name = sdist_name[:-7]
@@ -373,6 +376,13 @@ pycross_wheel_build = rule(
             doc = "The sdist file.",
             allow_single_file = [".tar.gz", ".zip"],
             mandatory = True,
+        ),
+        "sdist_subdirectory": attr.string(
+            doc = (
+                "An optional subdirectory within the extracted sdist to build " +
+                "from. Use for archives (e.g. monorepos referenced via a " +
+                "`#subdirectory=` URL dep) whose buildable package is nested."
+            ),
         ),
         "deps": attr.label_list(
             doc = "A list of Python build dependencies for the wheel.",

--- a/pycross/tests/uv/lock_url_subdirectory/BUILD.bazel
+++ b/pycross/tests/uv/lock_url_subdirectory/BUILD.bazel
@@ -1,0 +1,38 @@
+"""
+uv records a dependency on a URL archive referenced with a
+`#subdirectory=` fragment by putting the download URL on the `source`
+entry and leaving the `sdist` entry with only a `hash` (no `url`/`file`):
+
+  [[package]]
+  name = "uv-build"
+  version = "0.11.18"
+  source = { url = "https://github.com/astral-sh/uv/archive/refs/tags/0.11.18.tar.gz", subdirectory = "crates/uv-build" }
+  sdist = { hash = "sha256:..." }
+
+The translator falls back to the `source` URL for such sdists and
+synthesises a canonical `{name}-{version}.tar.gz` file name, since the
+archive file name is not a valid PEP 503 sdist name.
+"""
+
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("//pycross:defs.bzl", "pycross_uv_lock_model")
+
+pycross_uv_lock_model(
+    name = "lock",
+    lock_file = "uv.lock",
+    project_file = "pyproject.toml",
+)
+
+write_source_file(
+    name = "update_expected",
+    diff_test = False,
+    in_file = ":lock",
+    out_file = "expected.json",
+)
+
+diff_test(
+    name = "test",
+    file1 = ":lock",
+    file2 = "expected.json",
+)

--- a/pycross/tests/uv/lock_url_subdirectory/expected.json
+++ b/pycross/tests/uv/lock_url_subdirectory/expected.json
@@ -1,0 +1,24 @@
+{
+  "packages": {
+    "uv-build@0.11.18": {
+      "files": [
+        {
+          "name": "uv-build-0.11.18.tar.gz",
+          "package_name": "uv-build",
+          "package_version": "0.11.18",
+          "sha256": "0034799d786c2c4ded3c59c7327e6607ad802c85e814200d5719463aee490741",
+          "urls": [
+            "https://github.com/astral-sh/uv/archive/refs/tags/0.11.18.tar.gz"
+          ]
+        }
+      ],
+      "name": "uv-build",
+      "python_versions": "",
+      "version": "0.11.18"
+    }
+  },
+  "pins": {
+    "uv-build": "uv-build@0.11.18"
+  },
+  "python_versions": "<3.13,>=3.9"
+}

--- a/pycross/tests/uv/lock_url_subdirectory/pyproject.toml
+++ b/pycross/tests/uv/lock_url_subdirectory/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "rules-pycross-test"
+version = "0.1.0"
+description = ""
+requires-python = ">=3.9, <3.13"
+dependencies = [
+    "uv-build @ https://github.com/astral-sh/uv/archive/refs/tags/0.11.18.tar.gz#subdirectory=crates/uv-build",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/pycross/tests/uv/lock_url_subdirectory/uv.lock
+++ b/pycross/tests/uv/lock_url_subdirectory/uv.lock
@@ -1,0 +1,20 @@
+version = 1
+revision = 3
+requires-python = ">=3.9, <3.13"
+
+[[package]]
+name = "rules-pycross-test"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "uv-build" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "uv-build", url = "https://github.com/astral-sh/uv/archive/refs/tags/0.11.18.tar.gz", subdirectory = "crates/uv-build" }]
+
+[[package]]
+name = "uv-build"
+version = "0.11.18"
+source = { url = "https://github.com/astral-sh/uv/archive/refs/tags/0.11.18.tar.gz", subdirectory = "crates/uv-build" }
+sdist = { hash = "sha256:0034799d786c2c4ded3c59c7327e6607ad802c85e814200d5719463aee490741" }


### PR DESCRIPTION
# Support uv URL sources with `#subdirectory=` (lock translation + wheel build)

## Problem

A `pyproject.toml` dependency on a URL archive with a `#subdirectory=` fragment
(e.g. a monorepo whose installable package lives at `packages/<name>/`):

```toml
dependencies = [
    "uv-build @ https://github.com/astral-sh/uv/archive/refs/tags/0.11.18.tar.gz#subdirectory=crates/uv-build",
]
```

is recorded by uv with the download URL on the `source` entry, leaving the
`sdist` entry with only a hash:

```toml
[[package]]
name = "uv-build"
version = "0.11.18"
source = { url = "https://github.com/astral-sh/uv/archive/refs/tags/0.11.18.tar.gz", subdirectory = "crates/uv-build" }
sdist = { hash = "sha256:0034799d786c2c4ded3c59c7327e6607ad802c85e814200d5719463aee490741" }
```

This breaks rules_pycross in two places:

1. **Lock translation**: `uv_translator.parse_file_info` requires every file
   entry to carry a `url` or `file` member, so the whole lock fails with
   `AssertionError: file entry has no file or url member`.
2. **Wheel build**: even with a translated lock, `pycross_wheel_build` cannot
   build such a package. The downloaded sdist is the *whole* archive;
   `wheel_builder.extract_sdist` chdirs into its single top-level directory
   (the repo root, which has no `pyproject.toml`), so the PEP 517 build falls
   back to `setuptools.build_meta:__legacy__` and fails. The `#subdirectory=`
   fragment is a pip/uv concept the build path doesn't honor.

## Changes

* `uv_translator`: when an sdist entry has no `url`/`file` but the package
  `source` has a `url`, fall back to the source URL. The archive file name
  (e.g. a git ref tarball like `0.11.18.tar.gz`) is not a valid PEP 503 sdist
  name — which both `PackageFile` and pip's link evaluator reject — so a
  canonical `{name}-{version}.tar.gz` file name is synthesised while keeping
  the real download URL (and passing `package_name`/`package_version`
  explicitly so nothing is parsed from the synthetic name).
* `wheel_builder`: new optional `--sdist-subdirectory` flag that descends into
  the nested package directory after extraction, *before* the
  rename-to-`sdist`, so the subdirectory becomes the build root and all the
  existing `..`-relative path handling is unchanged. Absolute and
  `..`-containing values are rejected.
* `pycross_wheel_build`: expose it as an optional `sdist_subdirectory`
  attribute.

Used together with `package.always_build` + `package.build_target`, this makes
URL+subdirectory deps fully workable:

```starlark
lock_import.package(
    name = "my-nested-pkg",
    always_build = True,
    build_target = "@@//third_party/my_nested_pkg:wheel",
)

# and in third_party/my_nested_pkg/BUILD.bazel:
pycross_wheel_build(
    name = "wheel",
    sdist = "@pypi_lock_repo//my-nested-pkg:sdist",
    sdist_subdirectory = "packages/my-nested-pkg",
)
```

`sdist_subdirectory` is deliberately an explicit attribute rather than being
threaded automatically from the lock's `source.subdirectory` — that would
require plumbing through the resolved-lock model and renderer, and the
explicit attribute keeps the change minimal. Happy to look at the automatic
plumbing as a follow-up if there's interest.

## Testing

* New translator fixture `pycross/tests/uv/lock_url_subdirectory` (generated
  with uv 0.11.18 against a real public package with zero Python deps). On
  `main` without the translator change, this fixture fails with
  `AssertionError: file entry has no file or url member`.
* The full stack (translate → resolve → `pycross_wheel_build` with
  `sdist_subdirectory` → import the built wheels) is exercised in a large
  private monorepo against Lightricks/LTX-2 (a uv monorepo with two
  `packages/<name>` URL deps), including a smoke test importing both built
  wheels.
