### PR TITLE
fix: target_base_prefix invalid when base_prefix doesn't exist

### DIFF
--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -640,8 +640,8 @@ def build_venv(
     env_dir: Path,
     exec_python_exe: Path,
     target_python_exe: Path,
-    target_base_prefix: Path,
-    target_base_exec_prefix: Path,
+    target_sysconfig_vars: Dict[str, Any],
+    execroot: Path,
     sysconfig_vars: Dict[str, Any],
     path: List[Path],
     target_env: Optional[TargetEnv],
@@ -661,6 +661,12 @@ def build_venv(
     # If we're using a Bazel-provided python (i.e., not system python), set sys.base_prefix to a path
     # relative to the sdist root in an attempt to keep non-reproducible paths out of binaries.
     if bazel_root in target_python_exe.parents:
+        target_base_prefix, target_base_exec_prefix = target_base_prefixes(
+            target_sysconfig_vars=target_sysconfig_vars,
+            target_python_exe=target_python_exe,
+            execroot=execroot,
+            prefix=bazel_root,
+        )
         with open(site_dir / "_pycross_sys_base_prefix.pth", "w") as f:
             f.write(
                 "import sys; "
@@ -821,15 +827,19 @@ def target_base_prefixes(
     execroot: Path,
     prefix: Path,
 ) -> Tuple[Path, Path]:
+    # For Bazel-provided Python, prefer installed_base from the Python if it exists in the runfiles tree.
+    # E.g. target_python_exe may be a wrapper script that is not adjacent to the real Python, so its
+    # relative location to the base_prefix will be obscure.
     installed_base = target_sysconfig_vars.get("installed_base")
     installed_platbase = target_sysconfig_vars.get("installed_platbase") or installed_base
 
     if installed_base:
         base_prefix = execroot_relative_path(installed_base, execroot, prefix)
         base_exec_prefix = execroot_relative_path(installed_platbase, execroot, prefix)
-        if base_prefix and base_exec_prefix:
+        if base_prefix and base_prefix.exists() and base_exec_prefix and base_exec_prefix.exists():
             return base_prefix, base_exec_prefix
 
+    # If nothing is found, try using the grandparent.
     fallback = target_python_exe.parent.parent
     return fallback, fallback
 
@@ -902,12 +912,6 @@ def main(args: Any, temp_dir: Path, is_debug: bool) -> None:
         exec_python_exe=args.exec_python_executable,
         target_python_exe=args.target_python_executable,
     )
-    target_base_prefix, target_base_exec_prefix = target_base_prefixes(
-        target_sysconfig_vars=target_sysconfig_vars,
-        target_python_exe=args.target_python_executable,
-        execroot=cwd,
-        prefix=prefix,
-    )
     sysconfig_vars = generate_cross_sysconfig_vars(
         toolchain_vars=toolchain_sysconfig_vars,
         target_vars=target_sysconfig_vars,
@@ -921,8 +925,8 @@ def main(args: Any, temp_dir: Path, is_debug: bool) -> None:
         env_dir=build_env_dir,
         exec_python_exe=args.exec_python_executable,
         target_python_exe=args.target_python_executable,
-        target_base_prefix=target_base_prefix,
-        target_base_exec_prefix=target_base_exec_prefix,
+        target_sysconfig_vars=target_sysconfig_vars,
+        execroot=cwd,
         sysconfig_vars=sysconfig_vars,
         path=args.python_path,
         target_env=target_environment,

--- a/pycross/private/tools/wheel_builder_test.py
+++ b/pycross/private/tools/wheel_builder_test.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -78,22 +79,33 @@ class WheelBuilderPathTest(unittest.TestCase):
         )
 
     def test_target_base_prefixes_use_installed_base(self) -> None:
-        execroot = Path("/tmp/sandbox/execroot/_main")
-        prefix = Path("..") / "bazel-execroot" / "_main"
-        target_python_exe = prefix / "bazel-out/k8-fastbuild/bin/pkg/python_wrapper"
-        target_sysconfig_vars = {
-            "installed_base": ("/tmp/sandbox/execroot/_main/bazel-out/k8-fastbuild/bin/pkg/python_root"),
-            "installed_platbase": ("/tmp/sandbox/execroot/_main/bazel-out/k8-fastbuild/bin/pkg/python_root"),
-        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            execroot = tmp_path / "sandbox/execroot/_main"
+            sdist_dir = tmp_path / "sdist"
+            sdist_dir.mkdir()
+            prefix = Path("..") / "bazel-execroot" / "_main"
+            installed_base = "bazel-out/k8-fastbuild/bin/pkg/python_root"
+            (sdist_dir / prefix / installed_base).mkdir(parents=True)
+            target_python_exe = prefix / "bazel-out/k8-fastbuild/bin/pkg/python_wrapper"
+            target_sysconfig_vars = {
+                "installed_base": str(execroot / installed_base),
+                "installed_platbase": str(execroot / installed_base),
+            }
 
-        base_prefix, base_exec_prefix = wheel_builder.target_base_prefixes(
-            target_sysconfig_vars,
-            target_python_exe,
-            execroot,
-            prefix,
-        )
+            cwd = Path.cwd()
+            try:
+                os.chdir(sdist_dir)
+                base_prefix, base_exec_prefix = wheel_builder.target_base_prefixes(
+                    target_sysconfig_vars,
+                    target_python_exe,
+                    execroot,
+                    prefix,
+                )
+            finally:
+                os.chdir(cwd)
 
-        expected = Path("../bazel-execroot/_main/bazel-out/k8-fastbuild/bin/pkg/python_root")
+        expected = Path("../bazel-execroot/_main") / installed_base
         self.assertEqual(base_prefix, expected)
         self.assertEqual(base_exec_prefix, expected)
 


### PR DESCRIPTION
PR https://github.com/jvolkman/rules_pycross/pull/240 fixed target_base_prefix when the python executable from PyRuntimeInfo is a non-adjacent wrapper to the real executable. However, it also introduced a regression.

Bazel provided python can go through multiple rules before given to py_runtime() to create the PyRuntimeInfo. For example, on macos, one may want to correct rpath of the outputs before using it as a toolchain. This usually involves making a copy of the original python outputs and manipulating them.

Before PR240, the target_base_prefix can still be determined correctly since we are look at the grandparent location of the python executable. However, after PR240, we use 'installed_base' from sysconfigdata first to determine target_prefix_base, but we never check if this 'installed_base' actually exists. When a python build output is copied, its sysconfigdata remains the same so its 'installed_base' will likely be wrong.

This commit fixes this by checking if the calculate target_prefix_base actually exists. If not fallback to the grandparent.

Also moved the call to target_base_prefixes(...) inside build_venv where it is used.

The current `target_base_prefixes()` calculated will work for:

- bazel provided python that *doesn't* pass through additional rules which makes copy of the output.
- bazel provided python that *does* pass through additional rules which makes copy of the output.
- bazel provided python that uses a non-adjacent wrapper but *doesn't* pass through additional rules which makes copy of the output.

It will *not* work for:
- bazel provided python that uses a non-adjacent wrapper but *does* pass through additional rules which makes copy of the output.

It will not work because the "installed_base" will be wrong after passing through additional rules and falling back to grandparent won't help due to the wrapper. For this scenario, it is probably recommended for the bazel provided python to update sysconfigdata as it passes through its varies custom rules.