### PR TITLE
fix: installed_base inside wheel build temp_dir is valid

### DIFF
--- a/pycross/private/tools/wheel_builder.py
+++ b/pycross/private/tools/wheel_builder.py
@@ -813,12 +813,18 @@ def execroot_relative_path(path: Union[str, Path], execroot: Path, prefix: Path)
     if not path.is_absolute():
         return path
 
-    marker = f"/execroot/{prefix.name}/"
     path_str = str(path)
-    if marker not in path_str:
-        return None
+    for marker in (
+        # For a bazel provided python, path from sysconfigdata like 'installed_base'
+        # can have the regular bazel execroot (/execroot/) shape, or the shape pycross
+        # assumes for execroot (/bazel-execroot/) under the the temp_dir.
+        f"/execroot/{prefix.name}/",
+        f"/bazel-execroot/{prefix.name}/",
+    ):
+        if marker in path_str:
+            return prefix / path_str.split(marker, 1)[1]
 
-    return prefix / path_str.split(marker, 1)[1]
+    return None
 
 
 def target_base_prefixes(

--- a/pycross/private/tools/wheel_builder_test.py
+++ b/pycross/private/tools/wheel_builder_test.py
@@ -78,6 +78,16 @@ class WheelBuilderPathTest(unittest.TestCase):
             Path("../bazel-execroot/_main/bazel-out/k8-fastbuild/bin/pkg/python_root"),
         )
 
+    def test_execroot_relative_path_rewrites_temp_bazel_execroot_path(self) -> None:
+        execroot = Path("/tmp/sandbox/execroot/_main")
+        prefix = Path("..") / "bazel-execroot" / "_main"
+        path = Path("/tmp/wheelbuild/sdist/../bazel-execroot/_main/bazel-out/k8-fastbuild/bin/pkg/python_root")
+
+        self.assertEqual(
+            wheel_builder.execroot_relative_path(path, execroot, prefix),
+            Path("../bazel-execroot/_main/bazel-out/k8-fastbuild/bin/pkg/python_root"),
+        )
+
     def test_target_base_prefixes_use_installed_base(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
Previously, we assumed for bazel provided python, the installed_base from sysconfigdata should be always under the execroot. While this is true, we also create a temp dir for the wheel build with a "bazel-execroot" symlink to execroot. Therefore, it could also be valid for installed_base to be in the "bazel-execroot" path format. An example of this is if the user has modified python sysconfigdata post-build to be dynamic to the location of python executable.