### PR TITLE
feat: add variant_resolver intermediate layer for conflict set enforcement

### DIFF
--- a/pycross/private/BUILD.bazel
+++ b/pycross/private/BUILD.bazel
@@ -57,6 +57,15 @@ bzl_library(
     deps = [
         ":resolved_lock_renderer",
         ":util",
+        ":variant_resolver",
+    ],
+)
+
+bzl_library(
+    name = "variant_resolver",
+    srcs = ["variant_resolver.bzl"],
+    deps = [
+        "@bazel_skylib//rules:common_settings",
     ],
 )
 

--- a/pycross/private/package_repo.bzl
+++ b/pycross/private/package_repo.bzl
@@ -126,6 +126,8 @@ def _package_repo_impl(rctx):
     member_envs = {}  # member_name -> [env_name, ...]
     cycle_groups = {}  # group_name -> [pkg_key, ...]
     variant_items = {}  # qualified_name -> True (dedup across members)
+    variant_sets = []  # list of {"qnames": [...], "default": "..."}
+    variant_sets_seen = {}  # frozenset key -> True (dedup across members)
     for member, lock_label in rctx.attr.member_lock_files.items():
         member_lock = json.decode(rctx.read(rctx.path(Label(lock_label))))
 
@@ -137,12 +139,21 @@ def _package_repo_impl(rctx):
                 environments[env_name] = env_ref
 
         for variant_set in member_lock.get("variants", []):
+            set_qnames = []
+            set_default = ""
             for item in variant_set["items"]:
                 if item["kind"] == "project":
                     qname = "package_{}".format(item["package"])
                 else:
                     qname = "{}_{}".format(item["kind"], item["name"])
                 variant_items[qname] = True
+                set_qnames.append(qname)
+                if item.get("default", False):
+                    set_default = qname
+            set_key = "|".join(sorted(set_qnames))
+            if set_key not in variant_sets_seen:
+                variant_sets_seen[set_key] = True
+                variant_sets.append({"qnames": set_qnames, "default": set_default})
 
         member_envs[member] = sorted(member_env_names)
         member_packages[member] = member_lock.get("packages", {})
@@ -218,12 +229,37 @@ def _package_repo_impl(rctx):
     if variant_items:
         lock_build_lines.extend([
             'load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")',
+            'load("@rules_pycross//pycross/private:variant_resolver.bzl", "variant_resolver")',
             "",
         ])
+
+    # Map each variant item to the resolver(s) it participates in.
+    qname_to_resolvers = {}  # qname -> [resolver_name, ...]
+    resolver_names = []  # ordered list of resolver target names
+    for vset in variant_sets:
+        resolver_name = "_resolver_" + "_".join(sorted(vset["qnames"]))
+        resolver_names.append(resolver_name)
+        for qname in vset["qnames"]:
+            qname_to_resolvers.setdefault(qname, []).append(resolver_name)
+
+    # Check if we need config_setting_group for items in multiple sets.
+    needs_config_setting_group = False
+    for qname, resolvers in qname_to_resolvers.items():
+        if len(resolvers) > 1:
+            needs_config_setting_group = True
+            break
+    if needs_config_setting_group:
+        lock_build_lines.extend([
+            'load("@bazel_skylib//lib:selects.bzl", "selects")',
+            "",
+        ])
+
     lock_build_lines.extend([
         "targets()",
         "",
     ])
+
+    # Emit bool_flags (user-facing UX, unchanged).
     for qname in sorted(variant_items.keys()):
         lock_build_lines.extend([
             "bool_flag(",
@@ -231,12 +267,74 @@ def _package_repo_impl(rctx):
             "    build_setting_default = False,",
             ")",
             "",
-            "config_setting(",
-            '    name = "is_{}",'.format(qname),
-            '    flag_values = {{":{flag}": "True"}},'.format(flag = qname),
+        ])
+
+    # Emit variant_resolver targets (one per conflict set).
+    for vset in variant_sets:
+        resolver_name = "_resolver_" + "_".join(sorted(vset["qnames"]))
+        lock_build_lines.extend([
+            "variant_resolver(",
+            '    name = "{}",'.format(resolver_name),
+            "    flags = [",
+        ])
+        for qname in vset["qnames"]:
+            lock_build_lines.append('        ":{}",'.format(qname))
+        lock_build_lines.extend([
+            "    ],",
+            "    names = [",
+        ])
+        for qname in vset["qnames"]:
+            lock_build_lines.append('        "{}",'.format(qname))
+        lock_build_lines.extend([
+            "    ],",
+        ])
+        if vset["default"]:
+            lock_build_lines.append('    default = "{}",'.format(vset["default"]))
+        lock_build_lines.extend([
             ")",
             "",
         ])
+
+    # Emit config_settings referencing the resolver(s).
+    for qname in sorted(variant_items.keys()):
+        resolvers = qname_to_resolvers.get(qname, [])
+        if len(resolvers) == 1:
+            # Simple case: item is in exactly one conflict set.
+            lock_build_lines.extend([
+                "config_setting(",
+                '    name = "is_{}",'.format(qname),
+                '    flag_values = {{":{resolver}": "{value}"}},'.format(
+                    resolver = resolvers[0],
+                    value = qname,
+                ),
+                ")",
+                "",
+            ])
+        elif len(resolvers) > 1:
+            # Item appears in multiple conflict sets: OR them together.
+            for j, resolver in enumerate(resolvers):
+                lock_build_lines.extend([
+                    "config_setting(",
+                    '    name = "_is_{}_via_{}",'.format(qname, j),
+                    '    flag_values = {{":{resolver}": "{value}"}},'.format(
+                        resolver = resolver,
+                        value = qname,
+                    ),
+                    ")",
+                    "",
+                ])
+            lock_build_lines.extend([
+                "selects.config_setting_group(",
+                '    name = "is_{}",'.format(qname),
+                "    match_any = [",
+            ])
+            for j in range(len(resolvers)):
+                lock_build_lines.append('        ":_is_{}_via_{}",'.format(qname, j))
+            lock_build_lines.extend([
+                "    ],",
+                ")",
+                "",
+            ])
 
     rctx.file("_lock/BUILD.bazel", "\n".join(lock_build_lines))
 

--- a/pycross/private/variant_resolver.bzl
+++ b/pycross/private/variant_resolver.bzl
@@ -1,0 +1,56 @@
+"""Variant resolver rule for conflict set mutual exclusion enforcement.
+
+Each variant resolver reads a set of bool_flags that represent the items in
+a single conflict set. It validates that at most one flag is set, and returns
+a config_common.FeatureFlagInfo whose value is the qualified name of the
+active variant. This lets config_setting targets reference the resolver
+rather than individual bool_flags, providing:
+
+  1. Build-time enforcement of mutual exclusion (fail if >1 flag is set).
+  2. Clean default handling (return default variant when no flag is set).
+  3. A single point of indirection per conflict set.
+"""
+
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+def _variant_resolver_impl(ctx):
+    active = []
+    for i, flag in enumerate(ctx.attr.flags):
+        if flag[BuildSettingInfo].value:
+            active.append(ctx.attr.names[i])
+
+    if len(active) > 1:
+        fail(
+            "Conflicting variants are active simultaneously: {}. ".format(
+                " and ".join(["--" + name for name in active]),
+            ) + "Only one variant from each conflict set may be enabled at a time.",
+        )
+
+    if active:
+        value = active[0]
+    elif ctx.attr.default:
+        value = ctx.attr.default
+    else:
+        fail(
+            "No variant selected and no default configured for conflict set. " +
+            "Set one of: " + ", ".join(ctx.attr.names),
+        )
+
+    return [config_common.FeatureFlagInfo(value = value)]
+
+variant_resolver = rule(
+    implementation = _variant_resolver_impl,
+    attrs = {
+        "flags": attr.label_list(
+            providers = [BuildSettingInfo],
+            doc = "The bool_flag targets for each item in the conflict set.",
+        ),
+        "names": attr.string_list(
+            doc = "The qualified name for each flag, in the same order as flags.",
+        ),
+        "default": attr.string(
+            default = "",
+            doc = "The default variant qualified name when no flag is set.",
+        ),
+    },
+)

--- a/tests/unit/BUILD.bazel
+++ b/tests/unit/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 load(":test_common_attrs.bzl", "common_attrs_test_suite")
 load(":test_override_helpers.bzl", "override_helpers_test_suite")
 load(":test_resolved_lock_renderer.bzl", "resolved_lock_renderer_test_suite")
+load(":test_variant_resolver.bzl", "variant_resolver_test_suite")
 
 py_test(
     name = "inspect_package_test",
@@ -188,3 +189,5 @@ py_test(
         "@rules_pycross_internal//deps:packaging",
     ],
 )
+
+variant_resolver_test_suite(name = "test_variant_resolver")

--- a/tests/unit/test_variant_resolver.bzl
+++ b/tests/unit/test_variant_resolver.bzl
@@ -1,0 +1,403 @@
+"""Tests for variant_resolver rule."""
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("@rules_testing//lib:truth.bzl", "matching")
+
+# buildifier: disable=bzl-visibility
+load("//pycross/private:variant_resolver.bzl", "variant_resolver")
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+def _setup_flags(name, flag_names):
+    """Create bool_flag helper targets for tests."""
+    for flag_name in flag_names:
+        bool_flag(
+            name = name + "_flag_" + flag_name,
+            build_setting_default = False,
+        )
+    return [":" + name + "_flag_" + fn for fn in flag_names]
+
+# ── Test: single flag active ─────────────────────────────────────────
+
+def _test_single_flag_active_impl(env, target):
+    # If this analysis succeeds, the resolver accepted a single flag.
+    # We can't easily inspect FeatureFlagInfo from Starlark tests,
+    # but the fact that analysis doesn't fail proves correctness.
+    env.expect.that_target(target).default_outputs().contains_at_least([])
+
+def _test_single_flag_active(name):
+    flag_refs = _setup_flags(name, ["alpha", "beta"])
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["alpha", "beta"],
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_resolver",
+        impl = _test_single_flag_active_impl,
+        config_settings = {
+            "//command_line_option:extra_toolchains": [],
+            str(Label(":" + name + "_flag_alpha")): True,
+        },
+    )
+
+# ── Test: default when no flag set ───────────────────────────────────
+
+def _test_default_when_no_flag_impl(env, target):
+    env.expect.that_target(target).default_outputs().contains_at_least([])
+
+def _test_default_when_no_flag(name):
+    flag_refs = _setup_flags(name, ["cpu", "gpu"])
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["cpu", "gpu"],
+        default = "cpu",
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_resolver",
+        impl = _test_default_when_no_flag_impl,
+    )
+
+# ── Test: no flags and no default fails ──────────────────────────────
+
+def _test_no_flags_no_default_fails_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.contains("No variant selected"),
+    )
+
+def _test_no_flags_no_default_fails(name):
+    flag_refs = _setup_flags(name, ["a", "b"])
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["a", "b"],
+        # No default
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_resolver",
+        impl = _test_no_flags_no_default_fails_impl,
+        expect_failure = True,
+    )
+
+# ── Test: mutual exclusion (both flags set) ──────────────────────────
+
+def _test_mutual_exclusion_fails_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.contains("Conflicting variants are active simultaneously"),
+    )
+
+def _test_mutual_exclusion_fails(name):
+    flag_refs = _setup_flags(name, ["x", "y"])
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["x", "y"],
+        default = "x",
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_resolver",
+        impl = _test_mutual_exclusion_fails_impl,
+        expect_failure = True,
+        config_settings = {
+            str(Label(":" + name + "_flag_x")): True,
+            str(Label(":" + name + "_flag_y")): True,
+        },
+    )
+
+# ── Test: mixed extra+group conflict set ─────────────────────────────
+
+def _test_mixed_extra_group_impl(env, target):
+    env.expect.that_target(target).default_outputs().contains_at_least([])
+
+def _test_mixed_extra_group(name):
+    flag_refs = _setup_flags(name, ["extra_variant-a", "group_variant-b"])
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["extra_variant-a", "group_variant-b"],
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_resolver",
+        impl = _test_mixed_extra_group_impl,
+        config_settings = {
+            str(Label(":" + name + "_flag_extra_variant-a")): True,
+        },
+    )
+
+# ── Test: three-way conflict set ─────────────────────────────────────
+
+def _test_three_way_conflict_impl(env, target):
+    env.expect.that_target(target).default_outputs().contains_at_least([])
+
+def _test_three_way_conflict(name):
+    flag_refs = _setup_flags(name, ["cpu", "cu118", "cu124"])
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["cpu", "cu118", "cu124"],
+        default = "cpu",
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_resolver",
+        impl = _test_three_way_conflict_impl,
+        config_settings = {
+            str(Label(":" + name + "_flag_cu124")): True,
+        },
+    )
+
+# ── Test: three-way mutual exclusion (two of three set) ──────────────
+
+def _test_three_way_exclusion_fails_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.contains("Conflicting variants"),
+    )
+
+def _test_three_way_exclusion_fails(name):
+    flag_refs = _setup_flags(name, ["cpu", "cu118", "cu124"])
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["cpu", "cu118", "cu124"],
+        default = "cpu",
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_resolver",
+        impl = _test_three_way_exclusion_fails_impl,
+        expect_failure = True,
+        config_settings = {
+            str(Label(":" + name + "_flag_cu118")): True,
+            str(Label(":" + name + "_flag_cu124")): True,
+        },
+    )
+
+# ── Test: config_setting matches resolver value ──────────────────────
+
+def _test_config_setting_matches_resolver_impl(env, target):
+    # The alias should resolve successfully when the config_setting
+    # matches the resolver's returned value.
+    env.expect.that_target(target).default_outputs().contains_at_least([])
+
+def _test_config_setting_matches_resolver(name):
+    """End-to-end test: bool_flag → resolver → config_setting → select."""
+    flag_refs = _setup_flags(name, ["opt_a", "opt_b"])
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["opt_a", "opt_b"],
+        default = "opt_a",
+        tags = ["manual"],
+    )
+    native.config_setting(
+        name = name + "_is_opt_a",
+        flag_values = {":" + name + "_resolver": "opt_a"},
+    )
+    native.config_setting(
+        name = name + "_is_opt_b",
+        flag_values = {":" + name + "_resolver": "opt_b"},
+    )
+
+    # A filegroup whose srcs depend on the select, exercising the full chain.
+    native.filegroup(
+        name = name + "_subject",
+        srcs = select({
+            ":" + name + "_is_opt_a": [],
+            ":" + name + "_is_opt_b": [],
+        }),
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_subject",
+        impl = _test_config_setting_matches_resolver_impl,
+        # No flag set → default "opt_a" → config_setting _is_opt_a matches.
+    )
+
+# ── Test: config_setting matches with explicit flag ──────────────────
+
+def _test_config_setting_explicit_flag_impl(env, target):
+    env.expect.that_target(target).default_outputs().contains_at_least([])
+
+def _test_config_setting_explicit_flag(name):
+    """Same as above but with an explicit flag set to opt_b."""
+    flag_refs = _setup_flags(name, ["opt_a", "opt_b"])
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["opt_a", "opt_b"],
+        default = "opt_a",
+        tags = ["manual"],
+    )
+    native.config_setting(
+        name = name + "_is_opt_a",
+        flag_values = {":" + name + "_resolver": "opt_a"},
+    )
+    native.config_setting(
+        name = name + "_is_opt_b",
+        flag_values = {":" + name + "_resolver": "opt_b"},
+    )
+    native.filegroup(
+        name = name + "_subject",
+        srcs = select({
+            ":" + name + "_is_opt_a": [],
+            ":" + name + "_is_opt_b": [],
+        }),
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_subject",
+        impl = _test_config_setting_explicit_flag_impl,
+        config_settings = {
+            str(Label(":" + name + "_flag_opt_b")): True,
+        },
+    )
+
+# ── Test: item in multiple conflict sets (config_setting_group) ──────
+
+def _test_multi_set_overlap_impl(env, target):
+    """Shared item resolved via config_setting_group(match_any)."""
+    env.expect.that_target(target).default_outputs().contains_at_least([])
+
+def _test_multi_set_overlap(name):
+    """Simulates: set1=[variant-a, group-a], set2=[group-a, group-b].
+
+    group-a appears in both sets. Its config_setting must match if EITHER
+    resolver returns 'group_group-a'.
+    """
+    flag_refs = _setup_flags(name, ["extra_variant-a", "group_group-a", "group_group-b"])
+
+    # Resolver for set 1: [extra_variant-a, group_group-a]
+    variant_resolver(
+        name = name + "_resolver_set1",
+        flags = [flag_refs[0], flag_refs[1]],
+        names = ["extra_variant-a", "group_group-a"],
+        default = "group_group-a",
+        tags = ["manual"],
+    )
+
+    # Resolver for set 2: [group_group-a, group_group-b]
+    variant_resolver(
+        name = name + "_resolver_set2",
+        flags = [flag_refs[1], flag_refs[2]],
+        names = ["group_group-a", "group_group-b"],
+        default = "group_group-a",
+        tags = ["manual"],
+    )
+
+    # extra_variant-a: only in set 1
+    native.config_setting(
+        name = name + "_is_extra_variant-a",
+        flag_values = {":" + name + "_resolver_set1": "extra_variant-a"},
+    )
+
+    # group_group-a: in BOTH sets → config_setting_group
+    native.config_setting(
+        name = name + "_is_group_group-a_via_0",
+        flag_values = {":" + name + "_resolver_set1": "group_group-a"},
+    )
+    native.config_setting(
+        name = name + "_is_group_group-a_via_1",
+        flag_values = {":" + name + "_resolver_set2": "group_group-a"},
+    )
+    selects.config_setting_group(
+        name = name + "_is_group_group-a",
+        match_any = [
+            ":" + name + "_is_group_group-a_via_0",
+            ":" + name + "_is_group_group-a_via_1",
+        ],
+    )
+
+    # group_group-b: only in set 2
+    native.config_setting(
+        name = name + "_is_group_group-b",
+        flag_values = {":" + name + "_resolver_set2": "group_group-b"},
+    )
+
+    # A select that uses all three config_settings.
+    # With defaults, group_group-a is active in both sets.
+    native.filegroup(
+        name = name + "_subject",
+        srcs = select({
+            ":" + name + "_is_extra_variant-a": [],
+            ":" + name + "_is_group_group-a": [],
+            ":" + name + "_is_group_group-b": [],
+        }),
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_subject",
+        impl = _test_multi_set_overlap_impl,
+        # No flags set → both resolvers default to group_group-a → matches.
+    )
+
+# ── Test: cross-set mutual exclusion with shared item ────────────────
+
+def _test_multi_set_cross_exclusion_fails_impl(env, target):
+    """Setting variant-a AND group-a should fail because they share set 1."""
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.contains("Conflicting variants"),
+    )
+
+def _test_multi_set_cross_exclusion_fails(name):
+    """Set both variant-a and group-a which share a conflict set.
+
+    Targets the resolver directly since the downstream select chain
+    can't resolve when the resolver fails.
+    """
+    flag_refs = _setup_flags(name, ["extra_variant-a", "group_group-a"])
+
+    variant_resolver(
+        name = name + "_resolver",
+        flags = flag_refs,
+        names = ["extra_variant-a", "group_group-a"],
+        tags = ["manual"],
+    )
+    analysis_test(
+        name = name,
+        target = name + "_resolver",
+        impl = _test_multi_set_cross_exclusion_fails_impl,
+        expect_failure = True,
+        config_settings = {
+            # Both active → resolver should fail
+            str(Label(":" + name + "_flag_extra_variant-a")): True,
+            str(Label(":" + name + "_flag_group_group-a")): True,
+        },
+    )
+
+# ── Suite ────────────────────────────────────────────────────────────
+
+def variant_resolver_test_suite(name):
+    test_suite(
+        name = name,
+        tests = [
+            _test_single_flag_active,
+            _test_default_when_no_flag,
+            _test_no_flags_no_default_fails,
+            _test_mutual_exclusion_fails,
+            _test_mixed_extra_group,
+            _test_three_way_conflict,
+            _test_three_way_exclusion_fails,
+            _test_config_setting_matches_resolver,
+            _test_config_setting_explicit_flag,
+            _test_multi_set_overlap,
+            _test_multi_set_cross_exclusion_fails,
+        ],
+    )


### PR DESCRIPTION
Add a variant_resolver Starlark rule that sits between user-facing
bool_flags and config_settings. Each conflict set gets a resolver
target that:

1. Reads BuildSettingInfo from the bool_flag deps
2. Validates mutual exclusion (fail if >1 flag is active)
3. Returns config_common.FeatureFlagInfo with the active variant name
4. Falls back to a configured default when no flag is set

Config_settings now match against the resolver's derived value instead
of individual bool_flags. For items appearing in multiple conflict
sets, config_setting_group with match_any is used.

This enforces mutual exclusion at Bazel analysis time with clear error
messages, while preserving the existing bool_flag UX.
