### PR TITLE
refactor: Preserve PEP 508 extra markers and evaluate in Starlark

### DIFF
--- a/pycross/private/BUILD.bazel
+++ b/pycross/private/BUILD.bazel
@@ -408,6 +408,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "resolved_lock_renderer",
+    srcs = ["resolved_lock_renderer.bzl"],
+    deps = [":util"],
+)
+
+bzl_library(
     name = "backend_registry_repo",
     srcs = ["backend_registry_repo.bzl"],
 )
@@ -430,11 +436,6 @@ bzl_library(
 bzl_library(
     name = "providers",
     srcs = ["providers.bzl"],
-)
-
-bzl_library(
-    name = "resolved_lock_renderer",
-    srcs = ["resolved_lock_renderer.bzl"],
 )
 
 bzl_library(

--- a/pycross/private/lock_repos.bzl
+++ b/pycross/private/lock_repos.bzl
@@ -9,7 +9,7 @@ load("@rules_pycross//pycross/private:sdist_repo.bzl", "pycross_sdist_repo")
 load("//pycross/private:package_repo.bzl", "package_repo")
 load("//pycross/private:pypi_file.bzl", "pypi_file")
 load("//pycross/private:thin_package_repo.bzl", "thin_package_repo")
-load("//pycross/private:util.bzl", "key_name", "key_parts", "sanitize_name")
+load("//pycross/private:util.bzl", "key_name", "parse_package_key", "sanitize_name")
 load("//pycross/private:wheel_file.bzl", "pycross_wheel_file")
 load(":git_file.bzl", "pycross_git_file")
 load(":lock_attrs.bzl", "CREATE_REPOS_ATTRS")
@@ -183,7 +183,9 @@ def _lock_repos_impl(module_ctx):
                 deps_set[dep_label] = True
 
             # Compute the output whldir name: {normalized_name}-{version}.whldir
-            pkg_name_part, pkg_version = key_parts(pkg_key)
+            parts = parse_package_key(pkg_key)
+            pkg_name_part = parts.name
+            pkg_version = parts.version
             whldir_norm_name = sanitize_name(pkg_name_part)
             whldir_name = "{}-{}.whldir".format(whldir_norm_name, pkg_version)
 

--- a/pycross/private/package_repo.bzl
+++ b/pycross/private/package_repo.bzl
@@ -17,7 +17,7 @@ The file structure is as follows:
 
 load("@pypackaging.bzl", "pypackaging")
 load(":resolved_lock_renderer.bzl", "render_lock_bzl")
-load(":util.bzl", "key_name", "key_parts", "underscore_name")
+load(":util.bzl", "key_name", "parse_package_key", "underscore_name")
 
 def _normalize_name(name):
     return pypackaging.utils.canonicalize_name(name)
@@ -294,7 +294,14 @@ def _package_repo_impl(rctx):
         # Skip variant packages (they use __via_ suffix for conflict resolution)
         if "__via_" in pkg_key:
             continue
-        pkg_name_part, pkg_version = key_parts(pkg_key)
+        parts = parse_package_key(pkg_key)
+
+        # Skip extra packages (e.g. foo[test]@1.0.0). They do not have their
+        # own wheels or sdists; they share the base package's artifacts.
+        if parts.extra:
+            continue
+        pkg_name_part = parts.name
+        pkg_version = parts.version
         norm_name = _normalize_name(pkg_name_part)
         us_name = _underscore_name(pkg_name_part)
         whldir_name = "{}-{}.whldir".format(us_name, pkg_version)

--- a/pycross/private/pep508_marker_values.bzl
+++ b/pycross/private/pep508_marker_values.bzl
@@ -159,6 +159,7 @@ def marker_value_attrs():
         "implementation_name": attr.string(default = ""),
         "implementation_version": attr.string(default = ""),
         "platform_python_implementation": attr.string(default = ""),
+        "extra": attr.string(default = ""),
 
         # Hidden fallback targets pointing to standard marker definitions.
         "_os_name_target": attr.label(default = "@rules_pycross//pycross/private/markers:os_name"),
@@ -251,6 +252,8 @@ def collect_markers(ctx):
         else:
             platform_python_implementation = implementation_name
 
+    extra = ctx.attr.extra
+
     return {
         "os_name": os_name,
         "os.name": os_name,
@@ -269,6 +272,7 @@ def collect_markers(ctx):
         "platform_python_implementation": platform_python_implementation,
         "platform.python_implementation": platform_python_implementation,
         "python_implementation": platform_python_implementation,
+        "extra": extra,
     }
 
 def _marker_value_impl(ctx):

--- a/pycross/private/resolved_lock_renderer.bzl
+++ b/pycross/private/resolved_lock_renderer.bzl
@@ -22,6 +22,12 @@ def _ind(text, tabs = 1):
 def _sanitize_name(name):
     return name.lower().replace("-", "_").replace("@", "_").replace("+", "_").replace(".", "_").replace("[", "_").replace("]", "_")
 
+def _pkg_key_extra(pkg_key):
+    """Extract the extra name from a pkg_key like 'foo[test]@1.0', or '' if none."""
+    if "[" not in pkg_key:
+        return ""
+    return pkg_key.split("[", 1)[1].split("]", 1)[0]
+
 def _is_in_same_cycle(dep_key, pkg, packages):
     cycle_group = pkg.get("cycle_group")
     if not cycle_group:
@@ -74,37 +80,60 @@ def _render_extras_aggregates(lines, packages):
         ])
 
 def _collect_unique_markers(packages):
-    """Collect all unique marker strings across packages, returning a deduped set."""
+    """Collect all unique (marker, extra) pairs across packages.
+
+    Returns a dict mapping (marker_string, extra_value) to True.
+    The extra is derived from the package key (e.g. 'foo[test]@1.0' -> 'test').
+    """
     markers = {}
-    for pkg in packages.values():
+    for pkg_key, pkg in packages.items():
+        extra = _pkg_key_extra(pkg_key)
         for md in pkg.get("marker_dependencies", []):
             marker = md.get("marker")
             if marker:
-                markers[marker] = True
+                # Optimization: if "extra" is not in the marker string, it doesn't reference the extra variable.
+                # We can share a single evaluator by setting extra to "".
+                effective_extra = extra if "extra" in marker else ""
+                markers[(marker, effective_extra)] = True
     return markers.keys()
 
-def _marker_evaluator_name(marker_str):
-    """Generate a deterministic target name for a marker evaluator."""
+def _marker_evaluator_name(marker_str, extra = ""):
+    """Generate a deterministic target name for a marker evaluator.
+
+    Args:
+        marker_str: The PEP 508 marker expression.
+        extra: The PEP 508 extra value (e.g. 'test'), or '' for no extra.
+    """
 
     # Starlark's hash() is deterministic within a build invocation.
     # We sanitize the marker string for readability and add the hash for uniqueness.
-    san = _sanitize_name(marker_str.replace(" ", "").replace("\"", "").replace("'", ""))
+    key = marker_str if not extra else "{}|extra={}".format(marker_str, extra)
+    san = _sanitize_name(key.replace(" ", "").replace("\"", "").replace("'", ""))
 
     # Truncate to keep target names reasonable
     if len(san) > 40:
         san = san[:40]
-    return "_marker_eval_{}_{}".format(san, hash(marker_str))
+    return "_marker_eval_{}_{}".format(san, hash(key))
 
 def _render_marker_evaluators(lines, unique_markers):
-    """Render deduped pycross_pep508_evaluator and config_setting targets."""
-    for marker_str in sorted(unique_markers):
-        eval_name = _marker_evaluator_name(marker_str)
+    """Render deduped pycross_pep508_evaluator and config_setting targets.
+
+    Args:
+        lines: Output lines list.
+        unique_markers: Iterable of (marker_str, extra) tuples.
+    """
+    for marker_str, extra in sorted(unique_markers):
+        eval_name = _marker_evaluator_name(marker_str, extra)
 
         # Evaluator rule — returns FeatureFlagInfo("true"/"false")
         lines.extend([
             _ind("pycross_pep508_evaluator("),
             _ind('name = "{}",'.format(eval_name), 2),
             _ind('expr = "{}",'.format(marker_str.replace('"', '\\"')), 2),
+        ])
+        if extra:
+            lines.append(_ind('extra = "{}",'.format(extra), 2))
+        lines.extend([
             _ind(")"),
             "",
         ])
@@ -195,11 +224,14 @@ def _render_marker_cycle_member_deps(lines, cycle_groups, packages):
         lines.append("")
 
         for pkg_key in sorted(resolved_members):
+            extra = _pkg_key_extra(pkg_key)
             lines.append(_ind("pycross_cycle_member_marker_deps("))
             lines.append(_ind('name = "{}",'.format(pkg_key), 2))
             lines.append(_ind('raw_name = "_raw_{}",'.format(pkg_key), 2))
             lines.append(_ind('member = "{}",'.format(pkg_key), 2))
             lines.append(_ind("edges = {},".format(edges_var_name), 2))
+            if extra:
+                lines.append(_ind('extra = "{}",'.format(extra), 2))
             lines.append(_ind(")"))
             lines.append("")
 
@@ -263,13 +295,15 @@ def _render_marker_wheel_chooser(lines, pkg_key, pkg, repo_map, sdist_map, rctx_
         "",
     ])
 
-def _render_marker_package_deps(lines, pkg_key_san, pkg, packages):
+def _render_marker_package_deps(lines, pkg_key, pkg_key_san, pkg, packages):
     """Render deps using marker-based select() instead of environment-based."""
     marker_deps = pkg.get("marker_dependencies", [])
     if not marker_deps:
         lines.append(_ind("_{}_deps = []".format(pkg_key_san)))
         lines.append("")
         return
+
+    extra = _pkg_key_extra(pkg_key)
 
     unconditional = []
     conditional = []
@@ -290,7 +324,8 @@ def _render_marker_package_deps(lines, pkg_key_san, pkg, packages):
     if conditional:
         # Each conditional dep gets its own select()
         for md in sorted(conditional, key = lambda m: m["key"]):
-            eval_name = _marker_evaluator_name(md["marker"])
+            effective_extra = extra if "extra" in md["marker"] else ""
+            eval_name = _marker_evaluator_name(md["marker"], effective_extra)
             lines[-1] = lines[-1] + " + select({"
             lines.append(_ind('":{}_match": [":{}"],'.format(eval_name, md["key"]), 2))
             lines.append(_ind('"//conditions:default": [],', 2))
@@ -319,7 +354,7 @@ def _render_marker_package(lines, pkg_key, pkg, packages, repo_map, sdist_map, r
 
     # Runtime deps
     if has_marker_deps:
-        _render_marker_package_deps(lines, pkg_key_san, pkg, packages)
+        _render_marker_package_deps(lines, pkg_key, pkg_key_san, pkg, packages)
 
     if not has_wheel_candidates and "[" in pkg_key:
         # Extras packages wrap the base package plus their own deps.

--- a/pycross/private/resolved_lock_renderer.bzl
+++ b/pycross/private/resolved_lock_renderer.bzl
@@ -14,6 +14,8 @@ Naming conventions for generated targets:
     base package and all of its parsed extras into a single target.
 """
 
+load(":util.bzl", "parse_package_key")
+
 def _ind(text, tabs = 1):
     if not text:
         return ""
@@ -21,12 +23,6 @@ def _ind(text, tabs = 1):
 
 def _sanitize_name(name):
     return name.lower().replace("-", "_").replace("@", "_").replace("+", "_").replace(".", "_").replace("[", "_").replace("]", "_")
-
-def _pkg_key_extra(pkg_key):
-    """Extract the extra name from a pkg_key like 'foo[test]@1.0', or '' if none."""
-    if "[" not in pkg_key:
-        return ""
-    return pkg_key.split("[", 1)[1].split("]", 1)[0]
 
 def _is_in_same_cycle(dep_key, pkg, packages):
     cycle_group = pkg.get("cycle_group")
@@ -55,16 +51,15 @@ def _render_extras_aggregates(lines, packages):
     """Renders [_all_] pycross_library_proxy targets that aggregate a base package and all its extras."""
     base_packages_with_extras = {}
     for pkg_key in packages.keys():
-        if "[" in pkg_key:
-            base_name, extra_and_version = pkg_key.split("[", 1)
-            _, version = extra_and_version.split("]@", 1)
-            base_pkg_key = "{}@{}".format(base_name, version)
-            if base_pkg_key not in base_packages_with_extras:
-                base_packages_with_extras[base_pkg_key] = []
-            base_packages_with_extras[base_pkg_key].append(pkg_key)
+        parts = parse_package_key(pkg_key)
+        if parts.extra:
+            base_key = (parts.name, parts.version)
+            if base_key not in base_packages_with_extras:
+                base_packages_with_extras[base_key] = []
+            base_packages_with_extras[base_key].append(pkg_key)
 
-    for base_pkg_key, extra_keys in sorted(base_packages_with_extras.items()):
-        base_name, version = base_pkg_key.split("@", 1)
+    for (base_name, version), extra_keys in sorted(base_packages_with_extras.items()):
+        base_pkg_key = "{}@{}".format(base_name, version)
         lines.extend([
             _ind("pycross_library_proxy("),
             _ind('name = "{}[_all_]@{}",'.format(base_name, version), 2),
@@ -87,7 +82,7 @@ def _collect_unique_markers(packages):
     """
     markers = {}
     for pkg_key, pkg in packages.items():
-        extra = _pkg_key_extra(pkg_key)
+        extra = parse_package_key(pkg_key).extra
         for md in pkg.get("marker_dependencies", []):
             marker = md.get("marker")
             if marker:
@@ -224,7 +219,7 @@ def _render_marker_cycle_member_deps(lines, cycle_groups, packages):
         lines.append("")
 
         for pkg_key in sorted(resolved_members):
-            extra = _pkg_key_extra(pkg_key)
+            extra = parse_package_key(pkg_key).extra
             lines.append(_ind("pycross_cycle_member_marker_deps("))
             lines.append(_ind('name = "{}",'.format(pkg_key), 2))
             lines.append(_ind('raw_name = "_raw_{}",'.format(pkg_key), 2))
@@ -303,7 +298,7 @@ def _render_marker_package_deps(lines, pkg_key, pkg_key_san, pkg, packages):
         lines.append("")
         return
 
-    extra = _pkg_key_extra(pkg_key)
+    extra = parse_package_key(pkg_key).extra
 
     unconditional = []
     conditional = []
@@ -336,8 +331,10 @@ def _render_marker_package_deps(lines, pkg_key, pkg_key_san, pkg, packages):
 def _render_marker_package(lines, pkg_key, pkg, packages, repo_map, sdist_map, rctx_name):
     """Renders all targets for a single package using marker-based deps and wheel selection."""
     pkg_key_san = _sanitize_name(pkg_key)
-    package_name = pkg_key.split("@", 1)[0]
-    package_version = pkg_key.split("@", 1)[1]
+    parts = parse_package_key(pkg_key)
+    package_name = parts.name
+    package_version = parts.version
+    extra = parts.extra
 
     has_marker_deps = bool(pkg.get("marker_dependencies"))
     has_wheel_candidates = bool(pkg.get("wheel_candidates"))
@@ -356,12 +353,9 @@ def _render_marker_package(lines, pkg_key, pkg, packages, repo_map, sdist_map, r
     if has_marker_deps:
         _render_marker_package_deps(lines, pkg_key, pkg_key_san, pkg, packages)
 
-    if not has_wheel_candidates and "[" in pkg_key:
+    if not has_wheel_candidates and extra:
         # Extras packages wrap the base package plus their own deps.
-        base_name = pkg_key.split("[", 1)[0]
-        _, version = pkg_key.split("]", 1)
-        version = version.lstrip("@")
-        base_pkg_key = "{}@{}".format(base_name, version)
+        base_pkg_key = "{}@{}".format(package_name, package_version)
         lines.extend([
             _ind("pycross_library_proxy("),
             _ind('name = "{}",'.format(pkg_key), 2),

--- a/pycross/private/thin_package_repo.bzl
+++ b/pycross/private/thin_package_repo.bzl
@@ -12,7 +12,7 @@ The file structure is:
 - _variants/BUILD.bazel    - Aliases for bool_flag and config_setting targets for variant selection.
 """
 
-load(":util.bzl", "underscore_name")
+load(":util.bzl", "parse_package_key", "underscore_name")
 
 _requirement_func = """\
 load("@pypackaging.bzl", "pypackaging")
@@ -49,7 +49,8 @@ def _target_select(target_dict, prefix, suffix, workspace_repo, is_aggregated = 
     if len(target_dict) == 1 and "" in target_dict:
         t = target_dict[""]
         if is_aggregated:
-            t = "{}[_all_]@{}".format(t.split("@", 1)[0], t.split("@", 1)[1])
+            parts = parse_package_key(t)
+            t = "{}[_all_]@{}".format(parts.name, parts.version)
         return '"{}{}{}"'.format(prefix, t, suffix)
 
     lines = ["select({"]
@@ -57,7 +58,8 @@ def _target_select(target_dict, prefix, suffix, workspace_repo, is_aggregated = 
     for constraint, t in target_dict.items():
         t_base = t
         if is_aggregated:
-            t_base = "{}[_all_]@{}".format(t.split("@", 1)[0], t.split("@", 1)[1])
+            parts = parse_package_key(t)
+            t_base = "{}[_all_]@{}".format(parts.name, parts.version)
         if constraint == "":
             lines.append('        "//conditions:default": "{}{}{}",'.format(prefix, t_base, suffix))
         else:
@@ -232,16 +234,15 @@ def _thin_package_repo_impl(rctx):
     # Group pins by base package name to identify extras.
     grouped_pins = {}
     for pin_name, pin_target in pins.items():
-        if "[" in pin_name:
-            base, extra = pin_name.split("[", 1)
-            extra = extra[:-1]
-            if base not in grouped_pins:
-                grouped_pins[base] = {"base_target": None, "extras": {}}
-            grouped_pins[base]["extras"][extra] = pin_target
+        parts = parse_package_key(pin_name)
+        if parts.extra:
+            if parts.name not in grouped_pins:
+                grouped_pins[parts.name] = {"base_target": None, "extras": {}}
+            grouped_pins[parts.name]["extras"][parts.extra] = pin_target
         else:
-            if pin_name not in grouped_pins:
-                grouped_pins[pin_name] = {"base_target": None, "extras": {}}
-            grouped_pins[pin_name]["base_target"] = pin_target
+            if parts.name not in grouped_pins:
+                grouped_pins[parts.name] = {"base_target": None, "extras": {}}
+            grouped_pins[parts.name]["base_target"] = pin_target
 
     root_build_lines = [
         'load("@rules_pycross//pycross/private:modules_mapping.bzl", "pycross_modules_mapping")',
@@ -456,10 +457,9 @@ pycross_transitioning_file_proxy = rule(
 
     base_packages_with_extras = {}
     for pkg_key in packages.keys():
-        if "[" in pkg_key:
-            base_name, extra_and_version = pkg_key.split("[", 1)
-            extra_name, version = extra_and_version.split("]@", 1)
-            base_pkg_key = "{}@{}".format(base_name, version)
+        parts = parse_package_key(pkg_key)
+        if parts.extra:
+            base_pkg_key = "{}@{}".format(parts.name, parts.version)
             base_packages_with_extras[base_pkg_key] = True
 
     # Pin directories: proxies pointing to @workspace//_lock targets
@@ -470,10 +470,9 @@ pycross_transitioning_file_proxy = rule(
             first_extra_target_dict = list(group["extras"].values())[0]
             base_target_dict = {}
             for constraint, extra_target in first_extra_target_dict.items():
-                if "[" in extra_target:
-                    base_name, extra_and_version = extra_target.split("[", 1)
-                    _, version = extra_and_version.split("]@", 1)
-                    base_target_dict[constraint] = "{}@{}".format(base_name, version)
+                parts = parse_package_key(extra_target)
+                if parts.extra:
+                    base_target_dict[constraint] = "{}@{}".format(parts.name, parts.version)
 
         package = {}
         if base_target_dict:

--- a/pycross/private/tools/raw_lock_resolver.py
+++ b/pycross/private/tools/raw_lock_resolver.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import os
-import re
 from argparse import ArgumentParser
 from collections import defaultdict
 from dataclasses import dataclass
@@ -17,9 +16,6 @@ from typing import Set
 from typing import Tuple
 from urllib.parse import urlparse
 
-from packaging.markers import Marker as PkgMarker
-from packaging.markers import Value
-from packaging.markers import Variable
 from packaging.utils import NormalizedName
 from packaging.utils import parse_wheel_filename
 from packaging.version import Version
@@ -38,93 +34,6 @@ from pycross.private.tools.lock_model import ResolvedPackage
 from pycross.private.tools.lock_model import WheelCandidate
 from pycross.private.tools.lock_model import is_wheel
 from pycross.private.tools.lock_model import package_canonical_name
-
-EXTRA_PATTERN = re.compile(r"extra\s*==\s*['\"]([^'\"]+)['\"]")
-
-
-def _format_marker_node(node) -> str:
-    """Format a single marker node (Variable, Value, or Op) back to string."""
-    if isinstance(node, Variable):
-        return str(node)
-    if isinstance(node, Value):
-        return '"' + str(node) + '"'
-    return str(node)
-
-
-def _format_markers(markers) -> str:
-    """Reconstruct a PEP 508 marker string from packaging's internal list."""
-    if isinstance(markers, tuple) and len(markers) == 3:
-        return " ".join(_format_marker_node(x) for x in markers)
-    if isinstance(markers, list):
-        if len(markers) == 1:
-            return _format_markers(markers[0])
-        parts = []
-        for item in markers:
-            if isinstance(item, str):
-                parts.append(item)
-            else:
-                parts.append(_format_markers(item))
-        return " ".join(parts)
-    return str(markers)
-
-
-def _strip_extra_markers(marker_str: str) -> str:
-    """Remove 'extra == ...' clauses from a marker string.
-
-    Extras are handled by virtual extra nodes in the dependency graph,
-    not by runtime marker evaluation. We strip them so the evaluator
-    only sees platform/version markers.
-    """
-    if "extra" not in marker_str:
-        return marker_str
-
-    try:
-        marker = PkgMarker(marker_str)
-    except Exception:
-        return marker_str
-
-    filtered = _filter_extra_nodes(marker._markers)
-    if not filtered:
-        return ""
-
-    return _format_markers(filtered)
-
-
-def _filter_extra_nodes(markers) -> list:
-    """Recursively remove extra == ... comparisons from the marker tree."""
-    if isinstance(markers, tuple) and len(markers) == 3:
-        lhs, op, rhs = markers
-        # Check if this is an 'extra' comparison
-        if (isinstance(lhs, Variable) and str(lhs) == "extra") or (isinstance(rhs, Variable) and str(rhs) == "extra"):
-            return []
-        return [markers]
-
-    if isinstance(markers, list):
-        result = []
-        for item in markers:
-            if isinstance(item, str):  # 'and' or 'or'
-                result.append(item)
-            else:
-                filtered = _filter_extra_nodes(item)
-                result.extend(filtered)
-
-        # Clean up: remove leading/trailing/consecutive operators
-        cleaned = []
-        for item in result:
-            if isinstance(item, str):
-                if not cleaned or isinstance(cleaned[-1], str):
-                    continue  # skip leading or consecutive operators
-                cleaned.append(item)
-            else:
-                cleaned.append(item)
-
-        # Remove trailing operator
-        if cleaned and isinstance(cleaned[-1], str):
-            cleaned.pop()
-
-        return cleaned
-
-    return [markers]
 
 
 @dataclass(frozen=True)
@@ -291,9 +200,6 @@ class PackageResolver:
         if ignore_dependency_names:
             ordered_deps = [d for d in ordered_deps if d.name.package not in ignore_dependency_names]
 
-        # The package's own extra (if any), e.g. "test" for "foo[test]".
-        package_extra = package.name.extra
-
         for dep in ordered_deps:
             dep_base_key = PackageKey.from_parts(DependencyName(dep.name.package), dep.version)
             if context.lock_package_keys is not None and dep_base_key not in context.lock_package_keys:
@@ -304,17 +210,6 @@ class PackageResolver:
             seen_names.add(dep_key)
 
             marker_str = dep.marker
-            if marker_str:
-                # Check if the dep requires a specific extra.
-                extra_match = EXTRA_PATTERN.search(marker_str)
-                if extra_match:
-                    dep_extra = extra_match.group(1)
-                    # Only include this dep if the package's extra matches.
-                    if package_extra != dep_extra:
-                        continue
-
-                # Strip extra markers — those are handled by virtual extra nodes.
-                marker_str = _strip_extra_markers(marker_str)
 
             result.append(
                 MarkerDependency(

--- a/pycross/private/util.bzl
+++ b/pycross/private/util.bzl
@@ -63,20 +63,6 @@ def extract_pep508_name(spec):
     name = spec[:name_len]
     return pypackaging.utils.canonicalize_name(name)
 
-def key_parts(key):
-    """Split a lockfile package key into its name and version parts.
-
-    Args:
-        key: The package key string (e.g. "package@1.0.0").
-
-    Returns:
-        A tuple of (name, version).
-    """
-    parts = key.split("@", 1)
-    if len(parts) != 2:
-        fail("Invalid package key format: " + key)
-    return parts[0], parts[1]
-
 def key_name(key):
     """Extract the package name part from a lockfile package key.
 
@@ -87,6 +73,44 @@ def key_name(key):
         The package name part.
     """
     return key.split("@", 1)[0]
+
+def parse_package_key(key):
+    """Parses a package key or pin name into (name, extra, version).
+
+    Supports formats:
+      - name@version
+      - name[extra]@version
+      - name
+      - name[extra]
+
+    Args:
+        key: The package key or pin name string.
+
+    Returns:
+        A tuple of (name, extra, version). name is always present.
+        extra and version are strings, and will be empty if not present.
+    """
+    name_and_extra = key
+    version = ""
+    if "@" in key:
+        parts = key.split("@", 1)
+        name_and_extra = parts[0]
+        version = parts[1]
+
+    name = name_and_extra
+    extra = ""
+    if "[" in name_and_extra:
+        if not name_and_extra.endswith("]"):
+            fail("Invalid package key format: " + key)
+        parts = name_and_extra.split("[", 1)
+        name = parts[0]
+        extra = parts[1][:-1]
+
+    return struct(
+        name = name,
+        extra = extra,
+        version = version,
+    )
 
 # Attrs that consuming rules must include for merge_py_providers to work.
 PY_COMMON_ATTRS = py_common.API_ATTRS

--- a/tests/unit/raw_lock_resolver_test.py
+++ b/tests/unit/raw_lock_resolver_test.py
@@ -645,10 +645,11 @@ class TestExtras(unittest.TestCase):
         resolver = PackageResolver(pkg, ctx, None, [])
         resolved = resolver.to_resolved_package()
 
-        # The dep should appear with its marker (extra stripped, platform marker preserved)
+        # The dep should appear with its marker preserved (both extra and platform markers).
         self.assertEqual(len(resolved.marker_dependencies), 1)
         self.assertEqual(resolved.marker_dependencies[0].key.name.package, "depc")
         self.assertIn("sys_platform", resolved.marker_dependencies[0].marker)
+        self.assertIn("extra == 'test'", resolved.marker_dependencies[0].marker)
 
     def test_extras_no_extras(self):
         """Packages without extra markers have normal deps."""
@@ -690,17 +691,24 @@ class TestExtras(unittest.TestCase):
         resolver_dev = PackageResolver(pkg_dev, ctx, None, [])
         resolved_dev = resolver_dev.to_resolved_package()
 
-        # Check "test" extra has pytest
+        # With analysis-time extra evaluation, both extras get ALL deps.
+        # The extra-gated markers are preserved so the evaluator handles them at analysis time.
         test_dep_names = {md.key.name.package for md in resolved_test.marker_dependencies}
         self.assertIn("depa", test_dep_names)
         self.assertIn("pytest", test_dep_names)
-        self.assertNotIn("black", test_dep_names)
+        self.assertIn("black", test_dep_names)
 
-        # Check "dev" extra has black
+        # Verify markers are preserved (not stripped)
+        test_markers = {md.key.name.package: md.marker for md in resolved_test.marker_dependencies}
+        self.assertIsNone(test_markers["depa"])  # unconditional
+        self.assertEqual(test_markers["pytest"], "extra == 'test'")
+        self.assertEqual(test_markers["black"], "extra == 'dev'")
+
+        # Same for dev extra — all deps present with markers
         dev_dep_names = {md.key.name.package for md in resolved_dev.marker_dependencies}
         self.assertIn("depa", dev_dep_names)
         self.assertIn("black", dev_dep_names)
-        self.assertNotIn("pytest", dev_dep_names)
+        self.assertIn("pytest", dev_dep_names)
 
 
 class TestCycleDetection(unittest.TestCase):


### PR DESCRIPTION
- Removes custom extra stripping logic from raw_lock_resolver.py.
- Delegates extra evaluation to analysis time via pycross_pep508_evaluator.
- Optimizes evaluator generation by sharing instances for platform-only markers.
