### PR TITLE
Remove transitive package pruning from lock resolver

### DIFF
--- a/pycross/private/lock.bzl
+++ b/pycross/private/lock.bzl
@@ -89,7 +89,6 @@ def _resolve_lock_inline(module_ctx, lock_info, serialized_lock_model, workspace
         local_wheels = local_wheels,
         remote_wheels = {},
         always_include_sdist = False,
-        disallow_builds = lock_info.disallow_builds,
         annotations_data = annotations_data,
         default_build_dependencies_args = lock_info.default_build_dependencies,
         default_alias_single_version = lock_info.default_alias_single_version,
@@ -159,6 +158,7 @@ def _lock_impl(module_ctx):
         repo_flags = result.repo_flags,
         repo_constraint_values = result.repo_constraint_values,
         repo_platforms = result.repo_platforms,
+        repo_disallow_builds = result.repo_disallow_builds,
         pypi_index = create_tag.pypi_index,
         resolved_locks = resolved_locks,
     )

--- a/pycross/private/lock_common.bzl
+++ b/pycross/private/lock_common.bzl
@@ -687,6 +687,7 @@ def process_import_tags(module_ctx):
     repo_flags = {}
     repo_constraint_values = {}
     repo_platforms = {}
+    repo_disallow_builds = {}
 
     for repo_info in lock_repos.values():
         workspace_memberships[repo_info.repo_name] = repo_info.workspace
@@ -699,6 +700,8 @@ def process_import_tags(module_ctx):
             repo_constraint_values[repo_info.repo_name] = json.encode(repo_info.constraint_values)
         if repo_info.platform:
             repo_platforms[repo_info.repo_name] = repo_info.platform
+        if repo_info.disallow_builds:
+            repo_disallow_builds[repo_info.repo_name] = True
 
     return struct(
         lock_repos = lock_repos,
@@ -710,6 +713,7 @@ def process_import_tags(module_ctx):
         repo_flags = repo_flags,
         repo_constraint_values = repo_constraint_values,
         repo_platforms = repo_platforms,
+        repo_disallow_builds = repo_disallow_builds,
     )
 
 IMPORT_TAG_CLASSES = dict(

--- a/pycross/private/lock_repo_creation.bzl
+++ b/pycross/private/lock_repo_creation.bzl
@@ -18,6 +18,21 @@ load(":git_file.bzl", "pycross_git_file")
 # Annotation fields that affect pycross_wheel_library targets.
 _ANNOTATION_FIELDS = ["post_install_patches", "install_exclude_globs"]
 
+def _disallowed_sdist_repo_impl(rctx):
+    fail(
+        "Package '{}' requires building from source (sdist), ".format(rctx.attr.package_name) +
+        "but builds are disallowed for lock import '{}'. ".format(rctx.attr.lock_name) +
+        "Provide a pre-built wheel or remove disallow_builds.",
+    )
+
+pycross_disallowed_sdist_repo = repository_rule(
+    implementation = _disallowed_sdist_repo_impl,
+    attrs = {
+        "package_name": attr.string(mandatory = True),
+        "lock_name": attr.string(mandatory = True),
+    },
+)
+
 def create_repos(
         module_ctx,
         all_locks,
@@ -26,6 +41,7 @@ def create_repos(
         repo_flags,
         repo_constraint_values,
         repo_platforms,
+        repo_disallow_builds = {},
         pypi_index = None,
         resolved_locks = None):
     """Create all Bazel repos from resolved lock data.
@@ -38,6 +54,7 @@ def create_repos(
         repo_flags: Dict of repo_name -> JSON-encoded flags list.
         repo_constraint_values: Dict of repo_name -> JSON-encoded constraint_values list.
         repo_platforms: Dict of repo_name -> platform string.
+        repo_disallow_builds: Dict of repo_name -> boolean indicating if builds are disallowed.
         pypi_index: Optional PyPI index URL.
         resolved_locks: Optional dict of repo_name -> parsed lock JSON dict. When provided,
             lock data is taken from this dict instead of reading from all_locks file labels.
@@ -235,7 +252,14 @@ def create_repos(
             if pkg_overrides:
                 sdist_repo_attrs["override_backend_configs"] = json.encode(pkg_overrides)
 
-            pycross_sdist_repo(**sdist_repo_attrs)
+            if repo_disallow_builds.get(repo_name, False):
+                pycross_disallowed_sdist_repo(
+                    name = sdist_repo_name,
+                    package_name = pkg_key,
+                    lock_name = repo_name,
+                )
+            else:
+                pycross_sdist_repo(**sdist_repo_attrs)
 
         # Save per-repo data for workspace processing
         per_repo_data[repo_name] = struct(

--- a/pycross/private/lock_resolver.bzl
+++ b/pycross/private/lock_resolver.bzl
@@ -234,9 +234,11 @@ def _resolve_packages(
         annotations,
         default_build_dependencies,
         wildcard_only_keys):
-    work = []
+    work_set = {k: True for k in lock_model_packages.keys()}
     for pin_dict in pins.values():
-        work.extend(pin_dict.values())
+        for pkg_key in pin_dict.values():
+            work_set[pkg_key] = True
+    work = work_set.keys()
 
     packages_by_package_key = {}
     synthesized_packages = {}
@@ -395,12 +397,36 @@ def _compute_cycle_groups(packages):
 
     return cycle_groups
 
+def _compute_reachable_keys(pins, packages_by_package_key):
+    """Compute the set of package keys transitively reachable from pins."""
+    work = []
+    for pin_dict in pins.values():
+        work.extend(pin_dict.values())
+
+    num_edges = 0
+    for entry in packages_by_package_key.values():
+        num_edges += len(entry.all_dependency_keys)
+
+    max_iters = len(work) + num_edges + len(packages_by_package_key)
+
+    reachable = {}
+    for _ in range(max_iters):
+        if not work:
+            break
+        key = work.pop()
+        if key in reachable:
+            continue
+        reachable[key] = True
+        entry = packages_by_package_key.get(key)
+        if entry:
+            work.extend(entry.all_dependency_keys)
+    return reachable
+
 def resolve(
         lock_model_data,
         local_wheels = None,
         remote_wheels = None,
         always_include_sdist = False,
-        disallow_builds = False,
         annotations_data = None,
         default_build_dependencies_args = None,
         default_alias_single_version = False):
@@ -411,7 +437,6 @@ def resolve(
         local_wheels: Dictionary of local wheels.
         remote_wheels: Dictionary of remote wheels.
         always_include_sdist: Whether to always include sdist.
-        disallow_builds: Whether to disallow builds.
         annotations_data: Annotations data.
         default_build_dependencies_args: Default build dependencies args.
         default_alias_single_version: Whether to default alias single version.
@@ -506,16 +531,6 @@ def resolve(
     resolved_keys = sorted(packages_by_package_key.keys())
     resolved_packages = [packages_by_package_key[k] for k in resolved_keys]
 
-    if disallow_builds:
-        builds = []
-        for entry in resolved_packages:
-            if entry.uses_sdist:
-                builds.append(entry.key)
-        if builds:
-            fail("Builds are disallowed, but the following would include pycross_wheel_build targets: {}".format(
-                ", ".join(builds),
-            ))
-
     repos = {}
     for entry in resolved_packages:
         repos.update(entry.wheel_candidate_files)
@@ -526,8 +541,11 @@ def resolve(
     repos = {k: repos[k] for k in sorted_repo_keys}
 
     if default_alias_single_version:
+        reachable_keys = _compute_reachable_keys(pins, packages_by_package_key)
         resolved_versions_by_name = {}
         for entry in resolved_packages:
+            if entry.key not in reachable_keys:
+                continue
             pkg_name = entry.resolved_package["name"]
             pkg_version = entry.resolved_package["version"]
             if pkg_name not in resolved_versions_by_name:

--- a/pycross/private/resolved_lock_repo.bzl
+++ b/pycross/private/resolved_lock_repo.bzl
@@ -59,7 +59,6 @@ def _generate_lock_file(rctx):
         local_wheels = local_wheels,
         remote_wheels = rctx.attr.remote_wheels,
         always_include_sdist = rctx.attr.always_include_sdist,
-        disallow_builds = rctx.attr.disallow_builds,
         annotations_data = annotations_data,
         default_build_dependencies_args = rctx.attr.default_build_dependencies,
         default_alias_single_version = rctx.attr.default_alias_single_version,

--- a/tests/unit/test_lock_resolver.bzl
+++ b/tests/unit/test_lock_resolver.bzl
@@ -29,7 +29,6 @@ def _resolve_failure_subject_impl(ctx):
     resolve(
         lock_model_data = lock_model_data,
         annotations_data = annotations_data,
-        disallow_builds = ctx.attr.disallow_builds,
     )
     return []
 
@@ -38,7 +37,6 @@ _resolve_failure_subject = rule(
     attrs = {
         "lock_model_data": attr.string(),
         "annotations_data": attr.string(default = ""),
-        "disallow_builds": attr.bool(default = False),
     },
 )
 
@@ -664,12 +662,15 @@ def _test_unpinned_cycle_still_emitted_impl(env, target):
     res = resolve(lock_model_data)
 
     env.expect.that_collection(res.packages.keys()).contains("a@1.0")
-    env.expect.that_collection(res.packages.keys()).contains_none_of(["x@1.0", "y@1.0", "z@1.0"])
+    env.expect.that_collection(res.packages.keys()).contains_at_least(["x@1.0", "y@1.0", "z@1.0"])
 
     env.expect.that_collection(res.cycle_groups.keys()).has_size(1)
 
-    for pkg in res.packages.values():
-        env.expect.that_bool(pkg.get("cycle_group") == None).equals(True)
+    for pkg_key, pkg in res.packages.items():
+        if pkg_key in ["x@1.0", "y@1.0", "z@1.0"]:
+            env.expect.that_bool(pkg.get("cycle_group") != None).equals(True)
+        else:
+            env.expect.that_bool(pkg.get("cycle_group") == None).equals(True)
 
 def _test_unpinned_cycle_still_emitted(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
@@ -1558,33 +1559,6 @@ def _test_no_files_raises_error(name):
         expect_failure = True,
     )
 
-def _test_disallow_builds_raises_when_sdist_used_impl(env, target):
-    env.expect.that_target(target).failures().contains_predicate(
-        matching.contains("Builds are disallowed, but the following would include pycross_wheel_build targets"),
-    )
-
-def _test_disallow_builds_raises_when_sdist_used(name):
-    lock_model_data = {
-        "packages": {
-            "mylib@1.0": _make_pkg("mylib", "1.0", [_make_file("mylib-1.0.tar.gz")]),
-        },
-        "pins": {"mylib": "mylib@1.0"},
-    }
-
-    util.helper_target(
-        _resolve_failure_subject,
-        name = name + "_subject",
-        lock_model_data = json.encode(lock_model_data),
-        disallow_builds = True,
-    )
-
-    analysis_test(
-        name = name,
-        target = name + "_subject",
-        impl = _test_disallow_builds_raises_when_sdist_used_impl,
-        expect_failure = True,
-    )
-
 # buildifier: disable=unused-variable
 def _test_empty_lock_impl(env, target):
     lock_model_data = {
@@ -1722,37 +1696,6 @@ def _test_unconsumed_wildcard_annotations_no_error_impl(env, target):
 def _test_unconsumed_wildcard_annotations_no_error(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_unconsumed_wildcard_annotations_no_error_impl)
-
-def _test_unconsumed_specific_annotation_still_errors_impl(env, target):
-    env.expect.that_target(target).failures().contains_predicate(
-        matching.contains("not part of the locked set"),
-    )
-
-def _test_unconsumed_specific_annotation_still_errors(name):
-    lock_model_data = {
-        "packages": {
-            "foo@1.0": _make_pkg("foo", "1.0", [_make_file("foo-1.0.tar.gz")]),
-            "unused@1.0": _make_pkg("unused", "1.0", [_make_file("unused-1.0.tar.gz")]),
-        },
-        "pins": {"foo": "foo@1.0"},
-    }
-    annotations_data = {
-        "unused": {"always_build": True},
-    }
-
-    util.helper_target(
-        _resolve_failure_subject,
-        name = name + "_subject",
-        lock_model_data = json.encode(lock_model_data),
-        annotations_data = json.encode(annotations_data),
-    )
-
-    analysis_test(
-        name = name,
-        target = name + "_subject",
-        impl = _test_unconsumed_specific_annotation_still_errors_impl,
-        expect_failure = True,
-    )
 
 # buildifier: disable=unused-variable
 def _test_build_repo_flows_to_resolved_package_impl(env, target):
@@ -1905,13 +1848,11 @@ def lock_resolver_test_suite(name):
             _test_multi_tag_wheel_candidates,
             _test_sdist_only_package,
             _test_no_files_raises_error,
-            _test_disallow_builds_raises_when_sdist_used,
             _test_empty_lock,
             _test_pinned_package_not_in_packages,
             _test_wildcard_always_build_end_to_end,
             _test_wildcard_with_specific_override_end_to_end,
             _test_unconsumed_wildcard_annotations_no_error,
-            _test_unconsumed_specific_annotation_still_errors,
             _test_build_repo_flows_to_resolved_package,
             _test_wildcard_build_repo_flows_to_resolved_package,
             _test_wildcard_install_exclude_globs_end_to_end,


### PR DESCRIPTION
- Seed lock resolver work queue with all packages from lock model.
- Scope `default_alias_single_version` to reachable packages to prevent leaking dev-only transitive deps.
- Replace eager `disallow_builds` check with a lazy "bomb" repo approach in `lock_repo_creation.bzl`.
- Update tests to reflect new behavior.

This enables using build backends (like setuptools) defined in dev groups without explicitly importing those groups or maintaining a separate build repo, as all locked packages are now available in the central repository.
