### PR TITLE
Add per-format lock extensions (uv, pdm, poetry, pylock)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ See the [CI results](https://github.com/jvolkman/rules_pycross/actions/workflows
 Add your lock file import to `MODULE.bazel`:
 
 ```python
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
 
-lock.import_uv(
+uv.project(
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "pypi",
 )
-use_repo(lock, "pypi")
+use_repo(uv, "pypi")
 ```
 
 After this, packages are available as `@pypi//package_name`. A `requirement()` macro is generated in `@pypi//:requirements.bzl`.
 
-Other lock formats work the same way via `import_pdm`, `import_poetry`, or `import_pylock`.
+Other lock formats work the same way via their respective extensions: `pdm.bzl`, `poetry.bzl`, or `pylock.bzl`.
 
 <details>
 <summary>Legacy two-extension pattern (deprecated)</summary>
@@ -97,7 +97,7 @@ A `pip install` operation can be broken down into:
 `rules_pycross` maps each step to Bazel primitives:
 
 1. **Native Bazel Platforms** — target environments are determined by standard Bazel `@platforms` constraints and `rules_python` toolchain flags, mapped directly to PEP 508 markers at analysis time.
-2. **`lock`** extension — translates a lock file and resolves dependencies into Bazel repository rules: `http_file` for downloads, build rules for source distributions.
+2. **Lock extensions** (`uv`, `pdm`, etc.) — translates a lock file and resolves dependencies into Bazel repository rules: `http_file` for downloads, build rules for source distributions.
 3. **Build backends** (`setuptools_build`, `meson_build`, etc.) — build sdists into wheels inside sandboxed Bazel actions with remote execution support.
 4. **`pycross_wheel_library`** — extracts a wheel (downloaded or built) and provides it as a `py_library`.
 
@@ -146,20 +146,20 @@ py_library(
 ### UV Workspace (Single Lock, Multiple Members)
 
 ```python
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
 
 # 1. Declare the workspace (shared lock file and settings)
-lock.import_uv_workspace(
+uv.workspace(
     name = "shared",
     lock_file = "//:uv.lock",
 )
 
 # 2. Auto-discover all members; generate repos with a naming pattern
-lock.uv_all_members(
+uv.all_projects(
     workspace = "shared",
     repo_pattern = "lock_{member}",  # e.g., 'project-a' -> '@lock_project_a'
 )
-use_repo(lock, "lock_project_a", "lock_project_b")
+use_repo(uv, "lock_project_a", "lock_project_b")
 ```
 
 All members share a single backing `package_repo` — overlapping packages are downloaded and built only once.
@@ -170,27 +170,27 @@ Individual members can override the repo name or dependency groups using `uv_mem
 
 ```python
 # Override project-a's repo name (instead of the pattern-generated 'lock_project_a')
-lock.uv_member(
+uv.project(
     workspace = "shared",
-    project = "project-a",
+    name = "project-a",
     repo = "lock_a",
 )
 
 # Include specific optional groups only for project-b
-lock.uv_member(
+uv.project(
     workspace = "shared",
-    project = "project-b",
+    name = "project-b",
     optional_groups = ["grpc", "testing"],
 )
 ```
 
 ### Package Annotations in a Workspace
 
-`lock.package()` annotations in a workspace must use the `workspace` attribute (not `repo`):
+`uv.package()` annotations in a workspace must use the `workspace` attribute (not `repo`):
 
 ```python
 # Apply to all members of the "shared" workspace
-lock.package(
+uv.package(
     name = "regex",
     install_exclude_globs = ["test_regex.py"],
     workspace = "shared",
@@ -201,14 +201,14 @@ Use `name = "*"` to set defaults for all packages. A specific annotation for a p
 
 ```python
 # Force all packages to build from source by default
-lock.package(
+uv.package(
     name = "*",
     always_build = True,
     workspace = "shared",
 )
 
 # Override the wildcard for a specific package
-lock.package(
+uv.package(
     name = "requests",
     always_build = False,
     workspace = "shared",
@@ -220,17 +220,17 @@ lock.package(
 If your projects use separate lock files (not a shared workspace lock), each `import_uv` call creates its own isolated workspace:
 
 ```python
-lock.import_uv(
+uv.project(
     lock_file = "//frontend:uv.lock",
     project_file = "//frontend:pyproject.toml",
     repo = "frontend_deps",
 )
-lock.import_uv(
+uv.project(
     lock_file = "//ml:uv.lock",
     project_file = "//ml:pyproject.toml",
     repo = "ml_deps",
 )
-use_repo(lock, "frontend_deps", "ml_deps")
+use_repo(uv, "frontend_deps", "ml_deps")
 ```
 
 ---
@@ -255,7 +255,7 @@ use_repo(lock, "frontend_deps", "ml_deps")
 By default, `rules_pycross` uses pre-built wheels when available. To force building from source, set `always_build = True`:
 
 ```python
-lock.package(
+uv.package(
     name = "numpy",
     always_build = True,
     repo = "pypi",
@@ -335,12 +335,12 @@ rust.toolchain(
 )
 
 # Mark packages for source build
-lock.package(
+uv.package(
     name = "rpds-py",
     always_build = True,
     repo = "pypi",
 )
-lock.package(
+uv.package(
     name = "jiter",
     always_build = True,
     repo = "pypi",
@@ -361,7 +361,7 @@ use_repo(maturin, "pypi_cargo")
 For full control, provide your own build target:
 
 ```python
-lock.package(
+uv.package(
     name = "psycopg2",
     build_target = "@//deps/psycopg2:wheel",
     repo = "pypi",
@@ -462,9 +462,9 @@ There are three ways to specify the transition:
 **1. Using `flags` — embed `--flag=value` settings into a generated platform:**
 
 ```python
-lock.uv_member(
+uv.project(
     workspace = "shared",
-    project = "ml-pipeline",
+    name = "ml-pipeline",
     flags = [
         "--@pypi//_variants:extra_cu124=True",
     ],
@@ -474,9 +474,9 @@ lock.uv_member(
 **2. Using `constraint_values` — generate a platform with specific constraints:**
 
 ```python
-lock.uv_member(
+uv.project(
     workspace = "shared",
-    project = "ml-pipeline",
+    name = "ml-pipeline",
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
@@ -487,9 +487,9 @@ lock.uv_member(
 **3. Using `platform` — reference an existing platform target directly:**
 
 ```python
-lock.uv_member(
+uv.project(
     workspace = "shared",
-    project = "ml-pipeline",
+    name = "ml-pipeline",
     platform = "@//platforms:linux_cuda",
 )
 ```
@@ -497,7 +497,7 @@ lock.uv_member(
 > [!NOTE]
 > `flags` and `constraint_values` can be combined (they are merged into a single generated platform), but `platform` is mutually exclusive with both.
 
-These attributes are available on `uv_member`, `uv_all_members`, `import_uv`, and their PDM/Poetry/Pylock equivalents.
+These attributes are available on `uv.project`, `uv.all_projects`, and their PDM/Poetry/Pylock equivalents.
 
 When `constraint_values` alone are specified, `rules_pycross` generates an internal `platform()` target and uses `pycross_transitioning_library_proxy` / `pycross_transitioning_file_proxy` at each package level to apply the `--platforms` transition.
 
@@ -511,7 +511,7 @@ This is particularly useful for locking variant selections to a member without r
 
 `rules_pycross` integrates with `rules_python`. The generated target layout (`@<repo>//<package>`) is compatible with `rules_python` conventions.
 
-* **Venv support** — when `rules_python` venvs are enabled, `pycross_wheel_library` populates the symlinks needed for a correct `site-packages` layout. Auto-detected paths can be overridden via `lock.package(site_paths = [...])`, and additional path categories (`bin_paths`, `data_paths`, `include_paths`) are also supported.
+* **Venv support** — when `rules_python` venvs are enabled, `pycross_wheel_library` populates the symlinks needed for a correct `site-packages` layout. Auto-detected paths can be overridden via `uv.package(site_paths = [...])`, and additional path categories (`bin_paths`, `data_paths`, `include_paths`) are also supported.
 * **`py_console_script_binary`** — each `pycross_wheel_library` produces a `:dist_info` output group for entry point discovery. Use `py_console_script_binary(pkg = "@pypi//cython", script = "cython")` directly.
 
 ---

--- a/docs/ext_lock_import.md
+++ b/docs/ext_lock_import.md
@@ -24,29 +24,10 @@ lock_import.import_pylock(<a href="#lock_import.import_pylock-all_development_gr
                           <a href="#lock_import.import_pylock-constraint_values">constraint_values</a>, <a href="#lock_import.import_pylock-default_alias_single_version">default_alias_single_version</a>, <a href="#lock_import.import_pylock-default_build_dependencies">default_build_dependencies</a>,
                           <a href="#lock_import.import_pylock-default_group">default_group</a>, <a href="#lock_import.import_pylock-development_groups">development_groups</a>, <a href="#lock_import.import_pylock-disallow_builds">disallow_builds</a>, <a href="#lock_import.import_pylock-flags">flags</a>, <a href="#lock_import.import_pylock-local_wheels">local_wheels</a>,
                           <a href="#lock_import.import_pylock-lock_file">lock_file</a>, <a href="#lock_import.import_pylock-optional_groups">optional_groups</a>, <a href="#lock_import.import_pylock-platform">platform</a>, <a href="#lock_import.import_pylock-project_file">project_file</a>, <a href="#lock_import.import_pylock-repo">repo</a>)
-lock_import.import_pdm_workspace(<a href="#lock_import.import_pdm_workspace-name">name</a>, <a href="#lock_import.import_pdm_workspace-build_repo">build_repo</a>, <a href="#lock_import.import_pdm_workspace-default_alias_single_version">default_alias_single_version</a>,
-                                 <a href="#lock_import.import_pdm_workspace-default_build_dependencies">default_build_dependencies</a>, <a href="#lock_import.import_pdm_workspace-disallow_builds">disallow_builds</a>, <a href="#lock_import.import_pdm_workspace-local_wheels">local_wheels</a>, <a href="#lock_import.import_pdm_workspace-lock_file">lock_file</a>)
-lock_import.pdm_all_members(<a href="#lock_import.pdm_all_members-all_development_groups">all_development_groups</a>, <a href="#lock_import.pdm_all_members-all_optional_groups">all_optional_groups</a>, <a href="#lock_import.pdm_all_members-constraint_values">constraint_values</a>,
-                            <a href="#lock_import.pdm_all_members-development_groups">development_groups</a>, <a href="#lock_import.pdm_all_members-excluded_projects">excluded_projects</a>, <a href="#lock_import.pdm_all_members-flags">flags</a>, <a href="#lock_import.pdm_all_members-optional_groups">optional_groups</a>, <a href="#lock_import.pdm_all_members-platform">platform</a>,
-                            <a href="#lock_import.pdm_all_members-repo_pattern">repo_pattern</a>, <a href="#lock_import.pdm_all_members-workspace">workspace</a>)
-lock_import.pdm_member(<a href="#lock_import.pdm_member-constraint_values">constraint_values</a>, <a href="#lock_import.pdm_member-default_group">default_group</a>, <a href="#lock_import.pdm_member-development_groups">development_groups</a>, <a href="#lock_import.pdm_member-flags">flags</a>, <a href="#lock_import.pdm_member-optional_groups">optional_groups</a>,
-                       <a href="#lock_import.pdm_member-platform">platform</a>, <a href="#lock_import.pdm_member-project">project</a>, <a href="#lock_import.pdm_member-project_file">project_file</a>, <a href="#lock_import.pdm_member-repo">repo</a>, <a href="#lock_import.pdm_member-workspace">workspace</a>)
-lock_import.import_uv_workspace(<a href="#lock_import.import_uv_workspace-name">name</a>, <a href="#lock_import.import_uv_workspace-build_repo">build_repo</a>, <a href="#lock_import.import_uv_workspace-default_alias_single_version">default_alias_single_version</a>,
-                                <a href="#lock_import.import_uv_workspace-default_build_dependencies">default_build_dependencies</a>, <a href="#lock_import.import_uv_workspace-disallow_builds">disallow_builds</a>, <a href="#lock_import.import_uv_workspace-local_wheels">local_wheels</a>, <a href="#lock_import.import_uv_workspace-lock_file">lock_file</a>,
-                                <a href="#lock_import.import_uv_workspace-require_static_urls">require_static_urls</a>)
-lock_import.uv_all_members(<a href="#lock_import.uv_all_members-all_development_groups">all_development_groups</a>, <a href="#lock_import.uv_all_members-all_optional_groups">all_optional_groups</a>, <a href="#lock_import.uv_all_members-constraint_values">constraint_values</a>,
-                           <a href="#lock_import.uv_all_members-development_groups">development_groups</a>, <a href="#lock_import.uv_all_members-excluded_projects">excluded_projects</a>, <a href="#lock_import.uv_all_members-flags">flags</a>, <a href="#lock_import.uv_all_members-optional_groups">optional_groups</a>, <a href="#lock_import.uv_all_members-platform">platform</a>,
-                           <a href="#lock_import.uv_all_members-repo_pattern">repo_pattern</a>, <a href="#lock_import.uv_all_members-workspace">workspace</a>)
-lock_import.uv_member(<a href="#lock_import.uv_member-constraint_values">constraint_values</a>, <a href="#lock_import.uv_member-default_group">default_group</a>, <a href="#lock_import.uv_member-development_groups">development_groups</a>, <a href="#lock_import.uv_member-flags">flags</a>, <a href="#lock_import.uv_member-optional_groups">optional_groups</a>,
-                      <a href="#lock_import.uv_member-platform">platform</a>, <a href="#lock_import.uv_member-project">project</a>, <a href="#lock_import.uv_member-project_file">project_file</a>, <a href="#lock_import.uv_member-repo">repo</a>, <a href="#lock_import.uv_member-workspace">workspace</a>)
-lock_import.poetry_member(<a href="#lock_import.poetry_member-constraint_values">constraint_values</a>, <a href="#lock_import.poetry_member-default_group">default_group</a>, <a href="#lock_import.poetry_member-development_groups">development_groups</a>, <a href="#lock_import.poetry_member-flags">flags</a>,
-                          <a href="#lock_import.poetry_member-optional_groups">optional_groups</a>, <a href="#lock_import.poetry_member-platform">platform</a>, <a href="#lock_import.poetry_member-project">project</a>, <a href="#lock_import.poetry_member-project_file">project_file</a>, <a href="#lock_import.poetry_member-repo">repo</a>, <a href="#lock_import.poetry_member-workspace">workspace</a>)
-lock_import.pylock_member(<a href="#lock_import.pylock_member-constraint_values">constraint_values</a>, <a href="#lock_import.pylock_member-default_group">default_group</a>, <a href="#lock_import.pylock_member-development_groups">development_groups</a>, <a href="#lock_import.pylock_member-flags">flags</a>,
-                          <a href="#lock_import.pylock_member-optional_groups">optional_groups</a>, <a href="#lock_import.pylock_member-platform">platform</a>, <a href="#lock_import.pylock_member-project">project</a>, <a href="#lock_import.pylock_member-project_file">project_file</a>, <a href="#lock_import.pylock_member-repo">repo</a>, <a href="#lock_import.pylock_member-workspace">workspace</a>)
 lock_import.package(<a href="#lock_import.package-name">name</a>, <a href="#lock_import.package-always_build">always_build</a>, <a href="#lock_import.package-bin_paths">bin_paths</a>, <a href="#lock_import.package-build_backend">build_backend</a>, <a href="#lock_import.package-build_dependencies">build_dependencies</a>, <a href="#lock_import.package-build_repo">build_repo</a>,
                     <a href="#lock_import.package-build_target">build_target</a>, <a href="#lock_import.package-data_paths">data_paths</a>, <a href="#lock_import.package-ignore_dependencies">ignore_dependencies</a>, <a href="#lock_import.package-include_paths">include_paths</a>,
                     <a href="#lock_import.package-install_exclude_globs">install_exclude_globs</a>, <a href="#lock_import.package-post_install_patches">post_install_patches</a>, <a href="#lock_import.package-pre_build_patches">pre_build_patches</a>, <a href="#lock_import.package-repo">repo</a>, <a href="#lock_import.package-site_hooks">site_hooks</a>,
-                    <a href="#lock_import.package-site_paths">site_paths</a>, <a href="#lock_import.package-workspace">workspace</a>)
+                    <a href="#lock_import.package-site_paths">site_paths</a>)
 </pre>
 
 
@@ -160,169 +141,6 @@ Import a pylock.toml lock file.
 | <a id="lock_import.import_pylock-project_file"></a>project_file |  Optional pyproject.toml file.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="lock_import.import_pylock-repo"></a>repo |  The repository name   | String | required |  |
 
-<a id="lock_import.import_pdm_workspace"></a>
-
-### import_pdm_workspace
-
-Import a PDM workspace.
-
-**Attributes**
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="lock_import.import_pdm_workspace-name"></a>name |  Workspace name. Used to link members to this workspace.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="lock_import.import_pdm_workspace-build_repo"></a>build_repo |  Optional default repo to use for resolving sdist build dependencies.   | String | optional |  `""`  |
-| <a id="lock_import.import_pdm_workspace-default_alias_single_version"></a>default_alias_single_version |  Generate aliases for all packages that have a single version in the lock file.   | Boolean | optional |  `False`  |
-| <a id="lock_import.import_pdm_workspace-default_build_dependencies"></a>default_build_dependencies |  A list of package keys (name or name@version) that will be used as default build dependencies.   | List of strings | optional |  `[]`  |
-| <a id="lock_import.import_pdm_workspace-disallow_builds"></a>disallow_builds |  If True, only pre-built wheels are allowed.   | Boolean | optional |  `False`  |
-| <a id="lock_import.import_pdm_workspace-local_wheels"></a>local_wheels |  A list of local .whl files to consider when processing lock files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="lock_import.import_pdm_workspace-lock_file"></a>lock_file |  The shared pdm.lock file for the workspace.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-
-<a id="lock_import.pdm_all_members"></a>
-
-### pdm_all_members
-
-Auto-discover and import all members from a pdm.lock file.
-
-**Attributes**
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="lock_import.pdm_all_members-all_development_groups"></a>all_development_groups |  Install all dev dependencies.   | Boolean | optional |  `False`  |
-| <a id="lock_import.pdm_all_members-all_optional_groups"></a>all_optional_groups |  Install all optional dependencies.   | Boolean | optional |  `False`  |
-| <a id="lock_import.pdm_all_members-constraint_values"></a>constraint_values |  A list of constraint values to apply to the generated platform.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="lock_import.pdm_all_members-development_groups"></a>development_groups |  List of development dependency groups to install.   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pdm_all_members-excluded_projects"></a>excluded_projects |  Project names to skip during auto-discovery.   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pdm_all_members-flags"></a>flags |  A list of flags to apply to the generated platform (e.g., '--@flag=value').   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pdm_all_members-optional_groups"></a>optional_groups |  List of optional dependency groups to install.   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pdm_all_members-platform"></a>platform |  An existing platform target to use directly.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.pdm_all_members-repo_pattern"></a>repo_pattern |  Pattern for auto-generated repo names. Use '{member}' as a placeholder for the normalized project name. For example, 'ws_{member}' produces 'ws_lib_a' for a project named 'lib-a'. Default is '{member}'.   | String | optional |  `"{member}"`  |
-| <a id="lock_import.pdm_all_members-workspace"></a>workspace |  Name of the workspace this member belongs to.   | String | required |  |
-
-<a id="lock_import.pdm_member"></a>
-
-### pdm_member
-
-Override settings for a specific PDM member.
-
-**Attributes**
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="lock_import.pdm_member-constraint_values"></a>constraint_values |  A list of constraint values to apply to the generated platform.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="lock_import.pdm_member-default_group"></a>default_group |  Whether to install dependencies from the default group.   | Boolean | optional |  `True`  |
-| <a id="lock_import.pdm_member-development_groups"></a>development_groups |  List of development dependency groups to install (overrides all_members setting).   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pdm_member-flags"></a>flags |  A list of flags to apply to the generated platform (e.g., '--@flag=value').   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pdm_member-optional_groups"></a>optional_groups |  List of optional dependency groups to install (overrides all_members setting).   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pdm_member-platform"></a>platform |  An existing platform target to use directly.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.pdm_member-project"></a>project |  The project name as it appears in pdm.lock. Optional if the workspace has only one member.   | String | optional |  `""`  |
-| <a id="lock_import.pdm_member-project_file"></a>project_file |  Override auto-discovered pyproject.toml path.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.pdm_member-repo"></a>repo |  Override the repo name (default: {prefix}{normalized_project_name}).   | String | optional |  `""`  |
-| <a id="lock_import.pdm_member-workspace"></a>workspace |  Name of the workspace this member belongs to.   | String | required |  |
-
-<a id="lock_import.import_uv_workspace"></a>
-
-### import_uv_workspace
-
-Import a uv workspace. Define members with uv_all_members and uv_member tags.
-
-**Attributes**
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="lock_import.import_uv_workspace-name"></a>name |  Workspace name. Used to link members to this workspace.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="lock_import.import_uv_workspace-build_repo"></a>build_repo |  Optional default repo to use for resolving sdist build dependencies.   | String | optional |  `""`  |
-| <a id="lock_import.import_uv_workspace-default_alias_single_version"></a>default_alias_single_version |  Generate aliases for all packages that have a single version in the lock file.   | Boolean | optional |  `False`  |
-| <a id="lock_import.import_uv_workspace-default_build_dependencies"></a>default_build_dependencies |  A list of package keys (name or name@version) that will be used as default build dependencies.   | List of strings | optional |  `[]`  |
-| <a id="lock_import.import_uv_workspace-disallow_builds"></a>disallow_builds |  If True, only pre-built wheels are allowed.   | Boolean | optional |  `False`  |
-| <a id="lock_import.import_uv_workspace-local_wheels"></a>local_wheels |  A list of local .whl files to consider when processing lock files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="lock_import.import_uv_workspace-lock_file"></a>lock_file |  The shared uv.lock file for the workspace.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-| <a id="lock_import.import_uv_workspace-require_static_urls"></a>require_static_urls |  Require that the lock file is created with --static-urls.   | Boolean | optional |  `True`  |
-
-<a id="lock_import.uv_all_members"></a>
-
-### uv_all_members
-
-Auto-discover and import all members from a uv.lock file.
-
-**Attributes**
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="lock_import.uv_all_members-all_development_groups"></a>all_development_groups |  Install all dev dependencies.   | Boolean | optional |  `False`  |
-| <a id="lock_import.uv_all_members-all_optional_groups"></a>all_optional_groups |  Install all optional dependencies.   | Boolean | optional |  `False`  |
-| <a id="lock_import.uv_all_members-constraint_values"></a>constraint_values |  A list of constraint values to apply to the generated platform.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="lock_import.uv_all_members-development_groups"></a>development_groups |  List of development dependency groups to install.   | List of strings | optional |  `[]`  |
-| <a id="lock_import.uv_all_members-excluded_projects"></a>excluded_projects |  Project names to skip during auto-discovery.   | List of strings | optional |  `[]`  |
-| <a id="lock_import.uv_all_members-flags"></a>flags |  A list of flags to apply to the generated platform (e.g., '--@flag=value').   | List of strings | optional |  `[]`  |
-| <a id="lock_import.uv_all_members-optional_groups"></a>optional_groups |  List of optional dependency groups to install.   | List of strings | optional |  `[]`  |
-| <a id="lock_import.uv_all_members-platform"></a>platform |  An existing platform target to use directly.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.uv_all_members-repo_pattern"></a>repo_pattern |  Pattern for auto-generated repo names. Use '{member}' as a placeholder for the normalized project name. For example, 'ws_{member}' produces 'ws_lib_a' for a project named 'lib-a'. Default is '{member}'.   | String | optional |  `"{member}"`  |
-| <a id="lock_import.uv_all_members-workspace"></a>workspace |  Name of the workspace this member belongs to.   | String | required |  |
-
-<a id="lock_import.uv_member"></a>
-
-### uv_member
-
-Override settings for a specific member.
-
-**Attributes**
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="lock_import.uv_member-constraint_values"></a>constraint_values |  A list of constraint values to apply to the generated platform.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="lock_import.uv_member-default_group"></a>default_group |  Whether to install dependencies from the default group.   | Boolean | optional |  `True`  |
-| <a id="lock_import.uv_member-development_groups"></a>development_groups |  List of development dependency groups to install (overrides all_members setting).   | List of strings | optional |  `[]`  |
-| <a id="lock_import.uv_member-flags"></a>flags |  A list of flags to apply to the generated platform (e.g., '--@flag=value').   | List of strings | optional |  `[]`  |
-| <a id="lock_import.uv_member-optional_groups"></a>optional_groups |  List of optional dependency groups to install (overrides all_members setting).   | List of strings | optional |  `[]`  |
-| <a id="lock_import.uv_member-platform"></a>platform |  An existing platform target to use directly.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.uv_member-project"></a>project |  The project name as it appears in uv.lock. Optional if the workspace has only one member.   | String | optional |  `""`  |
-| <a id="lock_import.uv_member-project_file"></a>project_file |  Override auto-discovered pyproject.toml path.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.uv_member-repo"></a>repo |  Override the repo name (default: {prefix}{normalized_project_name}).   | String | optional |  `""`  |
-| <a id="lock_import.uv_member-workspace"></a>workspace |  Name of the workspace this member belongs to.   | String | required |  |
-
-<a id="lock_import.poetry_member"></a>
-
-### poetry_member
-
-Override settings for a specific Poetry member.
-
-**Attributes**
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="lock_import.poetry_member-constraint_values"></a>constraint_values |  A list of constraint values to apply to the generated platform.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="lock_import.poetry_member-default_group"></a>default_group |  Whether to install dependencies from the default group.   | Boolean | optional |  `True`  |
-| <a id="lock_import.poetry_member-development_groups"></a>development_groups |  List of development dependency groups to install (overrides all_members setting).   | List of strings | optional |  `[]`  |
-| <a id="lock_import.poetry_member-flags"></a>flags |  A list of flags to apply to the generated platform (e.g., '--@flag=value').   | List of strings | optional |  `[]`  |
-| <a id="lock_import.poetry_member-optional_groups"></a>optional_groups |  List of optional dependency groups to install (overrides all_members setting).   | List of strings | optional |  `[]`  |
-| <a id="lock_import.poetry_member-platform"></a>platform |  An existing platform target to use directly.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.poetry_member-project"></a>project |  Optional project name.   | String | optional |  `""`  |
-| <a id="lock_import.poetry_member-project_file"></a>project_file |  Override auto-discovered pyproject.toml path.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.poetry_member-repo"></a>repo |  Override the repo name.   | String | optional |  `""`  |
-| <a id="lock_import.poetry_member-workspace"></a>workspace |  Name of the workspace this member belongs to.   | String | required |  |
-
-<a id="lock_import.pylock_member"></a>
-
-### pylock_member
-
-Override settings for a specific Pylock member.
-
-**Attributes**
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="lock_import.pylock_member-constraint_values"></a>constraint_values |  A list of constraint values to apply to the generated platform.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="lock_import.pylock_member-default_group"></a>default_group |  Whether to install dependencies from the default group.   | Boolean | optional |  `True`  |
-| <a id="lock_import.pylock_member-development_groups"></a>development_groups |  List of development dependency groups to install (overrides all_members setting).   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pylock_member-flags"></a>flags |  A list of flags to apply to the generated platform (e.g., '--@flag=value').   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pylock_member-optional_groups"></a>optional_groups |  List of optional dependency groups to install (overrides all_members setting).   | List of strings | optional |  `[]`  |
-| <a id="lock_import.pylock_member-platform"></a>platform |  An existing platform target to use directly.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.pylock_member-project"></a>project |  Optional project name.   | String | optional |  `""`  |
-| <a id="lock_import.pylock_member-project_file"></a>project_file |  Override auto-discovered pyproject.toml path.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="lock_import.pylock_member-repo"></a>repo |  Override the repo name.   | String | optional |  `""`  |
-| <a id="lock_import.pylock_member-workspace"></a>workspace |  Name of the workspace this member belongs to.   | String | required |  |
-
 <a id="lock_import.package"></a>
 
 ### package
@@ -346,9 +164,8 @@ Specify package-specific settings.
 | <a id="lock_import.package-install_exclude_globs"></a>install_exclude_globs |  A list of globs for files to exclude during installation.   | List of strings | optional |  `[]`  |
 | <a id="lock_import.package-post_install_patches"></a>post_install_patches |  A list of patches to apply after wheel installation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="lock_import.package-pre_build_patches"></a>pre_build_patches |  A list of patches to apply to the sdist source tree before building.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="lock_import.package-repo"></a>repo |  The repository name (if applying to a specific lock file).   | String | optional |  `""`  |
+| <a id="lock_import.package-repo"></a>repo |  The repository name.   | String | required |  |
 | <a id="lock_import.package-site_hooks"></a>site_hooks |  A list of Python code snippets to execute on interpreter startup during builds.   | List of strings | optional |  `[]`  |
 | <a id="lock_import.package-site_paths"></a>site_paths |  Override the auto-detected top-level importable paths (packages, .pth files, standalone modules). Use forward slashes for nested namespaces (e.g. 'google/cloud/storage').   | List of strings | optional |  `[]`  |
-| <a id="lock_import.package-workspace"></a>workspace |  The workspace name (if applying to all members of a workspace).   | String | optional |  `""`  |
 
 

--- a/pycross/extensions/BUILD.bazel
+++ b/pycross/extensions/BUILD.bazel
@@ -4,7 +4,11 @@ exports_files([
     "backends.bzl",
     "lock_import.bzl",
     "lock_repos.bzl",
+    "pdm.bzl",
+    "poetry.bzl",
     "pycross.bzl",
+    "pylock.bzl",
+    "uv.bzl",
 ])
 
 bzl_library(
@@ -40,4 +44,32 @@ bzl_library(
     srcs = ["lock.bzl"],
     visibility = ["//visibility:public"],
     deps = ["//pycross/private:lock"],
+)
+
+bzl_library(
+    name = "uv",
+    srcs = ["uv.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//pycross/private:uv_extension"],
+)
+
+bzl_library(
+    name = "pdm",
+    srcs = ["pdm.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//pycross/private:pdm_extension"],
+)
+
+bzl_library(
+    name = "poetry",
+    srcs = ["poetry.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//pycross/private:poetry_extension"],
+)
+
+bzl_library(
+    name = "pylock",
+    srcs = ["pylock.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//pycross/private:pylock_extension"],
 )

--- a/pycross/extensions/pdm.bzl
+++ b/pycross/extensions/pdm.bzl
@@ -1,0 +1,5 @@
+"""The pdm extension."""
+
+load("//pycross/private:pdm_extension.bzl", _pdm = "pdm")
+
+pdm = _pdm

--- a/pycross/extensions/poetry.bzl
+++ b/pycross/extensions/poetry.bzl
@@ -1,0 +1,5 @@
+"""The poetry extension."""
+
+load("//pycross/private:poetry_extension.bzl", _poetry = "poetry")
+
+poetry = _poetry

--- a/pycross/extensions/pylock.bzl
+++ b/pycross/extensions/pylock.bzl
@@ -1,0 +1,5 @@
+"""The pylock extension."""
+
+load("//pycross/private:pylock_extension.bzl", _pylock = "pylock")
+
+pylock = _pylock

--- a/pycross/extensions/uv.bzl
+++ b/pycross/extensions/uv.bzl
@@ -1,0 +1,5 @@
+"""The uv extension."""
+
+load("//pycross/private:uv_extension.bzl", _uv = "uv")
+
+uv = _uv

--- a/pycross/private/BUILD.bazel
+++ b/pycross/private/BUILD.bazel
@@ -128,7 +128,9 @@ bzl_library(
         ":lock_resolver",
         ":pdm_lock_model",
         ":poetry_lock_model",
+        ":pylock_lock_model",
         ":resolved_lock_renderer",
+        ":uv_lock_model",
     ],
 )
 
@@ -256,17 +258,11 @@ bzl_library(
     name = "lock_import",
     srcs = ["lock_import.bzl"],
     deps = [
-        ":internal_repo",
         ":lock_attrs",
         ":lock_workspace_repo",
-        ":pdm_lock_model",
-        ":poetry_lock_model",
-        ":pylock_lock_model",
-        ":pypi_file",
         ":resolved_lock_repo",
-        ":uv_lock_model",
         "@bazel_features//:features",
-    ] + REPO_HTTP_DEPS,
+    ],
 )
 
 bzl_library(
@@ -427,6 +423,58 @@ bzl_library(
         ":pylock_lock_model",
         ":uv_lock_model",
         "@bazel_features//:features",
+    ],
+)
+
+bzl_library(
+    name = "format_extension",
+    srcs = ["format_extension.bzl"],
+    deps = [
+        ":json_file_repo",
+        ":lock_common",
+        ":lock_repo_creation",
+        ":lock_resolver",
+        "@bazel_features//:features",
+    ],
+)
+
+bzl_library(
+    name = "uv_extension",
+    srcs = ["uv_extension.bzl"],
+    deps = [
+        ":format_extension",
+        ":lock_common",
+        ":uv_lock_model",
+    ],
+)
+
+bzl_library(
+    name = "pdm_extension",
+    srcs = ["pdm_extension.bzl"],
+    deps = [
+        ":format_extension",
+        ":lock_common",
+        ":pdm_lock_model",
+    ],
+)
+
+bzl_library(
+    name = "poetry_extension",
+    srcs = ["poetry_extension.bzl"],
+    deps = [
+        ":format_extension",
+        ":lock_common",
+        ":poetry_lock_model",
+    ],
+)
+
+bzl_library(
+    name = "pylock_extension",
+    srcs = ["pylock_extension.bzl"],
+    deps = [
+        ":format_extension",
+        ":lock_common",
+        ":pylock_lock_model",
     ],
 )
 

--- a/pycross/private/format_extension.bzl
+++ b/pycross/private/format_extension.bzl
@@ -1,0 +1,609 @@
+"""Shared factory for creating per-format lock module extensions.
+
+Each per-format extension (uv, pdm, poetry, pylock) follows the same pattern:
+  1. Collect project/workspace/all_projects/package tags
+  2. Desugar standalone projects into workspace + member
+  3. Process workspaces (discover members, register repos)
+  4. Run translators + resolver inline
+  5. Call create_repos()
+
+This factory eliminates the boilerplate, similar to make_override_extension()
+for backend extensions.
+"""
+
+load("@bazel_features//:features.bzl", "bazel_features")
+load(":json_file_repo.bzl", "json_file_repo")
+load(
+    ":lock_common.bzl",
+    "check_proper_package_repo",
+    "normalize_package_tag",
+    "package_annotation",
+    "process_workspaces",
+    "validate_transition_attrs",
+)
+load(":lock_repo_creation.bzl", "create_repos")
+load(":lock_resolver.bzl", "resolve")
+
+# Shared attrs applied to every project tag (standalone or member override).
+COMMON_PROJECT_ATTRS = dict(
+    default_alias_single_version = attr.bool(
+        doc = "Generate aliases for all packages that have a single version in the lock file.",
+    ),
+    local_wheels = attr.label_list(
+        doc = "A list of local .whl files to consider when processing lock files.",
+    ),
+    disallow_builds = attr.bool(
+        doc = "If True, only pre-built wheels are allowed.",
+    ),
+    default_build_dependencies = attr.string_list(
+        doc = "A list of package keys (name or name@version) that will be used as default build dependencies.",
+    ),
+    build_repo = attr.string(
+        doc = "Optional default repo to use for resolving sdist build dependencies.",
+    ),
+    pypi_indexes = attr.string_list(
+        doc = "List of PyPI-compatible indexes to use for downloading packages.",
+    ),
+)
+
+# Shared attrs for standalone project imports (adds lock_file, project_file, repo).
+STANDALONE_PROJECT_ATTRS = dict(
+    repo = attr.string(
+        doc = "The repository name.",
+        mandatory = True,
+    ),
+    lock_file = attr.label(
+        doc = "The lock file.",
+        allow_single_file = True,
+        mandatory = True,
+    ),
+    project_file = attr.label(
+        doc = "The pyproject.toml file. If not specified, defaults to pyproject.toml next to the lock file.",
+        allow_single_file = True,
+    ),
+)
+
+# Shared attrs for workspace tags.
+WORKSPACE_COMMON_ATTRS = dict(
+    name = attr.string(
+        doc = "Workspace name. Used to link members to this workspace.",
+        mandatory = True,
+    ),
+    lock_file = attr.label(
+        doc = "The shared lock file for the workspace.",
+        allow_single_file = True,
+        mandatory = True,
+    ),
+    default_alias_single_version = attr.bool(
+        doc = "Generate aliases for all packages that have a single version in the lock file.",
+    ),
+    local_wheels = attr.label_list(
+        doc = "A list of local .whl files to consider when processing lock files.",
+    ),
+    disallow_builds = attr.bool(
+        doc = "If True, only pre-built wheels are allowed.",
+    ),
+    default_build_dependencies = attr.string_list(
+        doc = "A list of package keys (name or name@version) that will be used as default build dependencies.",
+    ),
+    build_repo = attr.string(
+        doc = "Optional default repo to use for resolving sdist build dependencies.",
+    ),
+    pypi_indexes = attr.string_list(
+        doc = "List of PyPI-compatible indexes to use for downloading packages.",
+    ),
+)
+
+# Shared attrs for all_projects tags.
+ALL_PROJECTS_COMMON_ATTRS = dict(
+    workspace = attr.string(
+        doc = "Name of the workspace to auto-discover members from.",
+        mandatory = True,
+    ),
+    repo_pattern = attr.string(
+        doc = "Pattern for auto-generated repo names. Use '{member}' as a placeholder " +
+              "for the normalized project name.",
+        default = "{member}",
+    ),
+    excluded_projects = attr.string_list(
+        doc = "Project names to skip during auto-discovery.",
+    ),
+)
+
+# Shared attrs for member override project tags (within workspace).
+MEMBER_PROJECT_ATTRS = dict(
+    workspace = attr.string(
+        doc = "Name of the workspace this member belongs to.",
+    ),
+    name = attr.string(
+        doc = "The project name as it appears in the lock file. Optional if the workspace has only one member.",
+    ),
+    repo = attr.string(
+        doc = "Override the repo name.",
+    ),
+    project_file = attr.label(
+        doc = "Override auto-discovered pyproject.toml path.",
+        allow_single_file = True,
+    ),
+)
+
+# Transition attrs for project and all_projects tags.
+TRANSITION_ATTRS = dict(
+    constraint_values = attr.label_list(
+        doc = "A list of constraint values to apply to the generated platform.",
+    ),
+    flags = attr.string_list(
+        doc = "A list of flags to apply to the generated platform (e.g., '--@flag=value').",
+    ),
+    platform = attr.label(
+        doc = "An existing platform target to use directly.",
+    ),
+)
+
+# Group-selection attrs for all_projects tags (group-wide defaults).
+GROUP_ATTRS = dict(
+    optional_groups = attr.string_list(
+        doc = "List of optional dependency groups to install.",
+    ),
+    all_optional_groups = attr.bool(
+        doc = "Install all optional dependencies.",
+    ),
+    development_groups = attr.string_list(
+        doc = "List of development dependency groups to install.",
+    ),
+    all_development_groups = attr.bool(
+        doc = "Install all dev dependencies.",
+    ),
+)
+
+# Group-selection attrs for member override project tags.
+GROUP_OVERRIDE_ATTRS = dict(
+    default_group = attr.bool(
+        doc = "Whether to install dependencies from the default group.",
+        default = True,
+    ),
+    optional_groups = attr.string_list(
+        doc = "List of optional dependency groups to install (overrides all_projects setting).",
+    ),
+    development_groups = attr.string_list(
+        doc = "List of development dependency groups to install (overrides all_projects setting).",
+    ),
+)
+
+# Attrs for the package tag.
+PACKAGE_ATTRS = dict(
+    name = attr.string(
+        doc = "The package key (name or name@version).",
+        mandatory = True,
+    ),
+    repo = attr.string(
+        doc = "The repository name (if applying to a specific lock file).",
+    ),
+    workspace = attr.string(
+        doc = "The workspace name (if applying to all members of a workspace).",
+    ),
+    build_backend = attr.string(
+        doc = "An explicit build backend rule name to use for this package.",
+    ),
+    build_target = attr.label(
+        doc = "An optional override build target to use when building from source.",
+    ),
+    always_build = attr.bool(
+        doc = "If True, don't use pre-built wheels for this package.",
+    ),
+    build_dependencies = attr.string_list(
+        doc = "A list of additional package keys to use when building this package from source.",
+    ),
+    build_repo = attr.string(
+        doc = "Optional repo to use for resolving sdist build dependencies for this package.",
+    ),
+    ignore_dependencies = attr.string_list(
+        doc = "A list of package keys to drop from this package's declared dependencies.",
+    ),
+    install_exclude_globs = attr.string_list(
+        doc = "A list of globs for files to exclude during installation.",
+    ),
+    post_install_patches = attr.label_list(
+        doc = "A list of patches to apply after wheel installation.",
+        allow_files = True,
+    ),
+    pre_build_patches = attr.label_list(
+        doc = "A list of patches to apply to the sdist source tree before building.",
+        allow_files = True,
+    ),
+    site_hooks = attr.string_list(
+        doc = "A list of Python code snippets to execute on interpreter startup during builds.",
+    ),
+    site_paths = attr.string_list(
+        doc = "Override the auto-detected top-level importable paths.",
+    ),
+    bin_paths = attr.string_list(
+        doc = "Override the auto-detected bin paths.",
+    ),
+    data_paths = attr.string_list(
+        doc = "Override the auto-detected data paths.",
+    ),
+    include_paths = attr.string_list(
+        doc = "Override the auto-detected include paths.",
+    ),
+)
+
+def _resolve_lock_inline(module_ctx, lock_info, serialized_lock_model, workspace_packages, repo_create_model_fn):
+    """Run translator + resolver inline within module_ctx.
+
+    Args:
+        module_ctx: The module_ctx object.
+        lock_info: The lock repo info struct.
+        serialized_lock_model: JSON-encoded lock model.
+        workspace_packages: Dict of workspace_name -> {pkg_name -> normalized_tag}.
+        repo_create_model_fn: The format-specific translator function.
+
+    Returns:
+        A dict containing the resolved lock data (packages, pins, remote_files, etc.).
+    """
+    lock_model = json.decode(serialized_lock_model)
+    if type(lock_model) == "dict":
+        lock_model = struct(**lock_model)
+
+    project_file = Label(lock_model.project_file) if getattr(lock_model, "project_file", "") else None
+    lock_file = Label(lock_model.lock_file)
+
+    # Use a unique output file per repo to avoid conflicts.
+    output = "raw_lock_{}.json".format(lock_info.repo_name)
+
+    repo_create_model_fn(module_ctx, project_file, lock_file, lock_model, output)
+
+    # Read the raw lock and resolve.
+    raw_lock_data = json.decode(module_ctx.read(module_ctx.path(output)))
+
+    # Compute annotations from package tags.
+    all_packages = {}
+    for package_name, package in workspace_packages.get(lock_info.workspace, {}).items():
+        all_packages[package_name] = package
+    for package_name, package in lock_info.packages.items():
+        all_packages[package_name] = package
+
+    annotations_data = {}
+    for package_name, package in all_packages.items():
+        annotations_data[package_name] = json.decode(package_annotation(
+            always_build = package.always_build,
+            build_dependencies = package.build_dependencies,
+            build_repo = package.build_repo,
+            build_target = str(package.build_target) if package.build_target else None,
+            ignore_dependencies = package.ignore_dependencies,
+            install_exclude_globs = package.install_exclude_globs,
+            post_install_patches = package.post_install_patches,
+            pre_build_patches = package.pre_build_patches,
+            site_hooks = package.site_hooks,
+            build_backend = package.build_backend,
+            site_paths = package.site_paths,
+            bin_paths = package.bin_paths,
+            data_paths = package.data_paths,
+            include_paths = package.include_paths,
+        ))
+
+    local_wheels = {}
+    for w in lock_info.local_wheels:
+        local_wheels[module_ctx.path(w).basename] = str(w)
+
+    resolved_lock = resolve(
+        lock_model_data = raw_lock_data,
+        local_wheels = local_wheels,
+        remote_wheels = {},
+        always_include_sdist = False,
+        annotations_data = annotations_data,
+        default_build_dependencies_args = lock_info.default_build_dependencies,
+        default_alias_single_version = lock_info.default_alias_single_version,
+    )
+
+    return {
+        "packages": resolved_lock.packages,
+        "pins": resolved_lock.pins,
+        "remote_files": resolved_lock.remote_files,
+        "cycle_groups": resolved_lock.cycle_groups,
+        "variants": resolved_lock.variants,
+    }
+
+def make_format_extension(
+        model_type,
+        standalone_project_attrs,
+        workspace_attrs = None,
+        all_projects_attrs = None,
+        member_project_attrs = None,
+        discover_members_fn = None,
+        repo_create_model_fn = None):
+    """Create a module_extension for a specific lock format.
+
+    Args:
+        model_type: The lock model type string (e.g. "uv", "pdm", "poetry", "pylock").
+        standalone_project_attrs: Format-specific attrs for standalone project imports.
+            These are merged with STANDALONE_PROJECT_ATTRS, COMMON_PROJECT_ATTRS, and TRANSITION_ATTRS.
+        workspace_attrs: Format-specific attrs for workspace tags, or None if
+            workspaces are not supported. Merged with WORKSPACE_COMMON_ATTRS.
+        all_projects_attrs: Format-specific attrs for all_projects tags, or None.
+            Merged with ALL_PROJECTS_COMMON_ATTRS and TRANSITION_ATTRS.
+        member_project_attrs: Format-specific attrs for member project override tags, or None.
+            Merged with MEMBER_PROJECT_ATTRS, GROUP_OVERRIDE_ATTRS, and TRANSITION_ATTRS.
+        discover_members_fn: Function(mctx, lock_file_label) -> [struct(name, path)].
+            Required when workspace_attrs is not None.
+        repo_create_model_fn: Function(module_ctx, project_file, lock_file, lock_model, output).
+            Runs the format-specific translator to produce raw lock JSON.
+
+    Returns:
+        A module_extension value.
+    """
+
+    def _impl(module_ctx):
+        lock_owners = {}
+        lock_repos = {}
+        root_direct_deps = []
+        lock_model_structs = {}
+
+        # Collect tags per module.
+        workspace_tags = []
+        member_tags = []
+        all_members_tags = []
+
+        # Track per-workspace pypi_indexes (from workspace or standalone project tags).
+        workspace_pypi_indexes = {}
+
+        for module in module_ctx.modules:
+            # 1. Process workspace tags (if supported).
+            if workspace_attrs != None:
+                for tag in module.tags.workspace:
+                    ws_name = tag.name
+                    workspace_tags.append(struct(tag = tag, module = module, ws_name = ws_name))
+                    if tag.pypi_indexes:
+                        workspace_pypi_indexes[ws_name] = tag.pypi_indexes
+
+            # 2. Process all_projects tags (if supported).
+            if all_projects_attrs != None:
+                for tag in module.tags.all_projects:
+                    validate_transition_attrs(tag, "all_projects")
+                    all_members_tags.append(struct(tag = tag, module = module))
+
+            # 3. Process project tags — separate standalone from member overrides.
+            for tag in module.tags.project:
+                validate_transition_attrs(tag, "project")
+
+                has_lock_file = bool(getattr(tag, "lock_file", None))
+                has_workspace = bool(getattr(tag, "workspace", None))
+
+                if has_lock_file and has_workspace:
+                    fail("project tag cannot specify both 'lock_file' and 'workspace'")
+
+                if has_lock_file:
+                    # Standalone project: desugar into workspace + member.
+                    repo_name = tag.repo
+                    workspace_tags.append(struct(tag = tag, module = module, ws_name = repo_name))
+                    if tag.pypi_indexes:
+                        workspace_pypi_indexes[repo_name] = tag.pypi_indexes
+
+                    member_tag = struct(
+                        workspace = repo_name,
+                        project = "",
+                        repo = repo_name,
+                        project_file = getattr(tag, "project_file", None),
+                        default_group = getattr(tag, "default_group", True),
+                        optional_groups = getattr(tag, "optional_groups", []),
+                        all_optional_groups = getattr(tag, "all_optional_groups", False),
+                        development_groups = getattr(tag, "development_groups", []),
+                        all_development_groups = getattr(tag, "all_development_groups", False),
+                        flags = getattr(tag, "flags", []),
+                        constraint_values = getattr(tag, "constraint_values", []),
+                        platform = getattr(tag, "platform", None),
+                    )
+                    member_tags.append(struct(tag = member_tag, module = module))
+
+                elif has_workspace:
+                    # Member override within a workspace.
+                    member_tag = struct(
+                        workspace = tag.workspace,
+                        project = getattr(tag, "name", ""),
+                        repo = getattr(tag, "repo", ""),
+                        project_file = getattr(tag, "project_file", None),
+                        default_group = getattr(tag, "default_group", True),
+                        optional_groups = getattr(tag, "optional_groups", []),
+                        development_groups = getattr(tag, "development_groups", []),
+                        flags = getattr(tag, "flags", []),
+                        constraint_values = getattr(tag, "constraint_values", []),
+                        platform = getattr(tag, "platform", None),
+                    )
+                    member_tags.append(struct(tag = member_tag, module = module))
+
+                else:
+                    fail("project tag must specify either 'lock_file' (standalone) or 'workspace' (member override)")
+
+        process_workspaces(
+            module_ctx,
+            lock_owners,
+            lock_repos,
+            lock_model_structs,
+            workspace_tags,
+            member_tags,
+            all_members_tags,
+            discover_members_fn,
+            model_type,
+            root_direct_deps,
+        )
+
+        # Process package annotations.
+        workspace_packages = {}
+        valid_workspaces = {r.workspace: True for r in lock_repos.values()}
+
+        for module in module_ctx.modules:
+            for tag in module.tags.package:
+                if tag.repo and tag.workspace:
+                    fail("package '{}' specifies both repo and workspace".format(tag.name))
+                if not tag.repo and not tag.workspace:
+                    fail("package '{}' must specify either repo or workspace".format(tag.name))
+
+                normalized = normalize_package_tag(tag)
+                if tag.repo:
+                    check_proper_package_repo(lock_owners, module, tag)
+                    repo_info = lock_repos[tag.repo]
+                    if repo_info.workspace != repo_info.repo_name:
+                        fail(
+                            "package '{}' targets repo '{}' which is a member of workspace '{}'. ".format(tag.name, tag.repo, repo_info.workspace) +
+                            "Use workspace = '{}' instead.".format(repo_info.workspace),
+                        )
+                    if tag.name in repo_info.packages:
+                        fail("Multiple package entries for package '{}' in repo '{}'".format(tag.name, tag.repo))
+                    repo_info.packages[tag.name] = normalized
+                elif tag.workspace:
+                    if tag.workspace not in valid_workspaces:
+                        fail("Package override specifies workspace '{}' which does not exist".format(tag.workspace))
+                    ws_pkgs = workspace_packages.setdefault(tag.workspace, {})
+                    if tag.name in ws_pkgs:
+                        fail("Multiple package entries for package '{}' in workspace '{}'".format(tag.name, tag.workspace))
+                    ws_pkgs[tag.name] = normalized
+
+        if not lock_repos:
+            if bazel_features.external_deps.extension_metadata_has_reproducible:
+                return module_ctx.extension_metadata(reproducible = True)
+            return module_ctx.extension_metadata()
+
+        # Run translators + resolver inline for each lock repo.
+        resolved_locks = {}
+        all_locks = {}
+        repo_pypi_indexes = {}  # repo_name -> pypi_indexes list
+
+        for repo_name, repo_info in lock_repos.items():
+            # Determine pypi_indexes for this repo from its workspace.
+            pypi_indexes = workspace_pypi_indexes.get(repo_info.workspace, [])
+            if pypi_indexes:
+                repo_pypi_indexes[repo_name] = pypi_indexes
+
+            resolved_data = _resolve_lock_inline(
+                module_ctx,
+                repo_info,
+                lock_model_structs[repo_name],
+                workspace_packages,
+                repo_create_model_fn,
+            )
+            resolved_locks[repo_info.repo_name] = resolved_data
+
+            # Write the resolved lock JSON to a repo.
+            lock_repo_name = "{}_lock_json".format(repo_info.repo_name)
+            json_file_repo(
+                name = lock_repo_name,
+                content = json.encode(resolved_data),
+            )
+            all_locks[repo_info.repo_name] = "@{}//:data.json".format(lock_repo_name)
+
+        # Compute workspace metadata.
+        workspace_memberships = {}
+        workspace_build_repos = {}
+        repo_flags = {}
+        repo_constraint_values = {}
+        repo_platforms = {}
+        repo_disallow_builds = {}
+
+        for repo_info in lock_repos.values():
+            workspace_memberships[repo_info.repo_name] = repo_info.workspace
+            if repo_info.build_repo:
+                workspace_build_repos[repo_info.workspace] = repo_info.build_repo
+            if repo_info.flags:
+                repo_flags[repo_info.repo_name] = json.encode(repo_info.flags)
+            if repo_info.constraint_values:
+                repo_constraint_values[repo_info.repo_name] = json.encode(repo_info.constraint_values)
+            if repo_info.platform:
+                repo_platforms[repo_info.repo_name] = repo_info.platform
+            if repo_info.disallow_builds:
+                repo_disallow_builds[repo_info.repo_name] = True
+
+        # Determine the pypi_index to pass (use the first from any repo for now).
+        # TODO: Support per-repo pypi_indexes in create_repos.
+        pypi_index = None
+        for _repo_name, indexes in repo_pypi_indexes.items():
+            if indexes:
+                pypi_index = indexes[0]
+                break
+
+        create_repos(
+            module_ctx = module_ctx,
+            all_locks = all_locks,
+            workspace_memberships = workspace_memberships,
+            workspace_build_repos = workspace_build_repos,
+            repo_flags = repo_flags,
+            repo_constraint_values = repo_constraint_values,
+            repo_platforms = repo_platforms,
+            repo_disallow_builds = repo_disallow_builds,
+            pypi_index = pypi_index,
+            resolved_locks = resolved_locks,
+        )
+
+        if bazel_features.external_deps.extension_metadata_has_reproducible:
+            return module_ctx.extension_metadata(
+                root_module_direct_deps = root_direct_deps,
+                root_module_direct_dev_deps = [],
+                reproducible = True,
+            )
+        return module_ctx.extension_metadata(
+            root_module_direct_deps = root_direct_deps,
+            root_module_direct_dev_deps = [],
+        )
+
+    # Build tag classes.
+    #
+    # The "project" tag is dual-purpose:
+    # - When lock_file is provided: standalone project (uses STANDALONE_PROJECT_ATTRS)
+    # - When workspace is provided: member override (uses MEMBER_PROJECT_ATTRS)
+    #
+    # We merge all attrs into a single tag_class since Bazel tag_class doesn't
+    # support conditional attrs. The _impl validates mutual exclusivity.
+    project_tag_attrs = {}
+    project_tag_attrs.update(standalone_project_attrs)
+    if member_project_attrs:
+        project_tag_attrs.update(member_project_attrs)
+    else:
+        project_tag_attrs.update(MEMBER_PROJECT_ATTRS)
+    project_tag_attrs.update(GROUP_OVERRIDE_ATTRS)
+    project_tag_attrs.update(COMMON_PROJECT_ATTRS)
+    project_tag_attrs.update(TRANSITION_ATTRS)
+
+    # For the dual-purpose project tag, lock_file and repo must not be mandatory
+    # since they are only required for standalone mode.
+    if "lock_file" in project_tag_attrs:
+        project_tag_attrs["lock_file"] = attr.label(
+            doc = "The lock file (required for standalone project, omit for workspace member).",
+            allow_single_file = True,
+        )
+    if "repo" in project_tag_attrs:
+        project_tag_attrs["repo"] = attr.string(
+            doc = "The repository name (required for standalone project, optional for workspace member override).",
+        )
+
+    tag_classes = {
+        "project": tag_class(
+            doc = "Import a %s lock file as a standalone project, or override a workspace member's settings." % model_type,
+            attrs = project_tag_attrs,
+        ),
+        "package": tag_class(
+            doc = "Specify package-specific settings.",
+            attrs = PACKAGE_ATTRS,
+        ),
+    }
+
+    if workspace_attrs != None:
+        ws_attrs = dict(workspace_attrs)
+        ws_attrs.update(WORKSPACE_COMMON_ATTRS)
+        tag_classes["workspace"] = tag_class(
+            doc = "Declare a %s workspace from a shared lock file." % model_type,
+            attrs = ws_attrs,
+        )
+
+    if all_projects_attrs != None:
+        ap_attrs = dict(all_projects_attrs)
+        ap_attrs.update(ALL_PROJECTS_COMMON_ATTRS)
+        ap_attrs.update(GROUP_ATTRS)
+        ap_attrs.update(TRANSITION_ATTRS)
+        tag_classes["all_projects"] = tag_class(
+            doc = "Auto-discover and import all members of a %s workspace." % model_type,
+            attrs = ap_attrs,
+        )
+
+    return module_extension(
+        implementation = _impl,
+        tag_classes = tag_classes,
+    )

--- a/pycross/private/format_extension.bzl
+++ b/pycross/private/format_extension.bzl
@@ -553,6 +553,7 @@ def make_format_extension(
     # We merge all attrs into a single tag_class since Bazel tag_class doesn't
     # support conditional attrs. The _impl validates mutual exclusivity.
     project_tag_attrs = {}
+    project_tag_attrs.update(STANDALONE_PROJECT_ATTRS)
     project_tag_attrs.update(standalone_project_attrs)
     if member_project_attrs:
         project_tag_attrs.update(member_project_attrs)

--- a/pycross/private/lock_import.bzl
+++ b/pycross/private/lock_import.bzl
@@ -1,39 +1,23 @@
-"""The lock_import extension."""
+"""The lock_import extension (V1 compatibility).
+
+This is the legacy two-extension pattern: lock_import defines lock repos,
+lock_repos creates them. For new projects, use the per-format extensions
+(uv.bzl, pdm.bzl, poetry.bzl, pylock.bzl) instead.
+"""
 
 load("@bazel_features//:features.bzl", "bazel_features")
-load("@toml.bzl//toml:toml.bzl", "decode")
 load("//pycross/private:resolved_lock_repo.bzl", "resolved_lock_repo")
-load("//pycross/private:util.bzl", "sanitize_name")
 load(
     ":lock_attrs.bzl",
     "COMMON_IMPORT_ATTRS",
-    "OVERRIDE_TARGET_ATTRS",
     "PACKAGE_ATTRS",
-    "PDM_ALL_MEMBERS_ATTRS",
     "PDM_IMPORT_ATTRS",
-    "PDM_MEMBER_ATTRS",
-    "PDM_WORKSPACE_ATTRS",
     "POETRY_IMPORT_ATTRS",
-    "POETRY_MEMBER_ATTRS",
     "PYLOCK_IMPORT_ATTRS",
-    "PYLOCK_MEMBER_ATTRS",
     "REPO_ATTR",
-    "UV_ALL_MEMBERS_ATTRS",
     "UV_IMPORT_ATTRS",
-    "UV_MEMBER_ATTRS",
-    "UV_WORKSPACE_ATTRS",
-    "WORKSPACE_COMMON_ATTRS",
-    "WORKSPACE_MEMBER_COMMON_ATTRS",
 )
 load(":lock_workspace_repo.bzl", "lock_workspace_repo")
-
-def _validate_transition_attrs(tag, tag_name):
-    has_platform = bool(getattr(tag, "platform", None))
-    has_flags = bool(getattr(tag, "flags", []))
-    has_constraints = bool(getattr(tag, "constraint_values", []))
-
-    if has_platform and (has_flags or has_constraints):
-        fail("Tag '{}' cannot specify both 'platform' and ('flags' or 'constraint_values')".format(tag_name))
 
 def _package_annotation(
         always_build = False,
@@ -68,7 +52,7 @@ def _package_annotation(
         include_paths = include_paths,
     ))
 
-def _generate_resolved_lock_repo(lock_info, serialized_lock_model, workspace_packages):
+def _generate_resolved_lock_repo(lock_info, serialized_lock_model):
     repo_name = lock_info.repo_name
     args = {
         "name": repo_name,
@@ -80,14 +64,7 @@ def _generate_resolved_lock_repo(lock_info, serialized_lock_model, workspace_pac
         "annotations": {},
     }
 
-    # Workspace-level packages first, then repo-level packages override.
-    all_packages = {}
-    for package_name, package in workspace_packages.get(lock_info.workspace, {}).items():
-        all_packages[package_name] = package
     for package_name, package in lock_info.packages.items():
-        all_packages[package_name] = package
-
-    for package_name, package in all_packages.items():
         args["annotations"][package_name] = _package_annotation(
             always_build = package.always_build,
             build_dependencies = package.build_dependencies,
@@ -108,15 +85,14 @@ def _generate_resolved_lock_repo(lock_info, serialized_lock_model, workspace_pac
     resolved_lock_repo(**args)
     return "@{}//:lock.json".format(repo_name)
 
-def _check_unique_repo_name(owners, module_name, repo_name):
-    """Check uniqueness using a repo name string instead of a tag."""
-    if repo_name in owners:
+def _check_unique_lock_repo(owners, module, tag):
+    if tag.repo in owners:
         fail("lock repo '{}' wanted by module '{}' already created by module '{}'".format(
-            repo_name,
-            module_name,
-            owners[repo_name],
+            tag.repo,
+            module.name,
+            owners[tag.repo],
         ))
-    owners[repo_name] = module_name
+    owners[tag.repo] = module.name
 
 def _check_proper_tag_repo(owners, module, tag, tag_desc):
     owner = owners.get(tag.repo)
@@ -141,20 +117,26 @@ def _check_proper_tag_repo(owners, module, tag, tag_desc):
 def _check_proper_package_repo(owners, module, tag):
     _check_proper_tag_repo(owners, module, tag, "package '{}'".format(tag.name))
 
-def _workspace_lock_struct(ws_tag, repo_name, workspace_name, transition_attrs):
-    """Create a lock struct for a workspace member, inheriting workspace-level settings."""
+def _validate_transition_attrs(tag, tag_name):
+    has_platform = bool(getattr(tag, "platform", None))
+    has_flags = bool(getattr(tag, "flags", []))
+    has_constraints = bool(getattr(tag, "constraint_values", []))
+
+    if has_platform and (has_flags or has_constraints):
+        fail("Tag '{}' cannot specify both 'platform' and ('flags' or 'constraint_values')".format(tag_name))
+
+def _lock_struct(tag):
     return struct(
-        repo_name = repo_name,
-        workspace = workspace_name,
-        build_repo = ws_tag.build_repo,
-        default_alias_single_version = ws_tag.default_alias_single_version,
-        local_wheels = ws_tag.local_wheels,
-        disallow_builds = ws_tag.disallow_builds,
-        default_build_dependencies = ws_tag.default_build_dependencies,
+        repo_name = tag.repo,
+        default_alias_single_version = tag.default_alias_single_version,
+        local_wheels = tag.local_wheels,
+        disallow_builds = tag.disallow_builds,
+        default_build_dependencies = tag.default_build_dependencies,
+        build_repo = tag.build_repo,
         packages = {},
-        flags = transition_attrs.get("flags", []),
-        constraint_values = transition_attrs.get("constraint_values", []),
-        platform = transition_attrs.get("platform"),
+        flags = getattr(tag, "flags", []),
+        constraint_values = getattr(tag, "constraint_values", []),
+        platform = getattr(tag, "platform", None),
     )
 
 def _normalize_package_tag(tag):
@@ -176,357 +158,6 @@ def _normalize_package_tag(tag):
         include_paths = tag.include_paths,
     )
 
-def _discover_uv_all_members(mctx, lock_file_label):
-    """Parse uv.lock and return workspace members (editable packages).
-
-    Args:
-        mctx: The module_ctx object.
-        lock_file_label: Label of the uv.lock file.
-
-    Returns:
-        A list of structs with 'name' and 'path' fields.
-    """
-    lock_content = mctx.read(lock_file_label)
-    lock_data = decode(lock_content)
-
-    # uv.lock uses "package" (newer) or "distribution" (older) for the package list.
-    packages_list = lock_data.get("package", lock_data.get("distribution", []))
-
-    members = []
-    for pkg in packages_list:
-        source = pkg.get("source", {})
-        if "editable" in source:
-            members.append(struct(
-                name = pkg["name"],
-                path = source["editable"],
-            ))
-        elif "virtual" in source:
-            # Only include virtual members that have actual dependencies.
-            # A virtual workspace root with no dependencies is just the workspace
-            # definition and shouldn't produce a lock repo.
-            has_deps = (
-                pkg.get("dependencies") or
-                pkg.get("optional-dependencies") or
-                pkg.get("dev-dependencies")
-            )
-            if has_deps:
-                members.append(struct(
-                    name = pkg["name"],
-                    path = source["virtual"],
-                ))
-
-    return members
-
-def _discover_pdm_all_members(mctx, lock_file_label):
-    """Parse pdm.lock and return workspace members (editable local packages)."""
-    lock_content = mctx.read(lock_file_label)
-    lock_data = decode(lock_content)
-
-    packages_list = lock_data.get("package", [])
-
-    members = []
-    for pkg in packages_list:
-        # PDM marks workspace members with editable = true and a path.
-        if pkg.get("editable") and "path" in pkg:
-            members.append(struct(
-                name = pkg["name"],
-                path = pkg["path"],
-            ))
-
-    return members
-
-def _discover_poetry_all_members(_mctx, _lock_file_label):
-    return [struct(name = "root", path = "")]
-
-def _discover_pylock_all_members(_mctx, _lock_file_label):
-    return [struct(name = "root", path = "")]
-
-def _resolve_member_project_file(lock_file_label, member_path):
-    """Resolve a member's pyproject.toml label relative to the lock file.
-
-    Args:
-        lock_file_label: Label of the uv.lock file.
-        member_path: Relative path from lock file to member directory (e.g. "./packages/lib-a").
-
-    Returns:
-        A Label pointing to the member's pyproject.toml.
-    """
-
-    # Strip leading "./" if present
-    clean_path = member_path
-    if clean_path.startswith("./"):
-        clean_path = clean_path[2:]
-    if clean_path == ".":
-        clean_path = ""
-
-    # Build the package path relative to the lock file's package
-    lock_package = lock_file_label.package
-    if lock_package:
-        member_package = lock_package + ("/" + clean_path if clean_path else "")
-    else:
-        member_package = clean_path
-
-    if member_package:
-        return lock_file_label.relative("//{}:pyproject.toml".format(member_package))
-    else:
-        return lock_file_label.relative("//:pyproject.toml")
-
-def _determine_project_file(override_tag, model_type, lock_file_label, member_path):
-    if override_tag and override_tag.project_file:
-        return override_tag.project_file
-    elif model_type == "pylock":
-        return ""
-    else:
-        return _resolve_member_project_file(lock_file_label, member_path)
-
-def _get_member_group_attrs(members_tag, override_tag):
-    """Merge group attrs from an all_members default and optional member override.
-
-    Design: boolean flags live at exactly one level to avoid clobber issues
-    (Starlark booleans have no None sentinel).
-      - default_group: only on the override tag (per-member decision).
-      - all_optional_groups: only on the all_members tag (group-wide).
-        If the override specifies an explicit optional_groups list, all_optional_groups
-        is disabled for that member.
-      - all_development_groups: same pattern as all_optional_groups.
-    """
-    has_explicit_optional = override_tag and override_tag.optional_groups
-    has_explicit_development = override_tag and override_tag.development_groups
-
-    return dict(
-        default_group = override_tag.default_group if override_tag else True,
-        optional_groups = override_tag.optional_groups if has_explicit_optional else (members_tag.optional_groups if hasattr(members_tag, "optional_groups") else []),
-        all_optional_groups = (members_tag.all_optional_groups if hasattr(members_tag, "all_optional_groups") else False) and not has_explicit_optional,
-        development_groups = override_tag.development_groups if has_explicit_development else (members_tag.development_groups if hasattr(members_tag, "development_groups") else []),
-        all_development_groups = (members_tag.all_development_groups if hasattr(members_tag, "all_development_groups") else False) and not has_explicit_development,
-    )
-
-def _get_member_transition_attrs(members_tag, override_tag):
-    """Merge transition attrs from an all_members default and optional member override."""
-    has_explicit_flags = override_tag and getattr(override_tag, "flags", [])
-    has_explicit_constraints = override_tag and getattr(override_tag, "constraint_values", [])
-    has_explicit_platform = override_tag and getattr(override_tag, "platform", None)
-
-    if override_tag and (has_explicit_flags or has_explicit_constraints or has_explicit_platform):
-        return dict(
-            flags = getattr(override_tag, "flags", []),
-            constraint_values = [str(c) for c in getattr(override_tag, "constraint_values", [])],
-            platform = str(override_tag.platform) if override_tag.platform else None,
-        )
-
-    return dict(
-        flags = getattr(members_tag, "flags", []) if members_tag else [],
-        constraint_values = [str(c) for c in getattr(members_tag, "constraint_values", [])] if members_tag else [],
-        platform = str(members_tag.platform) if members_tag and getattr(members_tag, "platform", None) else None,
-    )
-
-def _register_workspace_member(
-        lock_owners,
-        lock_repos,
-        lock_model_structs,
-        root_direct_deps,
-        ws_tag,
-        ws_name,
-        model_type,
-        repo_name,
-        project_file,
-        group_attrs,
-        transition_attrs,
-        lock_module):
-    """Register a single workspace member as a lock repo with its model.
-
-    This is the shared registration path for both bulk (uv_all_members)
-    and standalone (uv_member) imports.
-    """
-    _check_unique_repo_name(lock_owners, lock_module.name, repo_name)
-    lock_repos[repo_name] = _workspace_lock_struct(ws_tag, repo_name, ws_name, transition_attrs)
-    if lock_module.is_root:
-        root_direct_deps.append(repo_name)
-
-    model = dict(
-        model_type = model_type,
-        project_file = str(project_file),
-        lock_file = str(ws_tag.lock_file),
-        **group_attrs
-    )
-
-    # Handle attributes that are not common across all lock formats
-    for attr_name in ("require_static_urls",):
-        if hasattr(ws_tag, attr_name):
-            model[attr_name] = getattr(ws_tag, attr_name)
-    lock_model_structs[repo_name] = json.encode(model)
-
-def _process_member(
-        lock_owners,
-        lock_repos,
-        lock_model_structs,
-        root_direct_deps,
-        ws_tag,
-        ws_name,
-        member,
-        model_type,
-        overrides,
-        default_module,
-        members_tag = None):
-    for override in overrides:
-        # Determine repo name
-        normalized_name = sanitize_name(member.name)
-        if override and override.tag.repo:
-            repo_name = override.tag.repo
-        elif members_tag and hasattr(members_tag, "repo_pattern"):
-            repo_name = members_tag.repo_pattern.format(member = normalized_name)
-        else:
-            repo_name = normalized_name
-
-        # Determine project_file
-        project_file = _determine_project_file(override.tag if override else None, model_type, ws_tag.lock_file, member.path)
-
-        # Get group attrs (override wins)
-        group_attrs = _get_member_group_attrs(members_tag or struct(), override.tag if override else None)
-
-        # Get transition attrs (override wins)
-        transition_attrs = _get_member_transition_attrs(members_tag or struct(), override.tag if override else None)
-
-        lock_module = override.module if override else default_module
-
-        _register_workspace_member(
-            lock_owners,
-            lock_repos,
-            lock_model_structs,
-            root_direct_deps,
-            ws_tag,
-            ws_name,
-            model_type,
-            repo_name,
-            project_file,
-            group_attrs,
-            transition_attrs,
-            lock_module,
-        )
-
-def _process_workspaces(
-        module_ctx,
-        lock_owners,
-        lock_repos,
-        lock_model_structs,
-        workspace_tags,
-        member_tags,
-        all_members_tags,
-        discover_members_fn,
-        model_type,
-        root_direct_deps):
-    # Collect workspace definitions
-    workspaces = {}
-    for tag_info in workspace_tags:
-        if tag_info.ws_name in workspaces:
-            fail("Duplicate workspace name: '{}'".format(tag_info.ws_name))
-        workspaces[tag_info.ws_name] = tag_info
-
-    # Auto-discover members for each workspace
-    workspace_discovered_members = {}
-    for name, ws_info in workspaces.items():
-        discovered = discover_members_fn(module_ctx, ws_info.tag.lock_file)
-        workspace_discovered_members[name] = {m.name: m for m in discovered}
-
-    # Collect per-member overrides indexed by (workspace, project)
-    member_overrides = {}
-    for tag_info in member_tags:
-        tag = tag_info.tag
-        module = tag_info.module
-        if tag.workspace not in workspaces:
-            fail("member tag references non-existent workspace: '{}'".format(tag.workspace))
-
-        # If project is omitted, infer from discovered members.
-        project = tag.project
-        if not project:
-            discovered = workspace_discovered_members[tag.workspace]
-            if len(discovered) == 1:
-                project = list(discovered.keys())[0]
-            elif len(discovered) == 0:
-                fail("no members discovered in workspace '{}'; cannot infer project".format(tag.workspace))
-            else:
-                fail("workspace '{}' has {} members ({}); 'project' is required to disambiguate".format(
-                    tag.workspace,
-                    len(discovered),
-                    ", ".join(sorted(discovered.keys())),
-                ))
-
-        key = (tag.workspace, project)
-        if key not in member_overrides:
-            member_overrides[key] = []
-
-        # Check for duplicate repo names within the same project override
-        for existing in member_overrides[key]:
-            if existing.tag.repo and tag.repo and existing.tag.repo == tag.repo:
-                fail("Duplicate member override for project '{}' with repo '{}' in workspace '{}'".format(project, tag.repo, tag.workspace))
-
-        member_overrides[key].append(tag_info)
-
-    processed_members = {}  # (workspace, project) -> True
-
-    # Process bulk member imports
-    for tag_info in all_members_tags:
-        tag = tag_info.tag
-        module = tag_info.module
-        if tag.workspace not in workspaces:
-            fail("all_members tag references non-existent workspace: '{}'".format(tag.workspace))
-
-        ws_info = workspaces[tag.workspace]
-        ws_tag = ws_info.tag
-
-        discovered = workspace_discovered_members[tag.workspace]
-        excluded = {p: True for p in tag.excluded_projects}
-
-        for member_name, member in discovered.items():
-            if member_name in excluded:
-                continue
-
-            processed_members[(tag.workspace, member_name)] = True
-
-            overrides = member_overrides.get((tag.workspace, member_name), [None])
-
-            _process_member(
-                lock_owners,
-                lock_repos,
-                lock_model_structs,
-                root_direct_deps,
-                ws_tag,
-                tag.workspace,
-                member,
-                model_type,
-                overrides,
-                module,
-                members_tag = tag,
-            )
-
-    # Process standalone member imports
-    for key, overrides in member_overrides.items():
-        if key in processed_members:
-            continue
-
-        ws_name, project = key
-        ws_info = workspaces[ws_name]
-        ws_tag = ws_info.tag
-        discovered = workspace_discovered_members[ws_name]
-
-        if project not in discovered:
-            fail("Project '{}' not found in workspace '{}'".format(project, ws_name))
-
-        member = discovered[project]
-
-        _process_member(
-            lock_owners,
-            lock_repos,
-            lock_model_structs,
-            root_direct_deps,
-            ws_tag,
-            ws_name,
-            member,
-            model_type,
-            overrides,
-            None,
-        )
-
 def _lock_import_impl(module_ctx):
     lock_owners = {}
     lock_repos = {}
@@ -534,104 +165,72 @@ def _lock_import_impl(module_ctx):
     lock_model_structs = {}
     resolved_lock_files = {}
 
-    for name, tag_prefixes, discover_fn in [
-        ("uv", ["import_uv", "import_uv_workspace"], _discover_uv_all_members),
-        ("pdm", ["import_pdm", "import_pdm_workspace"], _discover_pdm_all_members),
-        ("poetry", ["import_poetry"], _discover_poetry_all_members),
-        ("pylock", ["import_pylock"], _discover_pylock_all_members),
-    ]:
-        workspace_tags = []
-        member_tags = []
-        all_members_tags = []
+    # First pass: initialize lock structures and check for duplicate repo names.
+    for module in module_ctx.modules:
+        for tag_name in ("import_uv", "import_pdm", "import_poetry", "import_pylock"):
+            for tag in getattr(module.tags, tag_name):
+                _validate_transition_attrs(tag, tag_name)
+                _check_unique_lock_repo(lock_owners, module, tag)
+                lock_repos[tag.repo] = _lock_struct(tag)
+                if module.is_root:
+                    root_direct_deps.append(tag.repo)
 
-        import_tag_name = tag_prefixes[0]
-        import_ws_tag_name = tag_prefixes[1] if len(tag_prefixes) > 1 else None
+    # Second pass: create lock models.
+    for module in module_ctx.modules:
+        for tag in module.tags.import_pdm:
+            lock_model_structs[tag.repo] = json.encode(dict(
+                model_type = "pdm",
+                lock_file = str(tag.lock_file),
+                project_file = str(tag.project_file) if tag.project_file else "",
+                default_group = tag.default_group,
+                optional_groups = tag.optional_groups,
+                all_optional_groups = tag.all_optional_groups,
+                development_groups = tag.development_groups,
+                all_development_groups = tag.all_development_groups,
+            ))
+        for tag in module.tags.import_poetry:
+            lock_model_structs[tag.repo] = json.encode(dict(
+                model_type = "poetry",
+                lock_file = str(tag.lock_file),
+                project_file = str(tag.project_file) if tag.project_file else "",
+                default_group = tag.default_group,
+                optional_groups = tag.optional_groups,
+                all_optional_groups = tag.all_optional_groups,
+            ))
+        for tag in module.tags.import_uv:
+            lock_model_structs[tag.repo] = json.encode(dict(
+                model_type = "uv",
+                lock_file = str(tag.lock_file),
+                project_file = str(tag.project_file) if tag.project_file else "",
+                default_group = tag.default_group,
+                optional_groups = tag.optional_groups,
+                all_optional_groups = tag.all_optional_groups,
+                development_groups = tag.development_groups,
+                all_development_groups = tag.all_development_groups,
+                require_static_urls = tag.require_static_urls,
+            ))
+        for tag in module.tags.import_pylock:
+            lock_model_structs[tag.repo] = json.encode(dict(
+                model_type = "pylock",
+                lock_file = str(tag.lock_file),
+                project_file = str(tag.project_file) if tag.project_file else "",
+                default_group = tag.default_group,
+                optional_groups = tag.optional_groups,
+                all_optional_groups = tag.all_optional_groups,
+                development_groups = tag.development_groups,
+                all_development_groups = tag.all_development_groups,
+            ))
 
-        for module in module_ctx.modules:
-            # 1. Process workspace tags
-            if import_ws_tag_name:
-                for tag in getattr(module.tags, import_ws_tag_name):
-                    workspace_tags.append(struct(tag = tag, module = module, ws_name = tag.name))
-                for tag in getattr(module.tags, name + "_all_members"):
-                    _validate_transition_attrs(tag, name + "_all_members")
-                    all_members_tags.append(struct(tag = tag, module = module))
-
-            for tag in getattr(module.tags, name + "_member"):
-                _validate_transition_attrs(tag, name + "_member")
-                member_tags.append(struct(tag = tag, module = module))
-
-            # 2. Process legacy/standalone import tags (desugar)
-            for tag in getattr(module.tags, import_tag_name):
-                _validate_transition_attrs(tag, import_tag_name)
-
-                # Synthesis workspace
-                workspace_tags.append(struct(tag = tag, module = module, ws_name = tag.repo))
-
-                # Synthesis member
-                member_tag = struct(
-                    workspace = tag.repo,
-                    project = "",
-                    repo = tag.repo,
-                    project_file = getattr(tag, "project_file", None),
-                    default_group = getattr(tag, "default_group", True),
-                    optional_groups = getattr(tag, "optional_groups", []),
-                    all_optional_groups = getattr(tag, "all_optional_groups", False),
-                    development_groups = getattr(tag, "development_groups", []),
-                    all_development_groups = getattr(tag, "all_development_groups", False),
-                    flags = getattr(tag, "flags", []),
-                    constraint_values = getattr(tag, "constraint_values", []),
-                    platform = getattr(tag, "platform", None),
-                )
-                member_tags.append(struct(tag = member_tag, module = module))
-
-        _process_workspaces(
-            module_ctx,
-            lock_owners,
-            lock_repos,
-            lock_model_structs,
-            workspace_tags,
-            member_tags,
-            all_members_tags,
-            discover_fn,
-            name,
-            root_direct_deps,
-        )
-
-    workspace_packages = {}  # workspace_name -> {pkg_name -> normalized_tag}
-    valid_workspaces = {r.workspace: True for r in lock_repos.values()}
-
-    # Add package attributes
+    # Add package attributes.
     for module in module_ctx.modules:
         for tag in module.tags.package:
-            if tag.repo and tag.workspace:
-                fail("package '{}' specifies both repo and workspace".format(tag.name))
-            if not tag.repo and not tag.workspace:
-                fail("package '{}' must specify either repo or workspace".format(tag.name))
+            _check_proper_package_repo(lock_owners, module, tag)
+            repo_info = lock_repos[tag.repo]
+            if tag.name in repo_info.packages:
+                fail("Multiple package entries for package '{}' in repo '{}'".format(tag.name, tag.repo))
+            repo_info.packages[tag.name] = _normalize_package_tag(tag)
 
-            normalized = _normalize_package_tag(tag)
-            if tag.repo:
-                _check_proper_package_repo(lock_owners, module, tag)
-                repo_info = lock_repos[tag.repo]
-                if repo_info.workspace != repo_info.repo_name:
-                    fail(
-                        "package '{}' targets repo '{}' which is a member of workspace '{}'. ".format(tag.name, tag.repo, repo_info.workspace) +
-                        "Use workspace = '{}' instead.".format(repo_info.workspace),
-                    )
-                if tag.name in repo_info.packages:
-                    fail("Multiple package entries for package '{}' in repo '{}'".format(tag.name, tag.repo))
-                repo_info.packages[tag.name] = normalized
-            elif tag.workspace:
-                # We intentionally don't enforce `_check_proper_package_repo` for workspaces.
-                # Workspaces are top-level constructs, and it's acceptable for any module to
-                # inject packages into a shared workspace configuration.
-                if tag.workspace not in valid_workspaces:
-                    fail("Package override specifies workspace '{}' which does not exist".format(tag.workspace))
-                ws_pkgs = workspace_packages.setdefault(tag.workspace, {})
-                if tag.name in ws_pkgs:
-                    fail("Multiple package entries for package '{}' in workspace '{}'".format(tag.name, tag.workspace))
-                ws_pkgs[tag.name] = normalized
-
-    # Generate the resolved lock repos
+    # Generate the resolved lock repos.
     workspace_memberships = {}
     workspace_build_repos = {}
     repo_flags = {}
@@ -639,11 +238,11 @@ def _lock_import_impl(module_ctx):
     repo_platforms = {}
 
     for repo_name, repo_info in lock_repos.items():
-        resolved_lock_repo_file = _generate_resolved_lock_repo(repo_info, lock_model_structs[repo_name], workspace_packages)
+        resolved_lock_repo_file = _generate_resolved_lock_repo(repo_info, lock_model_structs[repo_name])
         resolved_lock_files[repo_info.repo_name] = resolved_lock_repo_file
-        workspace_memberships[repo_info.repo_name] = repo_info.workspace
+        workspace_memberships[repo_info.repo_name] = repo_info.repo_name
         if repo_info.build_repo:
-            workspace_build_repos[repo_info.workspace] = repo_info.build_repo
+            workspace_build_repos[repo_info.repo_name] = repo_info.build_repo
 
         if repo_info.flags:
             repo_flags[repo_info.repo_name] = json.encode(repo_info.flags)
@@ -667,6 +266,13 @@ def _lock_import_impl(module_ctx):
         return module_ctx.extension_metadata(reproducible = True)
     return module_ctx.extension_metadata()
 
+# V1 package tag — repo only, no workspace scoping.
+_PACKAGE_ATTRS_V1 = dict(PACKAGE_ATTRS)
+_PACKAGE_ATTRS_V1["repo"] = attr.string(
+    doc = "The repository name.",
+    mandatory = True,
+)
+
 # Tag classes
 _import_pdm_tag = tag_class(
     doc = "Import a PDM lock file.",
@@ -684,41 +290,9 @@ _import_pylock_tag = tag_class(
     doc = "Import a pylock.toml lock file.",
     attrs = PYLOCK_IMPORT_ATTRS | COMMON_IMPORT_ATTRS | REPO_ATTR,
 )
-_import_pdm_workspace_tag = tag_class(
-    doc = "Import a PDM workspace.",
-    attrs = PDM_WORKSPACE_ATTRS | WORKSPACE_COMMON_ATTRS,
-)
-_pdm_all_members_tag = tag_class(
-    doc = "Auto-discover and import all members from a pdm.lock file.",
-    attrs = PDM_ALL_MEMBERS_ATTRS | WORKSPACE_MEMBER_COMMON_ATTRS,
-)
-_pdm_member_tag = tag_class(
-    doc = "Override settings for a specific PDM member.",
-    attrs = PDM_MEMBER_ATTRS | WORKSPACE_MEMBER_COMMON_ATTRS,
-)
-_import_uv_workspace_tag = tag_class(
-    doc = "Import a uv workspace. Define members with uv_all_members and uv_member tags.",
-    attrs = UV_WORKSPACE_ATTRS | WORKSPACE_COMMON_ATTRS,
-)
-_poetry_member_tag = tag_class(
-    doc = "Override settings for a specific Poetry member.",
-    attrs = POETRY_MEMBER_ATTRS | WORKSPACE_MEMBER_COMMON_ATTRS,
-)
-_pylock_member_tag = tag_class(
-    doc = "Override settings for a specific Pylock member.",
-    attrs = PYLOCK_MEMBER_ATTRS | WORKSPACE_MEMBER_COMMON_ATTRS,
-)
-_uv_all_members_tag = tag_class(
-    doc = "Auto-discover and import all members from a uv.lock file.",
-    attrs = UV_ALL_MEMBERS_ATTRS | WORKSPACE_MEMBER_COMMON_ATTRS,
-)
-_uv_member_tag = tag_class(
-    doc = "Override settings for a specific member.",
-    attrs = UV_MEMBER_ATTRS | WORKSPACE_MEMBER_COMMON_ATTRS,
-)
 _package_tag = tag_class(
     doc = "Specify package-specific settings.",
-    attrs = PACKAGE_ATTRS | OVERRIDE_TARGET_ATTRS,
+    attrs = _PACKAGE_ATTRS_V1,
 )
 
 lock_import = module_extension(
@@ -728,14 +302,6 @@ lock_import = module_extension(
         import_poetry = _import_poetry_tag,
         import_uv = _import_uv_tag,
         import_pylock = _import_pylock_tag,
-        import_pdm_workspace = _import_pdm_workspace_tag,
-        pdm_all_members = _pdm_all_members_tag,
-        pdm_member = _pdm_member_tag,
-        import_uv_workspace = _import_uv_workspace_tag,
-        uv_all_members = _uv_all_members_tag,
-        uv_member = _uv_member_tag,
-        poetry_member = _poetry_member_tag,
-        pylock_member = _pylock_member_tag,
         package = _package_tag,
     ),
 )

--- a/pycross/private/pdm_extension.bzl
+++ b/pycross/private/pdm_extension.bzl
@@ -1,0 +1,46 @@
+"""PDM lock format extension.
+
+Provides the `pdm` module extension for importing PDM lock files.
+"""
+
+load(
+    ":format_extension.bzl",
+    "make_format_extension",
+)
+load(":lock_common.bzl", "discover_pdm_all_members")
+load(":pdm_lock_model.bzl", "repo_create_pdm_model")
+
+# PDM-specific attrs for standalone project imports.
+_PDM_PROJECT_ATTRS = dict(
+    default_group = attr.bool(
+        doc = "Whether to install dependencies from the default group.",
+        default = True,
+    ),
+    optional_groups = attr.string_list(
+        doc = "List of optional dependency groups to install.",
+    ),
+    all_optional_groups = attr.bool(
+        doc = "Install all optional dependencies.",
+    ),
+    development_groups = attr.string_list(
+        doc = "List of development dependency groups to install.",
+    ),
+    all_development_groups = attr.bool(
+        doc = "Install all dev dependencies.",
+    ),
+)
+
+# PDM-specific attrs for workspace tags (none beyond shared).
+_PDM_WORKSPACE_ATTRS = dict()
+
+# PDM-specific attrs for all_projects tags (none beyond shared).
+_PDM_ALL_PROJECTS_ATTRS = dict()
+
+pdm = make_format_extension(
+    model_type = "pdm",
+    standalone_project_attrs = _PDM_PROJECT_ATTRS,
+    workspace_attrs = _PDM_WORKSPACE_ATTRS,
+    all_projects_attrs = _PDM_ALL_PROJECTS_ATTRS,
+    discover_members_fn = discover_pdm_all_members,
+    repo_create_model_fn = repo_create_pdm_model,
+)

--- a/pycross/private/poetry_extension.bzl
+++ b/pycross/private/poetry_extension.bzl
@@ -1,0 +1,36 @@
+"""Poetry lock format extension.
+
+Provides the `poetry` module extension for importing Poetry lock files.
+Poetry does not support workspaces, so only standalone project imports are available.
+"""
+
+load(
+    ":format_extension.bzl",
+    "make_format_extension",
+)
+load(":lock_common.bzl", "discover_poetry_all_members")
+load(":poetry_lock_model.bzl", "repo_create_poetry_model")
+
+# Poetry-specific attrs for standalone project imports.
+_POETRY_PROJECT_ATTRS = dict(
+    default_group = attr.bool(
+        doc = "Whether to install dependencies from the default group.",
+        default = True,
+    ),
+    optional_groups = attr.string_list(
+        doc = "List of optional dependency groups to install.",
+    ),
+    all_optional_groups = attr.bool(
+        doc = "Install all optional dependencies.",
+    ),
+)
+
+poetry = make_format_extension(
+    model_type = "poetry",
+    standalone_project_attrs = _POETRY_PROJECT_ATTRS,
+    # Poetry has no workspace support — single-project only.
+    workspace_attrs = None,
+    all_projects_attrs = None,
+    discover_members_fn = discover_poetry_all_members,
+    repo_create_model_fn = repo_create_poetry_model,
+)

--- a/pycross/private/pylock_extension.bzl
+++ b/pycross/private/pylock_extension.bzl
@@ -1,0 +1,42 @@
+"""Pylock (PEP 751) lock format extension.
+
+Provides the `pylock` module extension for importing pylock.toml lock files.
+Pylock does not support workspaces, so only standalone project imports are available.
+"""
+
+load(
+    ":format_extension.bzl",
+    "make_format_extension",
+)
+load(":lock_common.bzl", "discover_pylock_all_members")
+load(":pylock_lock_model.bzl", "repo_create_pylock_model")
+
+# Pylock-specific attrs for standalone project imports.
+_PYLOCK_PROJECT_ATTRS = dict(
+    default_group = attr.bool(
+        doc = "Whether to install dependencies from the default group.",
+        default = True,
+    ),
+    optional_groups = attr.string_list(
+        doc = "List of optional dependency groups to install.",
+    ),
+    all_optional_groups = attr.bool(
+        doc = "Install all optional dependencies.",
+    ),
+    development_groups = attr.string_list(
+        doc = "List of development dependency groups to install.",
+    ),
+    all_development_groups = attr.bool(
+        doc = "Install all dev dependencies.",
+    ),
+)
+
+pylock = make_format_extension(
+    model_type = "pylock",
+    standalone_project_attrs = _PYLOCK_PROJECT_ATTRS,
+    # Pylock has no workspace support — single-project only.
+    workspace_attrs = None,
+    all_projects_attrs = None,
+    discover_members_fn = discover_pylock_all_members,
+    repo_create_model_fn = repo_create_pylock_model,
+)

--- a/pycross/private/uv_extension.bzl
+++ b/pycross/private/uv_extension.bzl
@@ -1,0 +1,55 @@
+"""UV lock format extension.
+
+Provides the `uv` module extension for importing UV lock files.
+"""
+
+load(
+    ":format_extension.bzl",
+    "make_format_extension",
+)
+load(":lock_common.bzl", "discover_uv_all_members")
+load(":uv_lock_model.bzl", "repo_create_uv_model")
+
+# UV-specific attrs for standalone project imports.
+_UV_PROJECT_ATTRS = dict(
+    default_group = attr.bool(
+        doc = "Whether to install dependencies from the default group.",
+        default = True,
+    ),
+    optional_groups = attr.string_list(
+        doc = "List of optional dependency groups to install.",
+    ),
+    all_optional_groups = attr.bool(
+        doc = "Install all optional dependencies.",
+    ),
+    development_groups = attr.string_list(
+        doc = "List of development dependency groups to install.",
+    ),
+    all_development_groups = attr.bool(
+        doc = "Install all dev dependencies.",
+    ),
+    require_static_urls = attr.bool(
+        doc = "Require that the lock file is created with --static-urls.",
+        default = True,
+    ),
+)
+
+# UV-specific attrs for workspace tags.
+_UV_WORKSPACE_ATTRS = dict(
+    require_static_urls = attr.bool(
+        doc = "Require that the lock file is created with --static-urls.",
+        default = True,
+    ),
+)
+
+# UV-specific attrs for all_projects tags (none beyond shared).
+_UV_ALL_PROJECTS_ATTRS = dict()
+
+uv = make_format_extension(
+    model_type = "uv",
+    standalone_project_attrs = _UV_PROJECT_ATTRS,
+    workspace_attrs = _UV_WORKSPACE_ATTRS,
+    all_projects_attrs = _UV_ALL_PROJECTS_ATTRS,
+    discover_members_fn = discover_uv_all_members,
+    repo_create_model_fn = repo_create_uv_model,
+)

--- a/tests/e2e/always_build/MODULE.bazel
+++ b/tests/e2e/always_build/MODULE.bazel
@@ -38,15 +38,15 @@ environments.create_for_python_toolchains(
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "regex",
     always_build = True,
     repo = "uv",
 )
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/build_cmake/MODULE.bazel
+++ b/tests/e2e/build_cmake/MODULE.bazel
@@ -32,16 +32,16 @@ pycross.configure_toolchains(
     ],
 )
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     default_alias_single_version = True,
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "iminuit",
     always_build = True,
     repo = "uv",
 )
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/build_maturin/MODULE.bazel
+++ b/tests/e2e/build_maturin/MODULE.bazel
@@ -47,24 +47,24 @@ pycross.configure_toolchains(
     ],
 )
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     default_alias_single_version = True,
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "rpds-py",
     always_build = True,
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "jiter",
     always_build = True,
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "python-geohash",
     always_build = True,
     repo = "uv",
@@ -78,4 +78,4 @@ maturin.override(
 )
 use_repo(maturin, "uv_cargo")
 
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/build_meson/MODULE.bazel
+++ b/tests/e2e/build_meson/MODULE.bazel
@@ -38,35 +38,35 @@ pycross.configure_toolchains(
     ],
 )
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     default_alias_single_version = True,
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "numpy",
     always_build = True,
     build_target = "@//deps/numpy:wheel",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "pandas",
     always_build = True,
     build_target = "@//deps/pandas:wheel",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "contourpy",
     always_build = True,
     build_target = "@//deps/contourpy:wheel",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "pywavelets",
     always_build = True,
     build_target = "@//deps/pywavelets:wheel",
     repo = "uv",
 )
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/build_pure_python/MODULE.bazel
+++ b/tests/e2e/build_pure_python/MODULE.bazel
@@ -36,11 +36,11 @@ pycross.configure_toolchains(
     ],
 )
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     default_alias_single_version = True,
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/build_setuptools/MODULE.bazel
+++ b/tests/e2e/build_setuptools/MODULE.bazel
@@ -39,24 +39,24 @@ pycross.configure_toolchains(
     ],
 )
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     default_alias_single_version = True,
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "psycopg2",
     build_target = "@//deps/psycopg2:wheel",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "setproctitle",
     always_build = True,
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "pyyaml",
     always_build = True,
     repo = "uv",
@@ -81,7 +81,7 @@ setuptools.override(
     repo = "uv",
 )
 
-use_repo(lock, "uv")
+use_repo(uv, "uv")
 
 zstd = use_extension("//:zstd.bzl", "zstd")
 use_repo(zstd, "zstd")

--- a/tests/e2e/bzlmod_flags/MODULE.bazel
+++ b/tests/e2e/bzlmod_flags/MODULE.bazel
@@ -29,14 +29,14 @@ pycross.configure_toolchains(
     ],
 )
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     default_alias_single_version = True,
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "setproctitle",
     always_build = True,
     build_dependencies = ["wheel"],  # Test build_dependencies override
@@ -55,4 +55,4 @@ setuptools.override(
     repo = "uv",
 )
 
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/gazelle_integration/MODULE.bazel
+++ b/tests/e2e/gazelle_integration/MODULE.bazel
@@ -41,10 +41,10 @@ python.toolchain(
     python_version = "3.10.11",
 )
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/generate_lock/MODULE.bazel
+++ b/tests/e2e/generate_lock/MODULE.bazel
@@ -37,12 +37,12 @@ environments.create_for_python_toolchains(
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     development_groups = ["dev"],
     lock_file = "//:uv.lock",
     optional_groups = ["yaml"],
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/local_wheel/MODULE.bazel
+++ b/tests/e2e/local_wheel/MODULE.bazel
@@ -37,8 +37,8 @@ environments.create_for_python_toolchains(
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     local_wheels = [
         "@rules_pycross_e2e_shared//:cowsay-6.1-py3-none-any.whl",
     ],
@@ -46,4 +46,4 @@ lock.import_uv(
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/namespace_pkgs/MODULE.bazel
+++ b/tests/e2e/namespace_pkgs/MODULE.bazel
@@ -37,10 +37,10 @@ environments.create_for_python_toolchains(
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/patches_and_hooks/MODULE.bazel
+++ b/tests/e2e/patches_and_hooks/MODULE.bazel
@@ -30,14 +30,14 @@ pycross.configure_toolchains(
     ],
 )
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     default_alias_single_version = True,
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-lock.package(
+uv.package(
     name = "setproctitle",
     always_build = True,
     post_install_patches = ["@@//patches:setproctitle-postinstall.patch"],
@@ -52,4 +52,4 @@ setuptools.override(
     repo = "uv",
 )
 
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/pdm_workspace/MODULE.bazel
+++ b/tests/e2e/pdm_workspace/MODULE.bazel
@@ -36,27 +36,27 @@ environments.platform(
 )
 use_repo(environments, "pdm_workspace_envs")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_pdm_workspace(
+pdm = use_extension("@rules_pycross//pycross/extensions:pdm.bzl", "pdm")
+pdm.workspace(
     name = "shared",
     lock_file = "//:pdm.lock",
 )
-lock.pdm_all_members(
+pdm.all_projects(
     repo_pattern = "lock_{member}",
     workspace = "shared",
 )
 
 # Override project-a's repo name; project-b uses the pattern default (lock_project_b).
-lock.pdm_member(
-    project = "project-a",
+pdm.project(
+    name = "project-a",
     repo = "lock_a",
     workspace = "shared",
 )
 
 # Annotation conflict: exclude a test file from regex across the whole workspace.
-lock.package(
+pdm.package(
     name = "regex",
     install_exclude_globs = ["test_regex.py"],
     workspace = "shared",
 )
-use_repo(lock, "lock_a", "lock_project_b")
+use_repo(pdm, "lock_a", "lock_project_b")

--- a/tests/e2e/requirements/MODULE.bazel
+++ b/tests/e2e/requirements/MODULE.bazel
@@ -37,10 +37,10 @@ environments.create_for_python_toolchains(
 )
 use_repo(environments, "rules_pycross_e2e_environments")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "uv",
 )
-use_repo(lock, "uv")
+use_repo(uv, "uv")

--- a/tests/e2e/uv_conflicts/MODULE.bazel
+++ b/tests/e2e/uv_conflicts/MODULE.bazel
@@ -37,12 +37,13 @@ environments.platform(
 )
 use_repo(environments, "envs")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv_workspace(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.workspace(
     name = "shared",
     lock_file = "//:uv.lock",
 )
-lock.uv_member(
+uv.project(
+    name = "project",
     development_groups = [
         "group-a",
         "group-b",
@@ -51,11 +52,11 @@ lock.uv_member(
         "variant-a",
         "variant-b",
     ],
-    project = "project",
     repo = "project",
     workspace = "shared",
 )
-lock.uv_member(
+uv.project(
+    name = "project",
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
@@ -71,8 +72,7 @@ lock.uv_member(
         "variant-a",
         "variant-b",
     ],
-    project = "project",
     repo = "project_pinned",
     workspace = "shared",
 )
-use_repo(lock, "project", "project_pinned")
+use_repo(uv, "project", "project_pinned")

--- a/tests/e2e/uv_cycle/MODULE.bazel
+++ b/tests/e2e/uv_cycle/MODULE.bazel
@@ -31,8 +31,8 @@ environments.create_for_python_toolchains(
 )
 use_repo(environments, "uv_cycle_envs")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     local_wheels = [
         "//:cycle_a-1.0.0-py3-none-any.whl",
         "//:cycle_b-1.0.0-py3-none-any.whl",
@@ -41,4 +41,4 @@ lock.import_uv(
     project_file = "//:pyproject.toml",
     repo = "cycle_lock",
 )
-use_repo(lock, "cycle_lock")
+use_repo(uv, "cycle_lock")

--- a/tests/e2e/uv_cycle_stress/MODULE.bazel
+++ b/tests/e2e/uv_cycle_stress/MODULE.bazel
@@ -31,8 +31,8 @@ environments.create_for_python_toolchains(
 )
 use_repo(environments, "uv_cycle_stress_envs")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     local_wheels = [
         "//:stress_airflow-1.0.0-py3-none-any.whl",
         "//:stress_airflow_core-1.0.0-py3-none-any.whl",
@@ -50,4 +50,4 @@ lock.import_uv(
     project_file = "//:pyproject.toml",
     repo = "cycle_stress_lock",
 )
-use_repo(lock, "cycle_stress_lock")
+use_repo(uv, "cycle_stress_lock")

--- a/tests/e2e/uv_cycle_stress_mixed/MODULE.bazel
+++ b/tests/e2e/uv_cycle_stress_mixed/MODULE.bazel
@@ -31,8 +31,8 @@ environments.create_for_python_toolchains(
 )
 use_repo(environments, "uv_cycle_stress_mixed_envs")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     local_wheels = [
         "//:stress_airflow-1.0.0-py3-none-any.whl",
         "//:stress_airflow_core-1.0.0-py3-none-any.whl",
@@ -50,4 +50,4 @@ lock.import_uv(
     project_file = "//:pyproject.toml",
     repo = "cycle_stress_lock",
 )
-use_repo(lock, "cycle_stress_lock")
+use_repo(uv, "cycle_stress_lock")

--- a/tests/e2e/uv_markers/MODULE.bazel
+++ b/tests/e2e/uv_markers/MODULE.bazel
@@ -30,10 +30,10 @@ environments.create_for_python_toolchains(
 )
 use_repo(environments, "markers_envs")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.project(
     lock_file = "//:uv.lock",
     project_file = "//:pyproject.toml",
     repo = "markers_lock",
 )
-use_repo(lock, "markers_lock")
+use_repo(uv, "markers_lock")

--- a/tests/e2e/uv_workspace/MODULE.bazel
+++ b/tests/e2e/uv_workspace/MODULE.bazel
@@ -36,44 +36,44 @@ environments.platform(
 )
 use_repo(environments, "uv_workspace_envs")
 
-lock = use_extension("@rules_pycross//pycross/extensions:lock.bzl", "lock")
-lock.import_uv_workspace(
+uv = use_extension("@rules_pycross//pycross/extensions:uv.bzl", "uv")
+uv.workspace(
     name = "shared",
     lock_file = "//:uv.lock",
 )
-lock.uv_all_members(
+uv.all_projects(
     repo_pattern = "lock_{member}",
     workspace = "shared",
 )
 
 # Override project-a's repo name; project-b uses the pattern default (lock_project_b).
-lock.uv_member(
-    project = "project-a",
+uv.project(
+    name = "project-a",
     repo = "lock_a",
     workspace = "shared",
 )
 
 # Annotation conflict: exclude a test file from regex across the whole workspace.
-lock.package(
+uv.package(
     name = "regex",
     install_exclude_globs = ["test_regex.py"],
     workspace = "shared",
 )
-use_repo(lock, "lock_a", "lock_project_b")
+use_repo(uv, "lock_a", "lock_project_b")
 
 # Test standalone members (no uv_all_members)
-lock.import_uv_workspace(
+uv.workspace(
     name = "standalone",
     lock_file = "//:uv.lock",
 )
-lock.uv_member(
-    project = "project-a",
+uv.project(
+    name = "project-a",
     repo = "lock_standalone_a",
     workspace = "standalone",
 )
-lock.uv_member(
-    project = "project-b",
+uv.project(
+    name = "project-b",
     repo = "lock_standalone_b",
     workspace = "standalone",
 )
-use_repo(lock, "lock_standalone_a", "lock_standalone_b")
+use_repo(uv, "lock_standalone_a", "lock_standalone_b")


### PR DESCRIPTION
Split the unified lock extension into per-format module extensions.
Each format gets its own extension entry point (e.g. uv.bzl, pdm.bzl)
with format-specific tag classes (project, workspace, all_projects,
package).

A shared factory (format_extension.bzl) eliminates boilerplate via
make_format_extension(), similar to make_override_extension() for
backends.

Also simplifies lock_import.bzl to V1 API surface only:
- Keeps: import_uv, import_pdm, import_poetry, import_pylock, package
- Removes: all workspace/member/all_members tags (now exclusive to
  per-format extensions)

Fixes pre-existing bug in resolved_lock_repo bzl_library missing
pylock_lock_model and uv_lock_model deps.
