### PR TITLE
fix: pull pypi indexes from proper location, allowing overrides

### DIFF
--- a/pycross/private/lock_repo_creation.bzl
+++ b/pycross/private/lock_repo_creation.bzl
@@ -148,7 +148,8 @@ def create_repos(
                 )
                 if pypi_index:
                     pypi_file_attrs["index"] = pypi_index
-
+                elif file.get("index"):
+                    pypi_file_attrs["index"] = file["index"]
                 if file["name"].endswith(".whl"):
                     pycross_wheel_file(**pypi_file_attrs)
                 else:

--- a/pycross/private/lock_repos.bzl
+++ b/pycross/private/lock_repos.bzl
@@ -121,7 +121,8 @@ def _lock_repos_impl(module_ctx):
                 )
                 if create_tag.pypi_index:
                     pypi_file_attrs["index"] = create_tag.pypi_index
-
+                elif file.get("index"):
+                    pypi_file_attrs["index"] = file["index"]
                 if file["name"].endswith(".whl"):
                     pycross_wheel_file(**pypi_file_attrs)
                 else:

--- a/pycross/private/lock_resolver.bzl
+++ b/pycross/private/lock_resolver.bzl
@@ -6,7 +6,7 @@ load(":util.bzl", "parse_package_key")
 def _file_key(f):
     if not f.get("sha256"):
         fail("PackageFile missing sha256: " + str(f))
-    key = "{}/{}".format(f["name"], f["sha256"])
+    key = "{}/{}".format(f["name"], f["sha256"][:8])
     extra = ""
     if f.get("urls"):
         extra += ",".join(f["urls"])

--- a/pycross/private/lock_resolver.bzl
+++ b/pycross/private/lock_resolver.bzl
@@ -6,7 +6,16 @@ load(":util.bzl", "parse_package_key")
 def _file_key(f):
     if not f.get("sha256"):
         fail("PackageFile missing sha256: " + str(f))
-    return "{}/{}".format(f["name"], f["sha256"])
+    key = "{}/{}".format(f["name"], f["sha256"])
+    extra = ""
+    if f.get("urls"):
+        extra += ",".join(f["urls"])
+    if f.get("index"):
+        extra += "|" + f["index"]
+    if extra:
+        h = hash(extra)
+        key += "/%x" % (h & 0xffffffff)
+    return key
 
 def _resolve_single_version(name, versions_by_name, all_versions, attr_name):
     if "@" in name:

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -297,7 +297,7 @@ def translate_poetry(project_dict, lock_dict, lock_model):
     )
 
     # Parse file info helper
-    def parse_file_info(file_info, registry=None):
+    def parse_file_info(file_info, registry = None):
         filename = file_info["file"]
         file_hash = file_info["hash"]
         if not file_hash.startswith("sha256:"):

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -297,12 +297,15 @@ def translate_poetry(project_dict, lock_dict, lock_model):
     )
 
     # Parse file info helper
-    def parse_file_info(file_info):
+    def parse_file_info(file_info, registry=None):
         filename = file_info["file"]
         file_hash = file_info["hash"]
         if not file_hash.startswith("sha256:"):
             fail("Expected sha256: prefix on hash: {}".format(file_hash))
-        return {"name": filename, "sha256": file_hash[7:]}
+        res = {"name": filename, "sha256": file_hash[7:]}
+        if registry:
+            res["index"] = registry
+        return res
 
     # In Poetry 2.0, files are per-package (not in [metadata.files])
     # But we still support [metadata.files] as fallback for edge cases
@@ -343,13 +346,22 @@ def translate_poetry(project_dict, lock_dict, lock_model):
                 })
 
         # Source type check for local packages
-        source_type = lock_pkg.get("source", {}).get("type", "")
+        source = lock_pkg.get("source", {})
+        source_type = source.get("type", "")
         is_local = source_type in ("directory", "git", "url")
+        registry = source.get("url") if source_type == "legacy" else None
 
         # Parse files (inline in Poetry 2.0)
-        files = [parse_file_info(f) for f in lock_pkg.get("files", [])]
+        files = [parse_file_info(f, registry) for f in lock_pkg.get("files", [])]
         if not files:
             files = lock_files_by_name.get(package_listed_name, [])
+            if registry:
+                new_files = []
+                for f in files:
+                    nf = dict(f)
+                    nf["index"] = registry
+                    new_files.append(nf)
+                files = new_files
 
         # Add package name and version to files
         updated_files = []

--- a/pycross/private/util.bzl
+++ b/pycross/private/util.bzl
@@ -39,7 +39,14 @@ def trace_ctx(ctx, display_name = "ctx"):
     return struct(**{field_name: wrap(field_name) for field_name in dir(ctx)})
 
 def sanitize_name(val):
-    """Sanitize a string into a valid Bazel repository and target name identifier."""
+    """Sanitize a string into a valid Bazel repository and target name identifier.
+
+    Args:
+        val: The string to sanitize.
+
+    Returns:
+        The sanitized string.
+    """
     res = val.lower()
     for c in "-.+@!:/?=&%,~".elems():
         res = res.replace(c, "_")

--- a/pycross/private/util.bzl
+++ b/pycross/private/util.bzl
@@ -40,7 +40,10 @@ def trace_ctx(ctx, display_name = "ctx"):
 
 def sanitize_name(val):
     """Sanitize a string into a valid Bazel repository and target name identifier."""
-    return val.lower().replace("-", "_").replace(".", "_").replace("+", "_").replace("@", "_").replace("!", "_")
+    res = val.lower()
+    for c in "-.+@!:/?=&%,~".elems():
+        res = res.replace(c, "_")
+    return res
 
 def underscore_name(name):
     """rules_python-style normalization: lowercase, replace [-. ] with _."""

--- a/pycross/private/uv_lock_model.bzl
+++ b/pycross/private/uv_lock_model.bzl
@@ -15,16 +15,17 @@ load(
     "resolve_lock_graph",
 )
 
-def _parse_file_info(file_info, package_name, package_version):
+def _parse_file_info(file_info, package_name, package_version, registry = None):
     """Parse a UV lock file entry into a file dict.
 
     Args:
         file_info: A dict with "file", "filename", or "url" and "hash" keys.
         package_name: The name of the package.
         package_version: The version of the package.
+        registry: An optional string representing the index URL.
 
     Returns:
-        A dict with name, sha256, package_name, package_version, and optionally urls.
+        A dict with name, sha256, package_name, package_version, and optionally urls/index.
     """
     if "file" in file_info:
         filename = file_info["file"]
@@ -58,6 +59,8 @@ def _parse_file_info(file_info, package_name, package_version):
     }
     if urls:
         result["urls"] = urls
+    if registry:
+        result["index"] = registry
     return result
 
 def _sha256_from_string(s):
@@ -321,15 +324,17 @@ def translate_uv(project_dict, lock_dict, lock_model):
 
         # Parse files: wheels + sdist
         files = []
+        source = lock_pkg.get("source", {})
+        registry = source.get("registry")
+
         for w in lock_pkg.get("wheels", []):
-            files.append(_parse_file_info(w, package_name, package_version))
+            files.append(_parse_file_info(w, package_name, package_version, registry))
 
         sdist = lock_pkg.get("sdist", {})
-        source = lock_pkg.get("source", {})
 
         if sdist:
             if "url" in sdist or "file" in sdist:
-                files.append(_parse_file_info(sdist, package_name, package_version))
+                files.append(_parse_file_info(sdist, package_name, package_version, registry))
             elif "url" in source:
                 # URL-based source with subdirectory
                 url = source["url"]
@@ -337,17 +342,20 @@ def translate_uv(project_dict, lock_dict, lock_model):
                 if not file_hash.startswith("sha256:"):
                     fail("Expected sha256: prefix on hash")
                 filename = "{}-{}.tar.gz".format(package_name, package_version)
-                files.append({
+                f = {
                     "name": filename,
                     "sha256": file_hash[7:],
                     "urls": [url],
                     "package_name": package_name,
                     "package_version": package_version,
-                })
+                }
+                if registry:
+                    f["index"] = registry
+                files.append(f)
             elif "git" in source:
                 pass  # handled below
             else:
-                files.append(_parse_file_info(sdist, package_name, package_version))
+                files.append(_parse_file_info(sdist, package_name, package_version, registry))
 
         # Handle git sources
         if "git" in source and not files:

--- a/tests/unit/test_lock_resolver.bzl
+++ b/tests/unit/test_lock_resolver.bzl
@@ -1381,7 +1381,7 @@ def _test_remote_wheel_override_impl(env, target):
     pkg = res.packages["foo@1.0"]
 
     env.expect.that_collection(pkg["wheel_candidates"]).has_size(1)
-    expected_key = "foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl/remote_sha"
+    expected_key = "foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl/remote_sha/edfe9b3e"
     env.expect.that_str(pkg["wheel_candidates"][0]["file_reference"]["key"]).equals(expected_key)
 
 def _test_remote_wheel_override(name):

--- a/tests/unit/test_lock_resolver.bzl
+++ b/tests/unit/test_lock_resolver.bzl
@@ -1381,7 +1381,7 @@ def _test_remote_wheel_override_impl(env, target):
     pkg = res.packages["foo@1.0"]
 
     env.expect.that_collection(pkg["wheel_candidates"]).has_size(1)
-    expected_key = "foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl/remote_sha/edfe9b3e"
+    expected_key = "foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl/remote_s/edfe9b3e"
     env.expect.that_str(pkg["wheel_candidates"][0]["file_reference"]["key"]).equals(expected_key)
 
 def _test_remote_wheel_override(name):

--- a/tests/unit/uv/lock_0_2_35/expected.json
+++ b/tests/unit/uv/lock_0_2_35/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -571,6 +634,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -580,6 +644,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -589,6 +654,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -598,6 +664,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -607,6 +674,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -616,6 +684,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -625,6 +694,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -634,6 +704,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -643,6 +714,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -652,6 +724,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -661,6 +734,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -670,6 +744,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -679,6 +754,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -688,6 +764,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -697,6 +774,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_0_4_0_virtual/expected.json
+++ b/tests/unit/uv/lock_0_4_0_virtual/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -571,6 +634,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -580,6 +644,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -589,6 +654,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -598,6 +664,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -607,6 +674,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -616,6 +684,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -625,6 +694,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -634,6 +704,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -643,6 +714,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -652,6 +724,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -661,6 +734,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -670,6 +744,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -679,6 +754,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -688,6 +764,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -697,6 +774,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_0_4_27_legacy_dev_dependencies/expected.json
+++ b/tests/unit/uv/lock_0_4_27_legacy_dev_dependencies/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_0_4_27_pep735/expected.json
+++ b/tests/unit/uv/lock_0_4_27_pep735/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_pre_0_2_35/expected.json
+++ b/tests/unit/uv/lock_pre_0_2_35/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -571,6 +634,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -580,6 +644,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -589,6 +654,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -598,6 +664,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -607,6 +674,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -616,6 +684,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -625,6 +694,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -634,6 +704,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -643,6 +714,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -652,6 +724,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -661,6 +734,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -670,6 +744,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -679,6 +754,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -688,6 +764,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -697,6 +774,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_workspace/expected.json
+++ b/tests/unit/uv/lock_workspace/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",


### PR DESCRIPTION
- **Include URL and Index when deduplicating repos**
- **Extract package registry indexes from lock files**
- **Fix buildifier lint for sanitize_name**
- **Truncate sha256 to 8 chars in file keys**
