### PR TITLE
refactor: place cargo lock targets in thin + pkg repos

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -34,6 +34,7 @@ stardoc(
         "@rules_cc//cc:find_cc_toolchain_bzl",
         "@rules_pycross//pycross:backend",
         "@rules_pycross//pycross/extensions:lock_repos",
+        "@rules_pycross_backend_maturin//private:cargo_lock_package_repo_hook",
         "@rules_pycross_backend_maturin//private:maturin_sdist_hook",
         "@rules_pycross_backend_maturin//private:setuptools_rust_sdist_hook",
     ],

--- a/modules/backend_maturin/MODULE.bazel
+++ b/modules/backend_maturin/MODULE.bazel
@@ -29,6 +29,8 @@ backends = use_extension("@rules_pycross//pycross/extensions:backends.bzl", "bac
 backends.register(
     name = "maturin_build",
     override_json = "@maturin_overrides//:overrides.json",
+    package_repo_hook_bzl = "@rules_pycross_backend_maturin//private:cargo_lock_package_repo_hook.bzl",
+    package_repo_hook_fn = "cargo_lock_package_repo_hook",
     pyproject_backends = ["maturin"],
     rule_bzl = "@rules_pycross_backend_maturin//rules:maturin_build.bzl",
     sdist_hook_bzl = "@rules_pycross_backend_maturin//private:maturin_sdist_hook.bzl",
@@ -38,6 +40,8 @@ backends.register(
 backends.register(
     name = "setuptools_rust_build",
     override_json = "@setuptools_rust_overrides//:overrides.json",
+    package_repo_hook_bzl = "@rules_pycross_backend_maturin//private:cargo_lock_package_repo_hook.bzl",
+    package_repo_hook_fn = "cargo_lock_package_repo_hook",
     pyproject_backends = [
         "setuptools.build_meta[setuptools-rust]",
         "setuptools.build_meta:__legacy__[setuptools-rust]",

--- a/modules/backend_maturin/extensions/maturin.bzl
+++ b/modules/backend_maturin/extensions/maturin.bzl
@@ -18,7 +18,6 @@ load(
     "create_overrides_repo",
     "encode_build_system_attrs",
 )
-load("//private:cargo_lock_repo.bzl", "cargo_lock_repo")
 
 _CORE_OVERRIDE_ATTRS = dict(
     name = attr.string(
@@ -37,7 +36,6 @@ _MATURIN_OVERRIDE_ATTRS = _CORE_OVERRIDE_ATTRS | BUILD_SYSTEM_ATTRS | CC_BUILD_S
 
 def _maturin_overrides_impl(module_ctx):
     maturin_overrides = {}
-    cargo_targets = {}  # key -> {pkg_name -> {cargo_lock, sdist}}
 
     for module in module_ctx.modules:
         # Process maturin overrides
@@ -50,6 +48,8 @@ def _maturin_overrides_impl(module_ctx):
             backend_attrs = encode_build_system_attrs(tag)
             if tag.cargo_lock:
                 backend_attrs["cargo_lock"] = json.encode(str(tag.cargo_lock))
+            if tag.sdist:
+                backend_attrs["sdist"] = json.encode(str(tag.sdist))
 
             key = "repo:" + tag.repo if tag.repo else "workspace:" + tag.workspace
             maturin_overrides.setdefault(key, {})[tag.name] = {
@@ -57,32 +57,11 @@ def _maturin_overrides_impl(module_ctx):
                 "backend_attrs": backend_attrs,
             }
 
-            # Track for cargo repo generation
-            cargo_targets.setdefault(key, {})[tag.name] = {
-                "cargo_lock": str(tag.cargo_lock) if tag.cargo_lock else None,
-                "sdist": str(tag.sdist) if tag.sdist else None,
-            }
-
     # Write overrides JSON
     create_overrides_repo(
         name = "maturin_overrides",
         content = json.encode(maturin_overrides),
     )
-
-    # Generate <repo>_cargo repos with pycross_generate_cargo_lock targets
-    for key, pkgs in cargo_targets.items():
-        # Strip the "repo:" or "workspace:" prefix for the repo name.
-        if key.startswith("repo:"):
-            bare_name = key[len("repo:"):]
-        elif key.startswith("workspace:"):
-            bare_name = key[len("workspace:"):]
-        else:
-            bare_name = key
-        cargo_lock_repo(
-            name = bare_name + "_cargo",
-            repo_name = bare_name,
-            packages = json.encode(pkgs),
-        )
 
     if bazel_features.external_deps.extension_metadata_has_reproducible:
         return module_ctx.extension_metadata(reproducible = True)

--- a/modules/backend_maturin/extensions/setuptools_rust.bzl
+++ b/modules/backend_maturin/extensions/setuptools_rust.bzl
@@ -8,7 +8,6 @@ load(
     "create_overrides_repo",
     "encode_build_system_attrs",
 )
-load("//private:cargo_lock_repo.bzl", "cargo_lock_repo")
 
 _CORE_OVERRIDE_ATTRS = dict(
     name = attr.string(
@@ -27,7 +26,6 @@ _SETUPTOOLS_RUST_OVERRIDE_ATTRS = _CORE_OVERRIDE_ATTRS | BUILD_SYSTEM_ATTRS | CC
 
 def _setuptools_rust_overrides_impl(module_ctx):
     overrides = {}
-    cargo_targets = {}
 
     for module in module_ctx.modules:
         for tag in module.tags.override:
@@ -39,6 +37,8 @@ def _setuptools_rust_overrides_impl(module_ctx):
             backend_attrs = encode_build_system_attrs(tag)
             if tag.cargo_lock:
                 backend_attrs["cargo_lock"] = json.encode(str(tag.cargo_lock))
+            if tag.sdist:
+                backend_attrs["sdist"] = json.encode(str(tag.sdist))
 
             key = "repo:" + tag.repo if tag.repo else "workspace:" + tag.workspace
             overrides.setdefault(key, {})[tag.name] = {
@@ -46,28 +46,10 @@ def _setuptools_rust_overrides_impl(module_ctx):
                 "backend_attrs": backend_attrs,
             }
 
-            cargo_targets.setdefault(key, {})[tag.name] = {
-                "cargo_lock": str(tag.cargo_lock) if tag.cargo_lock else None,
-                "sdist": str(tag.sdist) if tag.sdist else None,
-            }
-
     create_overrides_repo(
         name = "setuptools_rust_overrides",
         content = json.encode(overrides),
     )
-
-    for key, pkgs in cargo_targets.items():
-        if key.startswith("repo:"):
-            bare_name = key[len("repo:"):]
-        elif key.startswith("workspace:"):
-            bare_name = key[len("workspace:"):]
-        else:
-            bare_name = key
-        cargo_lock_repo(
-            name = bare_name + "_cargo_setuptools_rust",
-            repo_name = bare_name,
-            packages = json.encode(pkgs),
-        )
 
     if bazel_features.external_deps.extension_metadata_has_reproducible:
         return module_ctx.extension_metadata(reproducible = True)

--- a/modules/backend_maturin/private/BUILD.bazel
+++ b/modules/backend_maturin/private/BUILD.bazel
@@ -29,6 +29,11 @@ bzl_library(
 )
 
 bzl_library(
+    name = "cargo_lock_package_repo_hook",
+    srcs = ["cargo_lock_package_repo_hook.bzl"],
+)
+
+bzl_library(
     name = "cargo_lock_repo",
     srcs = ["cargo_lock_repo.bzl"],
 )

--- a/modules/backend_maturin/private/cargo_lock_package_repo_hook.bzl
+++ b/modules/backend_maturin/private/cargo_lock_package_repo_hook.bzl
@@ -1,0 +1,63 @@
+"""Package repo hook for cargo lock generating backends (e.g. maturin, setuptools-rust).
+
+Generates a _cargo/ sub-directory in the package repo with
+pycross_generate_cargo_lock targets for each overridden package.
+Targets are versioned (e.g., _cargo:jiter@0.5.0) to handle multiple
+versions of the same package.
+"""
+
+# Resolve at load time so str() gives the canonical label form.
+_GENERATE_CARGO_LOCK_BZL = str(Label("@rules_pycross_backend_maturin//rules:generate_cargo_lock.bzl"))
+
+def cargo_lock_package_repo_hook(packages_info, override_packages):
+    """Generate _cargo/ directory with cargo lock generation targets.
+
+    Args:
+        packages_info: dict of normalized_name -> {"versions": [struct(version, package_key, has_sdist)]}.
+            All packages in the package repo.
+        override_packages: dict of pkg_name -> dict of backend_attrs.
+            Only packages that have overrides.
+
+    Returns:
+        A list of structs with dir and files fields.
+    """
+
+    if not override_packages:
+        return []
+
+    lines = [
+        'load("{}", "pycross_generate_cargo_lock")'.format(_GENERATE_CARGO_LOCK_BZL),
+        'package(default_visibility = ["//visibility:public"])',
+        "",
+    ]
+
+    for pkg_name in sorted(override_packages.keys()):
+        attrs = override_packages[pkg_name]
+        pkg_info = packages_info.get(pkg_name)
+        if not pkg_info:
+            continue
+
+        for version_info in pkg_info["versions"]:
+            if not version_info.has_sdist:
+                continue
+
+            versioned_name = "{}@{}".format(pkg_name, version_info.version)
+
+            lines.append("pycross_generate_cargo_lock(")
+            lines.append('    name = "%s",' % versioned_name)
+            lines.append('    sdist = "//_sdist:%s",' % versioned_name)
+
+            cargo_lock_json = attrs.get("cargo_lock")
+            if cargo_lock_json:
+                cargo_lock_label = json.decode(cargo_lock_json)
+                lbl = Label(cargo_lock_label)
+                output_path = lbl.package + "/" + lbl.name if lbl.package else lbl.name
+                lines.append('    output = "%s",' % output_path)
+
+            lines.append(")")
+            lines.append("")
+
+    return [struct(
+        dir = "_cargo",
+        files = {"BUILD.bazel": "\n".join(lines)},
+    )]

--- a/modules/backend_maturin/private/tools/generate_cargo_lock.py
+++ b/modules/backend_maturin/private/tools/generate_cargo_lock.py
@@ -114,10 +114,27 @@ def main():
             print(f"Error: cargo binary '{args.cargo}' not found.", file=sys.stderr)
             sys.exit(1)
 
-        generated_lock = cargo_toml_dir / "Cargo.lock"
+        try:
+            locate_output = subprocess.check_output(
+                [args.cargo, "locate-project", "--workspace", "--message-format", "plain"],
+                cwd=cargo_toml_dir,
+                text=True,
+            ).strip()
+            workspace_toml = Path(locate_output)
+            generated_lock = workspace_toml.parent / "Cargo.lock"
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: 'cargo locate-project' failed: {e}. Falling back to cargo_toml_dir.", file=sys.stderr)
+            generated_lock = cargo_toml_dir / "Cargo.lock"
+
         if not generated_lock.exists():
-            print("Error: Cargo.lock was not generated.", file=sys.stderr)
-            sys.exit(1)
+            print(f"Warning: Cargo.lock not found at {generated_lock}. Searching...", file=sys.stderr)
+            locks = list(sdist_root.glob("**/Cargo.lock"))
+            if not locks:
+                print("Error: Cargo.lock was not generated.", file=sys.stderr)
+                sys.exit(1)
+            generated_lock = locks[0]
+            if len(locks) > 1:
+                print(f"Warning: Found multiple Cargo.lock files, using {generated_lock}", file=sys.stderr)
 
         print(f"Writing Cargo.lock to {output_path}...")
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/modules/backend_maturin/tests/unit/generate_cargo_lock_test.py
+++ b/modules/backend_maturin/tests/unit/generate_cargo_lock_test.py
@@ -36,7 +36,16 @@ class GenerateCargoLockTest(unittest.TestCase):
     @patch("subprocess.run")
     def test_main(self, mock_run):
         # We simulate cargo generate-lockfile creating the lockfile.
-        def side_effect(args, cwd, check):
+        def side_effect(*args, **kwargs):
+            cwd = kwargs.get("cwd")
+
+            # check_output calls run and passes stdout.
+            # If it's a locate-project call, mock the output.
+            if len(args) > 0 and "locate-project" in args[0]:
+                mock = MagicMock()
+                mock.stdout = str(cwd / "Cargo.toml")
+                return mock
+
             (cwd / "Cargo.lock").write_text("lockfile contents")
             return MagicMock()
 
@@ -71,7 +80,14 @@ class GenerateCargoLockTest(unittest.TestCase):
     @patch("subprocess.run")
     def test_main_pyproject_manifest_path(self, mock_run):
         # We simulate cargo generate-lockfile creating the lockfile.
-        def side_effect(args, cwd, check):
+        def side_effect(*args, **kwargs):
+            cwd = kwargs.get("cwd")
+
+            if len(args) > 0 and "locate-project" in args[0]:
+                mock = MagicMock()
+                mock.stdout = str(cwd / "Cargo.toml")
+                return mock
+
             (cwd / "Cargo.lock").write_text("lockfile contents")
             return MagicMock()
 

--- a/pycross/private/BUILD.bazel
+++ b/pycross/private/BUILD.bazel
@@ -107,6 +107,7 @@ bzl_library(
         ":resolved_lock_renderer",
         ":util",
         ":variant_resolver",
+        "@pycross_backends//:package_repo_dispatch",
         "@pypackaging.bzl//:pypackaging",
     ],
 )
@@ -232,7 +233,9 @@ bzl_library(
 bzl_library(
     name = "thin_package_repo",
     srcs = ["thin_package_repo.bzl"],
-    deps = [":util"],
+    deps = [
+        ":util",
+    ],
 )
 
 bzl_library(

--- a/pycross/private/backend_registry_repo.bzl
+++ b/pycross/private/backend_registry_repo.bzl
@@ -4,6 +4,7 @@ This is created by the backends module extension from `backends.register` tags.
 It produces:
   - `registry.bzl`: exports BACKEND_TO_RULE, DEFAULT_BACKEND, BACKEND_CONFIGS
   - `sdist_dispatch.bzl`: exports SDIST_HOOKS mapping backend names to sdist hook functions
+  - `package_repo_dispatch.bzl`: exports PACKAGE_REPO_HOOKS mapping backend names to package repo hook functions
 """
 
 def _backend_registry_repo_impl(rctx):
@@ -77,10 +78,41 @@ def _backend_registry_repo_impl(rctx):
     ])
 
     rctx.file("sdist_dispatch.bzl", "\n".join(dispatch_lines))
+
+    # Emit package_repo_dispatch.bzl with per-backend package repo hook mappings.
+    package_dispatch_lines = [
+        '"""Generated package repo hook dispatch table. Do not edit."""',
+        "",
+    ]
+
+    package_load_aliases = {}  # rule_name -> alias symbol
+    for rule_name in sorted(rctx.attr.package_repo_hook_bzl.keys()):
+        bzl_file = rctx.attr.package_repo_hook_bzl[rule_name]
+        fn_name = rctx.attr.package_repo_hook_fn.get(rule_name, rule_name.replace("_build", "_package_repo_hook"))
+        alias = "_package_repo_hook_{}".format(rule_name)
+        package_dispatch_lines.append('load("{}", {} = "{}")'.format(bzl_file, alias, fn_name))
+        package_load_aliases[rule_name] = alias
+
+    package_dispatch_lines.extend([
+        "",
+        "# Maps backend rule names to their package repo hook functions.",
+        "PACKAGE_REPO_HOOKS = {",
+    ])
+
+    for rule_name in sorted(rctx.attr.backend_configs.keys()):
+        if rule_name in package_load_aliases:
+            package_dispatch_lines.append('    "{}": {},'.format(rule_name, package_load_aliases[rule_name]))
+
+    package_dispatch_lines.extend([
+        "}",
+        "",
+    ])
+
+    rctx.file("package_repo_dispatch.bzl", "\n".join(package_dispatch_lines))
     rctx.file("BUILD.bazel", """\
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-exports_files(["registry.bzl", "sdist_dispatch.bzl"])
+exports_files(["registry.bzl", "sdist_dispatch.bzl", "package_repo_dispatch.bzl"])
 
 bzl_library(
     name = "registry",
@@ -91,6 +123,12 @@ bzl_library(
 bzl_library(
     name = "sdist_dispatch",
     srcs = ["sdist_dispatch.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "package_repo_dispatch",
+    srcs = ["package_repo_dispatch.bzl"],
     visibility = ["//visibility:public"],
 )
 """)
@@ -116,6 +154,12 @@ backend_registry_repo = repository_rule(
         ),
         "override_files": attr.string_list(
             doc = "Labels of JSON files containing backend overrides.",
+        ),
+        "package_repo_hook_bzl": attr.string_dict(
+            doc = "Maps backend rule names to their custom package repo hook .bzl file labels.",
+        ),
+        "package_repo_hook_fn": attr.string_dict(
+            doc = "Maps backend rule names to the function name in the package repo hook .bzl file.",
         ),
     },
 )

--- a/pycross/private/backends.bzl
+++ b/pycross/private/backends.bzl
@@ -18,6 +18,8 @@ def _backends_impl(module_ctx):
     backend_configs = {}  # rule name -> JSON config string
     sdist_hook_bzl = {}  # rule name -> custom sdist hook .bzl file
     sdist_hook_fn = {}  # rule name -> custom sdist hook function name
+    package_repo_hook_bzl = {}  # rule name -> custom package repo hook .bzl file
+    package_repo_hook_fn = {}  # rule name -> custom package repo hook function name
     default_backend = None
     default_backend_module = None
     override_files = []
@@ -48,6 +50,10 @@ def _backends_impl(module_ctx):
                 sdist_hook_bzl[name] = str(tag.sdist_hook_bzl)
             if tag.sdist_hook_fn:
                 sdist_hook_fn[name] = tag.sdist_hook_fn
+            if tag.package_repo_hook_bzl:
+                package_repo_hook_bzl[name] = str(tag.package_repo_hook_bzl)
+            if tag.package_repo_hook_fn:
+                package_repo_hook_fn[name] = tag.package_repo_hook_fn
 
             for pyproject_backend in tag.pyproject_backends:
                 if pyproject_backend in backend_to_rule and not module.is_root:
@@ -86,6 +92,8 @@ def _backends_impl(module_ctx):
         backend_configs = backend_configs,
         sdist_hook_bzl = sdist_hook_bzl,
         sdist_hook_fn = sdist_hook_fn,
+        package_repo_hook_bzl = package_repo_hook_bzl,
+        package_repo_hook_fn = package_repo_hook_fn,
         override_files = override_files,
     )
 
@@ -133,6 +141,14 @@ backends = module_extension(
                 "sdist_hook_fn": attr.string(
                     doc = "Optional function name in sdist_hook_bzl. Defaults to " +
                           "'<name>_sdist_hook' (replacing '_build' suffix).",
+                ),
+                "package_repo_hook_bzl": attr.label(
+                    doc = "Optional label of a .bzl file providing a hook for " +
+                          "thin repo generation.",
+                ),
+                "package_repo_hook_fn": attr.string(
+                    doc = "Optional function name in package_repo_hook_bzl. Defaults to " +
+                          "'<name>_package_repo_hook' (replacing '_build' suffix).",
                 ),
                 "override_json": attr.label(
                     doc = "Optional label of a generated JSON file containing overrides for this backend.",

--- a/pycross/private/lock_repo_creation.bzl
+++ b/pycross/private/lock_repo_creation.bzl
@@ -148,7 +148,8 @@ def create_repos(
                 )
                 if pypi_index:
                     pypi_file_attrs["index"] = pypi_index
-
+                elif file.get("index"):
+                    pypi_file_attrs["index"] = file["index"]
                 if file["name"].endswith(".whl"):
                     pycross_wheel_file(**pypi_file_attrs)
                 else:

--- a/pycross/private/lock_repo_creation.bzl
+++ b/pycross/private/lock_repo_creation.bzl
@@ -7,6 +7,7 @@ Used by both the legacy lock_repos extension and the unified locks extension.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@pycross_backends//:registry.bzl", "BACKEND_CONFIGS", "BACKEND_TO_RULE", "DEFAULT_BACKEND", "OVERRIDE_FILES")
+load("@pypackaging.bzl", "pypackaging")
 load("@rules_pycross//pycross/private:sdist_repo.bzl", "pycross_sdist_repo")
 load("//pycross/private:package_repo.bzl", "package_repo")
 load("//pycross/private:pypi_file.bzl", "pypi_file")
@@ -73,7 +74,8 @@ def create_repos(
             for pkg_name, entry in packages.items():
                 backend_name = entry.get("build_backend", "")
                 backend_attrs = entry.get("backend_attrs", {})
-                override_configs.setdefault(key, {}).setdefault(pkg_name, {})[backend_name] = backend_attrs
+                norm_pkg = pypackaging.utils.canonicalize_name(pkg_name)
+                override_configs.setdefault(key, {}).setdefault(norm_pkg, {})[backend_name] = backend_attrs
 
     # Validate that repo: overrides don't target workspace members.
     for key in override_configs:
@@ -316,6 +318,15 @@ def create_repos(
                 if pkg_key in conflicts:
                     break
 
+        # Compute per-package override configs for package repo hooks.
+        ws_overrides = {}  # pkg_name -> {backend_name -> backend_attrs}
+        keys = ["workspace:" + workspace_name] + ["repo:" + member for member in member_repos]
+        for key in keys:
+            if key in override_configs:
+                for pkg_name, backends in override_configs[key].items():
+                    for b_name, b_attrs in backends.items():
+                        ws_overrides.setdefault(pkg_name, {})[b_name] = dict(b_attrs)
+
         package_repo_attrs = dict(
             name = workspace_repo_name,
             resolved_lock_file = per_repo_data[member_repos[0]].lock_file,
@@ -324,6 +335,8 @@ def create_repos(
             backend_configs = backend_configs_json,
             member_lock_files = member_lock_files,
         )
+        if ws_overrides:
+            package_repo_attrs["override_configs"] = json.encode(ws_overrides)
         if resolved_locks:
             package_repo_attrs["member_lock_data"] = {
                 member: json.encode(per_repo_data[member].resolved_lock)
@@ -353,5 +366,20 @@ def create_repos(
                 thin_repo_attrs["constraint_values"] = json.decode(constraints) if type(constraints) == "string" else constraints
             if member in repo_platforms:
                 thin_repo_attrs["platform"] = repo_platforms[member]
+
+            # Compute per-member override configs for thin repo hooks.
+            member_overrides = {}  # pkg_name -> {backend_name -> backend_attrs}
+            ws_key = "workspace:" + workspace_name
+            if ws_key in override_configs:
+                for pkg_name, backends in override_configs[ws_key].items():
+                    for b_name, b_attrs in backends.items():
+                        member_overrides.setdefault(pkg_name, {})[b_name] = dict(b_attrs)
+            repo_key = "repo:" + member
+            if repo_key in override_configs:
+                for pkg_name, backends in override_configs[repo_key].items():
+                    for b_name, b_attrs in backends.items():
+                        member_overrides.setdefault(pkg_name, {})[b_name] = dict(b_attrs)
+            if member_overrides:
+                thin_repo_attrs["override_configs"] = json.encode(member_overrides)
 
             thin_package_repo(**thin_repo_attrs)

--- a/pycross/private/lock_repos.bzl
+++ b/pycross/private/lock_repos.bzl
@@ -5,6 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@lock_import_repos_hub//:locks.bzl", lock_import_locks = "locks")
 load("@lock_import_repos_hub//:workspaces.bzl", "repo_constraint_values", "repo_flags", "repo_platforms", "root_repos", "workspace_build_repos", "workspace_memberships")
 load("@pycross_backends//:registry.bzl", "BACKEND_CONFIGS", "BACKEND_TO_RULE", "DEFAULT_BACKEND", "OVERRIDE_FILES")
+load("@pypackaging.bzl", "pypackaging")
 load("@rules_pycross//pycross/private:sdist_repo.bzl", "pycross_sdist_repo")
 load("//pycross/private:package_repo.bzl", "package_repo")
 load("//pycross/private:pypi_file.bzl", "pypi_file")
@@ -23,7 +24,7 @@ def _lock_repos_impl(module_ctx):
     all_remote_files = {}
 
     # Build per-repo, per-package override configs from registered override files.
-    # override_configs[key][pkg_name][backend_name] = {backend_attrs dict}
+    # override_configs[key][norm_pkg_name][backend_name] = {backend_attrs dict}
     # Keys are prefixed with "repo:" or "workspace:" to distinguish scope.
     override_configs = {}
     for f in OVERRIDE_FILES:
@@ -32,7 +33,8 @@ def _lock_repos_impl(module_ctx):
             for pkg_name, entry in packages.items():
                 backend_name = entry.get("build_backend", "")
                 backend_attrs = entry.get("backend_attrs", {})
-                override_configs.setdefault(key, {}).setdefault(pkg_name, {})[backend_name] = backend_attrs
+                norm_pkg = pypackaging.utils.canonicalize_name(pkg_name)
+                override_configs.setdefault(key, {}).setdefault(norm_pkg, {})[backend_name] = backend_attrs
 
     # Validate that repo: overrides don't target workspace members.
     for key in override_configs:

--- a/pycross/private/lock_repos.bzl
+++ b/pycross/private/lock_repos.bzl
@@ -121,7 +121,8 @@ def _lock_repos_impl(module_ctx):
                 )
                 if create_tag.pypi_index:
                     pypi_file_attrs["index"] = create_tag.pypi_index
-
+                elif file.get("index"):
+                    pypi_file_attrs["index"] = file["index"]
                 if file["name"].endswith(".whl"):
                     pycross_wheel_file(**pypi_file_attrs)
                 else:

--- a/pycross/private/lock_resolver.bzl
+++ b/pycross/private/lock_resolver.bzl
@@ -6,7 +6,7 @@ load(":util.bzl", "parse_package_key")
 def _file_key(f):
     if not f.get("sha256"):
         fail("PackageFile missing sha256: " + str(f))
-    key = "{}/{}".format(f["name"], f["sha256"])
+    key = "{}/{}".format(f["name"], f["sha256"][:8])
     extra = ""
     if f.get("urls"):
         extra += ",".join(f["urls"])

--- a/pycross/private/lock_resolver.bzl
+++ b/pycross/private/lock_resolver.bzl
@@ -6,7 +6,16 @@ load(":util.bzl", "parse_package_key")
 def _file_key(f):
     if not f.get("sha256"):
         fail("PackageFile missing sha256: " + str(f))
-    return "{}/{}".format(f["name"], f["sha256"])
+    key = "{}/{}".format(f["name"], f["sha256"])
+    extra = ""
+    if f.get("urls"):
+        extra += ",".join(f["urls"])
+    if f.get("index"):
+        extra += "|" + f["index"]
+    if extra:
+        h = hash(extra)
+        key += "/%x" % (h & 0xffffffff)
+    return key
 
 def _resolve_single_version(name, versions_by_name, all_versions, attr_name):
     if "@" in name:

--- a/pycross/private/package_repo.bzl
+++ b/pycross/private/package_repo.bzl
@@ -15,6 +15,7 @@ The file structure is as follows:
 - _backend/<rule>.bzl      - Backend macros with pre-configured tool deps.
 """
 
+load("@pycross_backends//:package_repo_dispatch.bzl", "PACKAGE_REPO_HOOKS")
 load("@pypackaging.bzl", "pypackaging")
 load(":resolved_lock_renderer.bzl", "render_lock_bzl")
 load(":util.bzl", "key_name", "parse_package_key", "underscore_name")
@@ -382,6 +383,52 @@ def _package_repo_impl(rctx):
 
         rctx.file("_backend/{}.bzl".format(macro_name), "\n".join(lines))
 
+    # Package repo hooks: let backends contribute sub-directories.
+    if PACKAGE_REPO_HOOKS:
+        override_configs = {}
+        if rctx.attr.override_configs:
+            override_configs = json.decode(rctx.attr.override_configs)
+
+        # Build the packages info dict for hooks, keyed by normalized name.
+        # Include version and sdist info so hooks can generate versioned targets.
+        packages_info = {}
+        for pkg_key in sorted(packages.keys()):
+            if "__via_" in pkg_key:
+                continue
+            parts = parse_package_key(pkg_key)
+            if parts.extra:
+                continue
+            norm_name = _normalize_name(parts.name)
+            has_sdist = bool(packages[pkg_key].get("sdist_file"))
+            versions = packages_info.get(norm_name, {"versions": []})
+            versions["versions"].append(struct(
+                version = parts.version,
+                package_key = pkg_key,
+                has_sdist = has_sdist,
+            ))
+            packages_info[norm_name] = versions
+
+        # Collect all hook results, merging files for the same path.
+        hook_files = {}  # "dir/filename" -> [content, ...]
+        for backend_name, hook_fn in PACKAGE_REPO_HOOKS.items():
+            # Filter overrides for this backend.
+            backend_overrides = {}
+            for pkg_name, backends in override_configs.items():
+                if backend_name in backends:
+                    backend_overrides[pkg_name] = backends[backend_name]
+
+            if not backend_overrides:
+                continue
+
+            results = hook_fn(packages_info, backend_overrides)
+            for result in results:
+                for filename, content in result.files.items():
+                    path = "{}/{}".format(result.dir, filename)
+                    hook_files.setdefault(path, []).append(content)
+
+        for path, contents in hook_files.items():
+            rctx.file(path, "\n".join(contents))
+
 package_repo = repository_rule(
     implementation = _package_repo_impl,
     attrs = {
@@ -401,6 +448,9 @@ package_repo = repository_rule(
         ),
         "member_lock_data": attr.string_dict(
             doc = "Maps member repo names to their lock JSON content directly. When set, bypasses file reads for those members.",
+        ),
+        "override_configs": attr.string(
+            doc = "JSON-encoded dict of pkg_name -> {backend_name -> backend_attrs} for package repo hooks.",
         ),
     },
 )

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -297,7 +297,7 @@ def translate_poetry(project_dict, lock_dict, lock_model):
     )
 
     # Parse file info helper
-    def parse_file_info(file_info, registry=None):
+    def parse_file_info(file_info, registry = None):
         filename = file_info["file"]
         file_hash = file_info["hash"]
         if not file_hash.startswith("sha256:"):

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -297,12 +297,15 @@ def translate_poetry(project_dict, lock_dict, lock_model):
     )
 
     # Parse file info helper
-    def parse_file_info(file_info):
+    def parse_file_info(file_info, registry=None):
         filename = file_info["file"]
         file_hash = file_info["hash"]
         if not file_hash.startswith("sha256:"):
             fail("Expected sha256: prefix on hash: {}".format(file_hash))
-        return {"name": filename, "sha256": file_hash[7:]}
+        res = {"name": filename, "sha256": file_hash[7:]}
+        if registry:
+            res["index"] = registry
+        return res
 
     # In Poetry 2.0, files are per-package (not in [metadata.files])
     # But we still support [metadata.files] as fallback for edge cases
@@ -343,13 +346,22 @@ def translate_poetry(project_dict, lock_dict, lock_model):
                 })
 
         # Source type check for local packages
-        source_type = lock_pkg.get("source", {}).get("type", "")
+        source = lock_pkg.get("source", {})
+        source_type = source.get("type", "")
         is_local = source_type in ("directory", "git", "url")
+        registry = source.get("url") if source_type == "legacy" else None
 
         # Parse files (inline in Poetry 2.0)
-        files = [parse_file_info(f) for f in lock_pkg.get("files", [])]
+        files = [parse_file_info(f, registry) for f in lock_pkg.get("files", [])]
         if not files:
             files = lock_files_by_name.get(package_listed_name, [])
+            if registry:
+                new_files = []
+                for f in files:
+                    nf = dict(f)
+                    nf["index"] = registry
+                    new_files.append(nf)
+                files = new_files
 
         # Add package name and version to files
         updated_files = []

--- a/pycross/private/thin_package_repo.bzl
+++ b/pycross/private/thin_package_repo.bzl
@@ -460,7 +460,7 @@ pycross_transitioning_file_proxy = rule(
     maybe_mapping_targets = {}  # pkg_key -> lock_label (for modules_mapping _maybe_ aliases)
 
     root_build_lines.extend([
-        'exports_files(["defs.bzl", "requirements.bzl"])',
+        'exports_files(["defs.bzl", "requirements.bzl", "_packages.bzl"])',
         "",
         "pycross_modules_mapping(",
         '    name = "modules_mapping",',
@@ -674,6 +674,72 @@ pycross_transitioning_file_proxy = rule(
 
             rctx.file("_backend/{}.bzl".format(macro_name), "\n".join(lines))
 
+    # _packages.bzl: metadata about all packages in this thin repo.
+    packages_lines = [
+        '"""Generated package metadata. Do not edit."""',
+        "",
+        "PACKAGES = {",
+    ]
+    for base_pin_name in sorted(grouped_pins.keys()):
+        group = grouped_pins[base_pin_name]
+        us_name = underscore_name(base_pin_name)
+
+        base_target_dict = group["base_target"]
+        has_sdist = False
+        if base_target_dict:
+            first_target = list(base_target_dict.values())[0]
+            pkg = packages.get(first_target, {})
+            has_sdist = bool(pkg.get("sdist_file"))
+
+        packages_lines.extend([
+            '    "{}": struct('.format(us_name),
+            "        has_sdist = {},".format(has_sdist),
+            "    ),",
+        ])
+    packages_lines.extend([
+        "}",
+        "",
+    ])
+    rctx.file("_packages.bzl", "\n".join(packages_lines))
+
+    # _cargo/ aliases: if any packages have cargo lock overrides, create
+    # aliases from unversioned names to versioned targets in the package repo.
+    if rctx.attr.override_configs:
+        override_configs = json.decode(rctx.attr.override_configs)
+
+        cargo_lines = [
+            'package(default_visibility = ["//visibility:public"])',
+            "",
+        ]
+
+        has_cargo_targets = False
+        for base_pin_name in sorted(grouped_pins.keys()):
+            us_name = underscore_name(base_pin_name)
+            if base_pin_name not in override_configs:
+                continue
+
+            group = grouped_pins[base_pin_name]
+            base_target_dict = group["base_target"]
+            if not base_target_dict:
+                continue
+
+            # Get the versioned package key from the pin.
+            first_target = list(base_target_dict.values())[0]
+            parts = parse_package_key(first_target)
+            versioned_name = "{}@{}".format(parts.name, parts.version)
+
+            cargo_lines.extend([
+                "alias(",
+                '    name = "{}",'.format(us_name),
+                '    actual = "@{}//_cargo:{}",'.format(workspace_repo, versioned_name),
+                ")",
+                "",
+            ])
+            has_cargo_targets = True
+
+        if has_cargo_targets:
+            rctx.file("_cargo/BUILD.bazel", "\n".join(cargo_lines))
+
 thin_package_repo = repository_rule(
     implementation = _thin_package_repo_impl,
     attrs = {
@@ -710,6 +776,9 @@ thin_package_repo = repository_rule(
         ),
         "platform": attr.string(
             doc = "Existing platform target to use directly.",
+        ),
+        "override_configs": attr.string(
+            doc = "JSON-encoded dict of pkg_name -> {backend_name -> backend_attrs} for package repo hooks.",
         ),
     },
 )

--- a/pycross/private/util.bzl
+++ b/pycross/private/util.bzl
@@ -39,7 +39,14 @@ def trace_ctx(ctx, display_name = "ctx"):
     return struct(**{field_name: wrap(field_name) for field_name in dir(ctx)})
 
 def sanitize_name(val):
-    """Sanitize a string into a valid Bazel repository and target name identifier."""
+    """Sanitize a string into a valid Bazel repository and target name identifier.
+
+    Args:
+        val: The string to sanitize.
+
+    Returns:
+        The sanitized string.
+    """
     res = val.lower()
     for c in "-.+@!:/?=&%,~".elems():
         res = res.replace(c, "_")

--- a/pycross/private/util.bzl
+++ b/pycross/private/util.bzl
@@ -40,7 +40,10 @@ def trace_ctx(ctx, display_name = "ctx"):
 
 def sanitize_name(val):
     """Sanitize a string into a valid Bazel repository and target name identifier."""
-    return val.lower().replace("-", "_").replace(".", "_").replace("+", "_").replace("@", "_").replace("!", "_")
+    res = val.lower()
+    for c in "-.+@!:/?=&%,~".elems():
+        res = res.replace(c, "_")
+    return res
 
 def underscore_name(name):
     """rules_python-style normalization: lowercase, replace [-. ] with _."""

--- a/pycross/private/uv_lock_model.bzl
+++ b/pycross/private/uv_lock_model.bzl
@@ -15,16 +15,17 @@ load(
     "resolve_lock_graph",
 )
 
-def _parse_file_info(file_info, package_name, package_version):
+def _parse_file_info(file_info, package_name, package_version, registry = None):
     """Parse a UV lock file entry into a file dict.
 
     Args:
         file_info: A dict with "file", "filename", or "url" and "hash" keys.
         package_name: The name of the package.
         package_version: The version of the package.
+        registry: An optional string representing the index URL.
 
     Returns:
-        A dict with name, sha256, package_name, package_version, and optionally urls.
+        A dict with name, sha256, package_name, package_version, and optionally urls/index.
     """
     if "file" in file_info:
         filename = file_info["file"]
@@ -58,6 +59,8 @@ def _parse_file_info(file_info, package_name, package_version):
     }
     if urls:
         result["urls"] = urls
+    if registry:
+        result["index"] = registry
     return result
 
 def _sha256_from_string(s):
@@ -321,15 +324,17 @@ def translate_uv(project_dict, lock_dict, lock_model):
 
         # Parse files: wheels + sdist
         files = []
+        source = lock_pkg.get("source", {})
+        registry = source.get("registry")
+
         for w in lock_pkg.get("wheels", []):
-            files.append(_parse_file_info(w, package_name, package_version))
+            files.append(_parse_file_info(w, package_name, package_version, registry))
 
         sdist = lock_pkg.get("sdist", {})
-        source = lock_pkg.get("source", {})
 
         if sdist:
             if "url" in sdist or "file" in sdist:
-                files.append(_parse_file_info(sdist, package_name, package_version))
+                files.append(_parse_file_info(sdist, package_name, package_version, registry))
             elif "url" in source:
                 # URL-based source with subdirectory
                 url = source["url"]
@@ -337,17 +342,20 @@ def translate_uv(project_dict, lock_dict, lock_model):
                 if not file_hash.startswith("sha256:"):
                     fail("Expected sha256: prefix on hash")
                 filename = "{}-{}.tar.gz".format(package_name, package_version)
-                files.append({
+                f = {
                     "name": filename,
                     "sha256": file_hash[7:],
                     "urls": [url],
                     "package_name": package_name,
                     "package_version": package_version,
-                })
+                }
+                if registry:
+                    f["index"] = registry
+                files.append(f)
             elif "git" in source:
                 pass  # handled below
             else:
-                files.append(_parse_file_info(sdist, package_name, package_version))
+                files.append(_parse_file_info(sdist, package_name, package_version, registry))
 
         # Handle git sources
         if "git" in source and not files:

--- a/tests/e2e/build_maturin/MODULE.bazel
+++ b/tests/e2e/build_maturin/MODULE.bazel
@@ -77,6 +77,5 @@ maturin.override(
     repo = "uv",
     sdist = "@uv//jiter:sdist",
 )
-use_repo(maturin, "uv_cargo")
 
 use_repo(uv, "uv")

--- a/tests/e2e/build_maturin/jiter.lock
+++ b/tests/e2e/build_maturin/jiter.lock
@@ -16,12 +16,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,16 +28,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
 
 [[package]]
-name = "bitflags"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-
-[[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -103,12 +91,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,24 +134,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -185,21 +156,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -246,13 +209,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -261,12 +223,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical-parse-float"
@@ -305,16 +261,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "log"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
-
-[[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -376,16 +326,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -462,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -492,12 +432,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -551,9 +485,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "static_assertions"
@@ -563,9 +497,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -591,12 +525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,11 +532,11 @@ checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -621,27 +549,18 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -652,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -662,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -675,45 +594,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -791,97 +676,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wyz"
@@ -894,18 +691,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/unit/test_lock_resolver.bzl
+++ b/tests/unit/test_lock_resolver.bzl
@@ -1381,7 +1381,7 @@ def _test_remote_wheel_override_impl(env, target):
     pkg = res.packages["foo@1.0"]
 
     env.expect.that_collection(pkg["wheel_candidates"]).has_size(1)
-    expected_key = "foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl/remote_sha"
+    expected_key = "foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl/remote_sha/edfe9b3e"
     env.expect.that_str(pkg["wheel_candidates"][0]["file_reference"]["key"]).equals(expected_key)
 
 def _test_remote_wheel_override(name):

--- a/tests/unit/test_lock_resolver.bzl
+++ b/tests/unit/test_lock_resolver.bzl
@@ -1381,7 +1381,7 @@ def _test_remote_wheel_override_impl(env, target):
     pkg = res.packages["foo@1.0"]
 
     env.expect.that_collection(pkg["wheel_candidates"]).has_size(1)
-    expected_key = "foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl/remote_sha/edfe9b3e"
+    expected_key = "foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl/remote_s/edfe9b3e"
     env.expect.that_str(pkg["wheel_candidates"][0]["file_reference"]["key"]).equals(expected_key)
 
 def _test_remote_wheel_override(name):

--- a/tests/unit/uv/lock_0_2_35/expected.json
+++ b/tests/unit/uv/lock_0_2_35/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -571,6 +634,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -580,6 +644,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -589,6 +654,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -598,6 +664,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -607,6 +674,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -616,6 +684,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -625,6 +694,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -634,6 +704,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -643,6 +714,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -652,6 +724,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -661,6 +734,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -670,6 +744,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -679,6 +754,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -688,6 +764,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -697,6 +774,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_0_4_0_virtual/expected.json
+++ b/tests/unit/uv/lock_0_4_0_virtual/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -571,6 +634,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -580,6 +644,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -589,6 +654,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -598,6 +664,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -607,6 +674,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -616,6 +684,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -625,6 +694,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -634,6 +704,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -643,6 +714,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -652,6 +724,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -661,6 +734,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -670,6 +744,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -679,6 +754,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -688,6 +764,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -697,6 +774,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_0_4_27_legacy_dev_dependencies/expected.json
+++ b/tests/unit/uv/lock_0_4_27_legacy_dev_dependencies/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_0_4_27_pep735/expected.json
+++ b/tests/unit/uv/lock_0_4_27_pep735/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_pre_0_2_35/expected.json
+++ b/tests/unit/uv/lock_pre_0_2_35/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp313-cp313-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -571,6 +634,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -580,6 +644,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -589,6 +654,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -598,6 +664,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -607,6 +674,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -616,6 +684,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -625,6 +694,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -634,6 +704,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -643,6 +714,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -652,6 +724,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -661,6 +734,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -670,6 +744,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -679,6 +754,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -688,6 +764,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -697,6 +774,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",

--- a/tests/unit/uv/lock_workspace/expected.json
+++ b/tests/unit/uv/lock_workspace/expected.json
@@ -4,6 +4,7 @@
       "dependencies": [],
       "files": [
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -13,6 +14,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -22,6 +24,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -31,6 +34,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -40,6 +44,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -49,6 +54,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -58,6 +64,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -67,6 +74,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -76,6 +84,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -85,6 +94,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -94,6 +104,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -103,6 +114,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -112,6 +124,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -121,6 +134,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -130,6 +144,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -139,6 +154,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp310-cp310-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -148,6 +164,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -157,6 +174,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -166,6 +184,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -175,6 +194,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -184,6 +204,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -193,6 +214,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -202,6 +224,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -211,6 +234,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -220,6 +244,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -229,6 +254,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -238,6 +264,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -247,6 +274,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -256,6 +284,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -265,6 +294,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -274,6 +304,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp311-cp311-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -283,6 +314,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -292,6 +324,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -301,6 +334,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -310,6 +344,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -319,6 +354,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -328,6 +364,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -337,6 +374,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -346,6 +384,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -355,6 +394,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -364,6 +404,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -373,6 +414,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -382,6 +424,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -391,6 +434,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -400,6 +444,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -409,6 +454,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp312-cp312-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -418,6 +464,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_universal2.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -427,6 +474,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_10_9_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -436,6 +484,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-macosx_11_0_arm64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -445,6 +494,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -454,6 +504,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -463,6 +514,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -472,6 +524,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -481,6 +534,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -490,6 +544,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -499,6 +554,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_aarch64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -508,6 +564,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_i686.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -517,6 +574,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_ppc64le.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -526,6 +584,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_s390x.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -535,6 +594,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-musllinux_1_2_x86_64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -544,6 +604,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win32.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -553,6 +614,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6-cp39-cp39-win_amd64.whl",
           "package_name": "regex",
           "package_version": "2024.11.6",
@@ -562,6 +624,7 @@
           ]
         },
         {
+          "index": "https://pypi.org/simple",
           "name": "regex-2024.11.6.tar.gz",
           "package_name": "regex",
           "package_version": "2024.11.6",


### PR DESCRIPTION
- **Include URL and Index when deduplicating repos**
- **Extract package registry indexes from lock files**
- **Fix buildifier lint for sanitize_name**
- **Truncate sha256 to 8 chars in file keys**
- **Move cargo lock targets into package repo with thin repo aliases**
