### PR TITLE
fix: fail on duplicate wheel filename with mismatched hashes

### DIFF
--- a/pycross/private/lock_resolver.bzl
+++ b/pycross/private/lock_resolver.bzl
@@ -119,6 +119,29 @@ def _create_package_resolver(pkg_key, pkg, ann, default_build_dependencies, cont
 
     package_sources = {}
     for f in pkg.get("files", []):
+        existing = package_sources.get(f["name"])
+        if existing != None and "file" in existing:
+            existing_file = existing["file"]
+
+            # Two files sharing a name but not a hash cannot be silently
+            # collapsed: keeping whichever entry is seen last makes wheel
+            # selection non-deterministic and is a supply-chain hazard. This
+            # commonly happens when a package is listed under more than one
+            # index. Fail and require the user to disambiguate. Multiple sdists
+            # with the same name are left unhandled.
+            if existing_file["name"].endswith(".whl") and existing_file.get("sha256") != f.get("sha256"):
+                fail(
+                    ("package {name}=={version} has multiple distinct files named {filename} " +
+                     "(sha256 {existing_sha} vs {new_sha}). This usually means the package is " +
+                     "listed under more than one index; pick one explicitly via " +
+                     "[tool.uv.sources] in pyproject.toml.").format(
+                        name = pkg_name,
+                        version = pkg_version,
+                        filename = repr(f["name"]),
+                        existing_sha = existing_file.get("sha256"),
+                        new_sha = f.get("sha256"),
+                    ),
+                )
         package_sources[f["name"]] = {"file": f}
 
     pkg_key_no_extra = "{}@{}".format(pkg_name, pkg_version)

--- a/tests/unit/test_lock_resolver.bzl
+++ b/tests/unit/test_lock_resolver.bzl
@@ -1573,6 +1573,39 @@ def _test_empty_lock(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_empty_lock_impl)
 
+def _test_duplicate_wheel_filename_raises_error_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.contains("has multiple distinct files named"),
+    )
+
+def _test_duplicate_wheel_filename_raises_error(name):
+    lock_model_data = {
+        "packages": {
+            "foo@1.0": _make_pkg(
+                "foo",
+                "1.0",
+                [
+                    _make_file("foo-1.0-py3-none-any.whl", sha256 = "aaaa"),
+                    _make_file("foo-1.0-py3-none-any.whl", sha256 = "bbbb"),
+                ],
+            ),
+        },
+        "pins": {"foo": "foo@1.0"},
+    }
+
+    util.helper_target(
+        _resolve_failure_subject,
+        name = name + "_subject",
+        lock_model_data = json.encode(lock_model_data),
+    )
+
+    analysis_test(
+        name = name,
+        target = name + "_subject",
+        impl = _test_duplicate_wheel_filename_raises_error_impl,
+        expect_failure = True,
+    )
+
 def _test_pinned_package_not_in_packages_impl(env, target):
     env.expect.that_target(target).failures().contains_predicate(
         matching.contains("Missing package foo@1.0"),
@@ -1848,6 +1881,7 @@ def lock_resolver_test_suite(name):
             _test_multi_tag_wheel_candidates,
             _test_sdist_only_package,
             _test_no_files_raises_error,
+            _test_duplicate_wheel_filename_raises_error,
             _test_empty_lock,
             _test_pinned_package_not_in_packages,
             _test_wildcard_always_build_end_to_end,


### PR DESCRIPTION
## Description
- Fail resolution when a package has multiple files sharing the same wheel filename but different sha256 hashes, instead of silently keeping whichever one is inserted last into `package_sources`.
- Add a unit test covering the new failure path.

## Why
- The same wheel filename can be served by more than one index with different contents. Silently picking one made wheel selection non-deterministic and is a supply-chain hazard.
- Failing forces the user to disambiguate the index explicitly (for example via `[tool.uv.sources]` in pyproject.toml).

## Example
`coverage` is a real case. It has a C extension, so it publishes platform-specific
wheels, but it also ships a pure-Python `py3-none-any` fallback wheel. For version
7.15.0 that includes:
- `coverage-7.15.0-py3-none-any.whl` (universal, pure-Python fallback)
- `coverage-7.15.0-cp313-cp313-manylinux_2_28_x86_64.whl` (Linux)
- `coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl` (macOS)

Now configure two indexes split by platform, one used for Linux and one for
everything else. Both indexes carry `coverage`, and each serves its own copy of the
universal `coverage-7.15.0-py3-none-any.whl` with a different hash (for example
because one index rebuilds wheels from source).

uv then records both universal wheels in `uv.lock` under the same package. They share
the filename but differ in `sha256`:

    wheels = [
        { url = "https://index-a/coverage-7.15.0-py3-none-any.whl", hash = "sha256:aaaa..." },
        { url = "https://index-b/coverage-7.15.0-py3-none-any.whl", hash = "sha256:bbbb..." },
    ]

Before this change the resolver silently kept whichever entry was inserted last, so the
wheel actually used depended on iteration order. This change fails instead and asks the
user to pin the package to a single index.

## Notes
- This does not attempt to handle multiple sdist files sharing a name.