### PR TITLE
fix: advertise `PyInfo` from `pycross_wheel_library`

### DIFF
--- a/pycross/private/wheel_library.bzl
+++ b/pycross/private/wheel_library.bzl
@@ -200,6 +200,7 @@ def _pycross_wheel_library_impl(ctx):
 
 pycross_wheel_library = rule(
     implementation = _pycross_wheel_library_impl,
+    provides = [PyInfo],
     attrs = dict({
         "deps": attr.label_list(
             doc = "A list of this wheel's Python library dependencies.",


### PR DESCRIPTION
`pycross_wheel_library` returns `PyInfo` but doesn't advertise it via
`provides`. Bazel matches an aspect's `required_providers` against a rule's
*advertised* providers, so aspects gated on `required_providers = [PyInfo]`
are never applied to these targets.

We ran into this with an aspect that propagates over `PyInfo`-providing
targets: it skipped `pycross_wheel_library` deps until the provider was
advertised.