### PR TITLE
chore: switch to pull_request_target to enable remote cache for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
   workflow_dispatch:
 
@@ -21,6 +21,8 @@ jobs:
       cross-workspaces: ${{ steps.set-matrix.outputs.cross }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - id: set-matrix
         run: |
           e2e_ws=()
@@ -61,6 +63,8 @@ jobs:
         workspace: ${{ fromJSON(needs.unit.outputs.e2e-workspaces) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelrc: |
@@ -105,6 +109,8 @@ jobs:
         workspace: ${{ fromJSON(needs.unit.outputs.cross-workspaces) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Enable unprivileged user namespaces
         if: matrix.host == 'ubuntu'
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
@@ -130,6 +136,8 @@ jobs:
         runner: [ubuntu, macos]
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Enable unprivileged user namespaces
         if: matrix.runner == 'ubuntu'
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
@@ -179,6 +187,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"


### PR DESCRIPTION
Switch from pull_request to pull_request_target so that PRs from forks have
access to the BuildBuddy API key secret for remote caching.

Update all actions/checkout steps to explicitly use the PR Head SHA when
triggered by a pull request, as pull_request_target defaults to checking
out the base branch (main).
