### PR TITLE
chore: add missing provides declarations to rules

### DIFF
--- a/pycross/private/build/wheel_headers.bzl
+++ b/pycross/private/build/wheel_headers.bzl
@@ -40,6 +40,7 @@ def _pycross_wheel_headers_impl(ctx):
 
 pycross_wheel_headers = rule(
     implementation = _pycross_wheel_headers_impl,
+    provides = [CcInfo],
     doc = """Extracts C/C++ headers from an installed wheel library.
 
 Given a pycross_wheel_library target, this rule exposes the headers found at

--- a/pycross/private/variant_resolver.bzl
+++ b/pycross/private/variant_resolver.bzl
@@ -40,6 +40,7 @@ def _variant_resolver_impl(ctx):
 
 variant_resolver = rule(
     implementation = _variant_resolver_impl,
+    provides = [config_common.FeatureFlagInfo],
     attrs = {
         "flags": attr.label_list(
             providers = [BuildSettingInfo],

--- a/pycross/private/wheel_chooser.bzl
+++ b/pycross/private/wheel_chooser.bzl
@@ -65,6 +65,7 @@ def _pycross_wheel_chooser_impl(ctx):
 
 _pycross_wheel_chooser = rule(
     implementation = _pycross_wheel_chooser_impl,
+    provides = [config_common.FeatureFlagInfo],
     attrs = {
         "candidates": attr.string_list(
             mandatory = True,

--- a/pycross/private/wheel_library.bzl
+++ b/pycross/private/wheel_library.bzl
@@ -200,7 +200,7 @@ def _pycross_wheel_library_impl(ctx):
 
 pycross_wheel_library = rule(
     implementation = _pycross_wheel_library_impl,
-    provides = [PyInfo],
+    provides = [PyInfo, PycrossExtractedWheelInfo],
     attrs = dict({
         "deps": attr.label_list(
             doc = "A list of this wheel's Python library dependencies.",
@@ -259,6 +259,7 @@ def _pycross_wheel_metadata_impl(ctx):
 
 pycross_wheel_metadata = rule(
     implementation = _pycross_wheel_metadata_impl,
+    provides = [PycrossPackageInfo],
     attrs = {
         "wheel": attr.label(allow_files = True, mandatory = True),
         "package_name": attr.string(),

--- a/pycross/private/wheel_zipimport_library.bzl
+++ b/pycross/private/wheel_zipimport_library.bzl
@@ -53,6 +53,7 @@ def _pycross_wheel_zipimport_library_impl(ctx):
 
 pycross_wheel_zipimport_library = rule(
     implementation = _pycross_wheel_zipimport_library_impl,
+    provides = [PyInfo],
     attrs = dict({
         "deps": attr.label_list(
             doc = "A list of this wheel's Python library dependencies.",


### PR DESCRIPTION
Declare provides on rules that return providers beyond DefaultInfo:

- pycross_wheel_library: provides = [PyInfo, PycrossExtractedWheelInfo]
- pycross_wheel_metadata: provides = [PycrossPackageInfo]
- pycross_wheel_zipimport_library: provides = [PyInfo]
- pycross_wheel_headers: provides = [CcInfo]
- _pycross_wheel_chooser: provides = [config_common.FeatureFlagInfo]
- variant_resolver: provides = [config_common.FeatureFlagInfo]

This enables better analysis-time error messages and allows other rules'
providers constraints to validate targets at analysis time.

Conditional providers (PycrossPackageInfo on wheel_library,
TemplateVariableInfo on wheel_headers) are intentionally excluded
since Bazel requires declared providers to always be returned.
