### PR TITLE
Rename `development` groups to just `group`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Breaking
+
+- **`"development:<name>"` renamed to `"group:<name>"`** in `dependency_groups`
+  specifiers. PEP 735 dependency groups are not inherently development
+  dependencies — they are general-purpose named groups. Update your `repo()`
+  declarations: e.g. `"development:dev"` → `"group:dev"`,
+  `"development:*"` → `"group:*"`.
+
+### Fixed
+
+- **PDM: correctly parse `[tool.pdm.dev-dependencies]`.** The previous code
+  iterated over the dict keys instead of the group contents, silently producing
+  incorrect results when multiple named dev groups were present.
+- **PDM: enforce group name disjointedness.** PDM does not allow the same group
+  name in both `[dependency-groups]` and `[tool.pdm.dev-dependencies]`, or in
+  both development groups and `[project.optional-dependencies]`. The translator
+  now fails early with a clear error message in these cases.
+- **Poetry: add PEP 735 `[dependency-groups]` support.** Poetry 2.2+ supports
+  standard PEP 735 dependency groups alongside legacy `[tool.poetry.group]`
+  sections. The translator now reads from both sources with union semantics
+  (per [python-poetry/poetry#10130](https://github.com/python-poetry/poetry/pull/10130)).
+
 ## [2.0.0-alpha.1]
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ All notable changes to this project will be documented in this file.
   Single-project lock files only need `workspace()` — the repo is auto-created.
   Multi-project workspaces use `repo(projects = ["*"])` or per-project `repo()` tags.
 - **`dependency_groups` attribute on `repo()`.** String-based group specifiers:
-  `"default"`, `"optional:<name>"`, `"development:<name>"`, `"optional:*"`,
-  `"development:*"`, `"*"`. Replaces the old boolean/list attributes.
+  `"default"`, `"optional:<name>"`, `"group:<name>"`, `"optional:*"`,
+  `"group:*"`, `"*"`. Replaces the old boolean/list attributes.
 - **Auto-generated `__build` repos.** Build dependency repos are now auto-created
   from workspace configuration; no manual `build_repo` declaration needed.
 - **`legacy_create_root_aliases` on `repo()`** for migrating from 1.x target

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -153,7 +153,7 @@ _DEFAULT_LOCK_MODEL = '{"projects": ["*"], "dependency_groups": ["default"]}'
 
 _DEFAULT_UV_LOCK_MODEL = '{"projects": ["*"], "dependency_groups": ["default"]}'
 
-_ALL_DEV_UV_LOCK_MODEL = '{"projects": ["*"], "dependency_groups": ["default", "development:*"]}'
+_ALL_DEV_UV_LOCK_MODEL = '{"projects": ["*"], "dependency_groups": ["default", "group:*"]}'
 
 starlark_translators = use_extension(
     "//tests:starlark_lock_model_test.bzl",

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This repository is managed automatically. However, if you need to customize its 
 ```python
 uv.repo(
     name = "pypi__build",
-    dependency_groups = ["default", "development:build"],
+    dependency_groups = ["default", "group:build"],
     workspace = "pypi",
 )
 ```
@@ -202,15 +202,15 @@ The `dependency_groups` attribute on `uv.repo()` controls which dependency group
 
 * `"default"` — the project's default dependencies
 * `"optional:<name>"` — a specific optional dependency group (`[project.optional-dependencies]`)
-* `"development:<name>"` — a specific development group (`[dependency-groups]`)
-* `"optional:*"` / `"development:*"` — all optional or all development groups
+* `"group:<name>"` — a specific dependency group (`[dependency-groups]`)
+* `"optional:*"` / `"group:*"` — all optional or all dependency groups
 * `"*"` — all groups (default + all optional + all development)
 
 The default is `["default"]`.
 
 ```python
 uv.repo(
-    dependency_groups = ["default", "optional:grpc", "development:test"],
+    dependency_groups = ["default", "optional:grpc", "group:test"],
     workspace = "pypi",
 )
 ```
@@ -282,7 +282,7 @@ uv.repo(
 uv.repo(
     name = "lock_b",
     projects = ["project-b"],
-    dependency_groups = ["default", "optional:grpc", "development:testing"],
+    dependency_groups = ["default", "optional:grpc", "group:testing"],
     workspace = "shared",
 )
 use_repo(uv, "lock_a", "lock_b")

--- a/pycross/private/format_extension.bzl
+++ b/pycross/private/format_extension.bzl
@@ -64,7 +64,7 @@ REPO_ATTRS = dict(
         doc = "Generate aliases for transitive single-version packages in this repo.",
     ),
     dependency_groups = attr.string_list(
-        doc = "A list of dependency groups to include. E.g. ['default', 'development:foo', '*']. Defaults to ['default'].",
+        doc = "A list of dependency groups to include. E.g. ['default', 'group:foo', '*']. Defaults to ['default'].",
         default = ["default"],
     ),
     legacy_create_root_aliases = attr.bool(

--- a/pycross/private/pdm_lock_model.bzl
+++ b/pycross/private/pdm_lock_model.bzl
@@ -113,7 +113,7 @@ def translate_pdm(project_dict, lock_dict, lock_model):
         for dep_str in default_deps:
             requirements.append(parse_pep508_requirement(dep_str))
 
-    effective_groups = ["optional:*", "development:*"] if include_all else dependency_groups
+    effective_groups = ["optional:*", "group:*"] if include_all else dependency_groups
     for group in effective_groups:
         if group == "default" or group == "*":
             continue
@@ -121,10 +121,10 @@ def translate_pdm(project_dict, lock_dict, lock_model):
         kind, _, name = group.partition(":")
         if kind == "optional":
             groups_dict = optional_deps
-        elif kind == "development":
+        elif kind == "group":
             groups_dict = dev_deps
         else:
-            fail("Invalid dependency group format '{}'. Must be 'optional:name' or 'development:name'.".format(group))
+            fail("Invalid dependency group format '{}'. Must be 'optional:name' or 'group:name'.".format(group))
 
         if name == "*":
             target_names = list(groups_dict.keys())

--- a/pycross/private/pdm_lock_model.bzl
+++ b/pycross/private/pdm_lock_model.bzl
@@ -92,12 +92,14 @@ def translate_pdm(project_dict, lock_dict, lock_model):
     legacy_dev_deps = project_dict.get("tool", {}).get("pdm", {}).get("dev-dependencies", {})
     if legacy_dev_deps:
         for group_name, deps in legacy_dev_deps.items():
-            existing = dev_deps.get(group_name, [])
-            merged = list(existing)
-            for d in deps:
-                if d not in merged:
-                    merged.append(d)
-            dev_deps[group_name] = merged
+            if group_name in dev_deps:
+                fail("PDM error: group '{}' cannot appear in both [dependency-groups] and [tool.pdm.dev-dependencies]".format(group_name))
+            dev_deps[group_name] = deps
+
+    # Enforce PDM PEP 735 rule
+    for group_name in dev_deps:
+        if group_name in optional_deps:
+            fail("PDM error: the same group name '{}' MUST NOT appear in both development groups and [project.optional-dependencies]".format(group_name))
 
     requires_python = project_dict.get("project", {}).get("requires-python", "")
 

--- a/pycross/private/pdm_lock_model.bzl
+++ b/pycross/private/pdm_lock_model.bzl
@@ -89,16 +89,15 @@ def translate_pdm(project_dict, lock_dict, lock_model):
 
     # Development dependencies: dependency-groups + legacy tool.pdm.dev-dependencies
     dev_deps = dict(project_dict.get("dependency-groups", {}))
-    legacy_dev_deps = project_dict.get("tool", {}).get("pdm", {}).get("dev-dependencies", [])
+    legacy_dev_deps = project_dict.get("tool", {}).get("pdm", {}).get("dev-dependencies", {})
     if legacy_dev_deps:
-        existing = dev_deps.get("dev", [])
-
-        # Merge and deduplicate
-        merged = list(existing)
-        for d in legacy_dev_deps:
-            if d not in merged:
-                merged.append(d)
-        dev_deps["dev"] = merged
+        for group_name, deps in legacy_dev_deps.items():
+            existing = dev_deps.get(group_name, [])
+            merged = list(existing)
+            for d in deps:
+                if d not in merged:
+                    merged.append(d)
+            dev_deps[group_name] = merged
 
     requires_python = project_dict.get("project", {}).get("requires-python", "")
 

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -261,6 +261,7 @@ def translate_poetry(project_dict, lock_dict, lock_model):
                     pinned_package_specs[pin] = {"": _poetry_constraint_to_pep440(pin_info.get("version", "*"))}
 
     project_optional_deps = project_dict.get("project", {}).get("optional-dependencies", {})
+    pep735_groups = project_dict.get("dependency-groups", {})
 
     effective_groups = ["optional:*", "group:*"] if include_all else dependency_groups
     for group in effective_groups:
@@ -270,7 +271,7 @@ def translate_poetry(project_dict, lock_dict, lock_model):
         kind, _, name = group.partition(":")
 
         if name == "*":
-            target_names = list(poetry_groups.keys()) + list(project_optional_deps.keys())
+            target_names = list(poetry_groups.keys()) + list(pep735_groups.keys()) + list(project_optional_deps.keys())
 
             # Deduplicate
             target_names = {k: True for k in target_names}.keys()
@@ -278,7 +279,13 @@ def translate_poetry(project_dict, lock_dict, lock_model):
             target_names = [name]
 
         for group_name in target_names:
-            if group_name in poetry_groups:
+            if group_name in pep735_groups:
+                for dep_str in pep735_groups[group_name]:
+                    req = parse_pep508_requirement(dep_str)
+                    if req.name == "python":
+                        continue
+                    pinned_package_specs[canonicalize_name(req.name)] = {"": req.specifier}
+            elif group_name in poetry_groups:
                 g = poetry_groups[group_name]
                 for pin, pin_info in g.get("dependencies", {}).items():
                     pin = canonicalize_name(pin)

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -263,6 +263,11 @@ def translate_poetry(project_dict, lock_dict, lock_model):
     project_optional_deps = project_dict.get("project", {}).get("optional-dependencies", {})
     pep735_groups = project_dict.get("dependency-groups", {})
 
+    # Poetry does not allow the same group name in both [dependency-groups] and [tool.poetry.group]
+    for group_name in pep735_groups:
+        if group_name in poetry_groups:
+            fail("Poetry error: group '{}' cannot appear in both [dependency-groups] and [tool.poetry.group]".format(group_name))
+
     effective_groups = ["optional:*", "group:*"] if include_all else dependency_groups
     for group in effective_groups:
         if group == "default" or group == "*":

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -263,11 +263,6 @@ def translate_poetry(project_dict, lock_dict, lock_model):
     project_optional_deps = project_dict.get("project", {}).get("optional-dependencies", {})
     pep735_groups = project_dict.get("dependency-groups", {})
 
-    # Poetry does not allow the same group name in both [dependency-groups] and [tool.poetry.group]
-    for group_name in pep735_groups:
-        if group_name in poetry_groups:
-            fail("Poetry error: group '{}' cannot appear in both [dependency-groups] and [tool.poetry.group]".format(group_name))
-
     effective_groups = ["optional:*", "group:*"] if include_all else dependency_groups
     for group in effective_groups:
         if group == "default" or group == "*":
@@ -284,13 +279,14 @@ def translate_poetry(project_dict, lock_dict, lock_model):
             target_names = [name]
 
         for group_name in target_names:
+            # Poetry merges PEP 735 and legacy groups (union, not fallback).
             if group_name in pep735_groups:
                 for dep_str in pep735_groups[group_name]:
                     req = parse_pep508_requirement(dep_str)
                     if req.name == "python":
                         continue
                     pinned_package_specs[canonicalize_name(req.name)] = {"": req.specifier}
-            elif group_name in poetry_groups:
+            if group_name in poetry_groups:
                 g = poetry_groups[group_name]
                 for pin, pin_info in g.get("dependencies", {}).items():
                     pin = canonicalize_name(pin)
@@ -302,7 +298,7 @@ def translate_poetry(project_dict, lock_dict, lock_model):
                         if "path" in pin_info:
                             continue
                         pinned_package_specs[pin] = {"": _poetry_constraint_to_pep440(pin_info.get("version", "*"))}
-            elif group_name in project_optional_deps:
+            if group_name in project_optional_deps:
                 for dep_str in project_optional_deps[group_name]:
                     req = parse_pep508_requirement(dep_str)
                     if req.name == "python":

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -262,7 +262,7 @@ def translate_poetry(project_dict, lock_dict, lock_model):
 
     project_optional_deps = project_dict.get("project", {}).get("optional-dependencies", {})
 
-    effective_groups = ["optional:*", "development:*"] if include_all else dependency_groups
+    effective_groups = ["optional:*", "group:*"] if include_all else dependency_groups
     for group in effective_groups:
         if group == "default" or group == "*":
             continue

--- a/pycross/private/pylock_lock_model.bzl
+++ b/pycross/private/pylock_lock_model.bzl
@@ -175,7 +175,7 @@ def translate_pylock(lock_dict, project_dict, lock_model):
         optional_deps = project_section.get("optional-dependencies", {})
         dev_deps = project_dict.get("dependency-groups", {})
 
-        effective_groups = ["optional:*", "development:*"] if include_all else dependency_groups
+        effective_groups = ["optional:*", "group:*"] if include_all else dependency_groups
         for group in effective_groups:
             if group == "default" or group == "*":
                 continue
@@ -183,10 +183,10 @@ def translate_pylock(lock_dict, project_dict, lock_model):
             kind, _, name = group.partition(":")
             if kind == "optional":
                 groups_dict = optional_deps
-            elif kind == "development":
+            elif kind == "group":
                 groups_dict = dev_deps
             else:
-                fail("Invalid dependency group format '{}'. Must be 'optional:name' or 'development:name'.".format(group))
+                fail("Invalid dependency group format '{}'. Must be 'optional:name' or 'group:name'.".format(group))
 
             if name == "*":
                 target_names = list(groups_dict.keys())

--- a/pycross/private/uv_lock_model.bzl
+++ b/pycross/private/uv_lock_model.bzl
@@ -291,7 +291,7 @@ def translate_uv(project_dict, lock_dict, lock_model):
                     requirements.append((dep_name, specifier, ""))
 
         # Parse groups
-        effective_groups = ["optional:*", "development:*"] if include_all else dependency_groups
+        effective_groups = ["optional:*", "group:*"] if include_all else dependency_groups
         for group in effective_groups:
             if group == "default" or group == "*":
                 continue
@@ -300,11 +300,11 @@ def translate_uv(project_dict, lock_dict, lock_model):
             if kind == "optional":
                 groups_dict = optional_dependencies
                 constraint_dict = extra_variant_values
-            elif kind == "development":
+            elif kind == "group":
                 groups_dict = development_dependencies
                 constraint_dict = group_variant_values
             else:
-                fail("Invalid dependency group format '{}'. Must be 'optional:name' or 'development:name'.".format(group))
+                fail("Invalid dependency group format '{}'. Must be 'optional:name' or 'group:name'.".format(group))
 
             if name == "*":
                 target_names = list(groups_dict.keys())

--- a/tests/e2e/generate_lock/MODULE.bazel
+++ b/tests/e2e/generate_lock/MODULE.bazel
@@ -44,7 +44,7 @@ uv.workspace(
 )
 uv.repo(
     dependency_groups = [
-        "development:dev",
+        "group:dev",
         "optional:yaml",
     ],
     projects = ["*"],

--- a/tests/e2e/uv_conflicts/MODULE.bazel
+++ b/tests/e2e/uv_conflicts/MODULE.bazel
@@ -46,8 +46,8 @@ uv.repo(
     name = "project",
     dependency_groups = [
         "default",
-        "development:group-a",
-        "development:group-b",
+        "group:group-a",
+        "group:group-b",
         "optional:variant-a",
         "optional:variant-b",
     ],
@@ -62,8 +62,8 @@ uv.repo(
     ],
     dependency_groups = [
         "default",
-        "development:group-a",
-        "development:group-b",
+        "group:group-a",
+        "group:group-b",
         "optional:variant-a",
         "optional:variant-b",
     ],

--- a/tests/unit/test_pdm_translator.bzl
+++ b/tests/unit/test_pdm_translator.bzl
@@ -119,7 +119,7 @@ def _test_pdm_package_with_groups_dev_included_impl(env, target):
     ])
 
     # Dev group included: both should be pinned
-    result = translate_pdm(project, lock, _lock_model(dependency_groups = ["default", "development:dev"]))
+    result = translate_pdm(project, lock, _lock_model(dependency_groups = ["default", "group:dev"]))
     env.expect.that_collection(result["pins"].keys()).contains_at_least(["requests", "pytest"])
 
 def _test_pdm_package_with_groups_dev_included(name):

--- a/tests/unit/test_pylock_translator.bzl
+++ b/tests/unit/test_pylock_translator.bzl
@@ -313,7 +313,7 @@ def _test_pylock_development_group_impl(env, target):
     result = translate_pylock(
         _LOCK_WITH_GROUPS,
         _PROJECT_WITH_GROUPS,
-        _lock_model(dependency_groups = ["development:dev"]),
+        _lock_model(dependency_groups = ["group:dev"]),
     )
     names = _pkg_names(result)
     env.expect.that_collection(names).contains_exactly(["mypy"])
@@ -329,7 +329,7 @@ def _test_pylock_all_development_groups_impl(env, target):
     result = translate_pylock(
         _LOCK_WITH_GROUPS,
         _PROJECT_WITH_GROUPS,
-        _lock_model(dependency_groups = ["development:*"]),
+        _lock_model(dependency_groups = ["group:*"]),
     )
     names = _pkg_names(result)
     env.expect.that_collection(names).contains_at_least(["mypy", "typing-extensions", "ruff"])
@@ -345,7 +345,7 @@ def _test_pylock_include_group_impl(env, target):
     result = translate_pylock(
         _LOCK_WITH_GROUPS,
         _PROJECT_WITH_GROUPS,
-        _lock_model(dependency_groups = ["development:all"]),
+        _lock_model(dependency_groups = ["group:all"]),
     )
     names = _pkg_names(result)
     env.expect.that_collection(names).contains_at_least(["ruff", "typing-extensions"])

--- a/tests/unit/test_uv_translator.bzl
+++ b/tests/unit/test_uv_translator.bzl
@@ -270,7 +270,7 @@ def _test_uv_dev_dependencies_pep735_impl(env, target):
         _vpkg("my-app", dev_deps = {"dev": [_dep("b")]}),
         _pkg("b", "2.0", wheels = [_whl("b-2.0-py3-none-any.whl", "b")]),
     ])
-    result = translate_uv(project, lock, _lock_model(dependency_groups = ["default", "development:dev"]))
+    result = translate_uv(project, lock, _lock_model(dependency_groups = ["default", "group:dev"]))
     env.expect.that_int(len(result["packages"])).equals(1)
     env.expect.that_collection(result["packages"].keys()).contains("b@2.0")
 
@@ -361,7 +361,7 @@ def _test_uv_group_variants_impl(env, target):
             {"package": "my-app", "group": "test-slow"},
         ]],
     )
-    result = translate_uv(project, lock, _lock_model(dependency_groups = ["development:*"]))
+    result = translate_uv(project, lock, _lock_model(dependency_groups = ["group:*"]))
     env.expect.that_int(len(result.get("variants", []))).equals(1)
     vs = result["variants"][0]
     names = ["{}_{}".format(item["kind"], item.get("name", "")) for item in vs["items"]]


### PR DESCRIPTION
- **refactor: rename "development:" dependency group prefix to "group:"**
- **fix(pdm): correctly parse tool.pdm.dev-dependencies**
- **fix(pdm): enforce PDM strictness for pep 735 dependency groups**
- **feat(poetry): add PEP 735 dependency-groups support**
- **fix(poetry): validate PEP 735 and legacy group names don't overlap**
- **fix(poetry): allow PEP 735 and legacy groups to coexist**
