### PR TITLE
feat: various tweaks for reproducible wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
     name: Repro check
     needs: [cross-build]
     runs-on: ubuntu-latest
-    continue-on-error: true
+
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/ext_meson.md
+++ b/docs/ext_meson.md
@@ -9,8 +9,8 @@ Meson build backend for rules_pycross.
 <pre>
 load("@rules_pycross//pycross/backends:meson.bzl", "meson_build")
 
-meson_build(<a href="#meson_build-name">name</a>, <a href="#meson_build-deps">deps</a>, <a href="#meson_build-data">data</a>, <a href="#meson_build-build_deps">build_deps</a>, <a href="#meson_build-build_env">build_env</a>, <a href="#meson_build-config_settings">config_settings</a>, <a href="#meson_build-copts">copts</a>, <a href="#meson_build-linkopts">linkopts</a>,
-            <a href="#meson_build-meson_properties">meson_properties</a>, <a href="#meson_build-native_deps">native_deps</a>, <a href="#meson_build-path_tools">path_tools</a>, <a href="#meson_build-pkg_config_files">pkg_config_files</a>, <a href="#meson_build-post_build_hooks">post_build_hooks</a>,
+meson_build(<a href="#meson_build-name">name</a>, <a href="#meson_build-deps">deps</a>, <a href="#meson_build-data">data</a>, <a href="#meson_build-allow_native_exec">allow_native_exec</a>, <a href="#meson_build-build_deps">build_deps</a>, <a href="#meson_build-build_env">build_env</a>, <a href="#meson_build-config_settings">config_settings</a>, <a href="#meson_build-copts">copts</a>,
+            <a href="#meson_build-linkopts">linkopts</a>, <a href="#meson_build-meson_properties">meson_properties</a>, <a href="#meson_build-native_deps">native_deps</a>, <a href="#meson_build-path_tools">path_tools</a>, <a href="#meson_build-pkg_config_files">pkg_config_files</a>, <a href="#meson_build-post_build_hooks">post_build_hooks</a>,
             <a href="#meson_build-pre_build_hooks">pre_build_hooks</a>, <a href="#meson_build-pre_build_patches">pre_build_patches</a>, <a href="#meson_build-resource_size">resource_size</a>, <a href="#meson_build-sdist">sdist</a>, <a href="#meson_build-site_hooks">site_hooks</a>, <a href="#meson_build-source_dir">source_dir</a>,
             <a href="#meson_build-target_environment">target_environment</a>, <a href="#meson_build-tool_deps">tool_deps</a>, <a href="#meson_build-whldir_name">whldir_name</a>)
 </pre>
@@ -25,6 +25,7 @@ meson_build(<a href="#meson_build-name">name</a>, <a href="#meson_build-deps">de
 | <a id="meson_build-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="meson_build-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="meson_build-data"></a>data |  Additional data and dependencies used by the build. These files are made available in the sandbox and can be referenced via $(location) in build_env and config_settings values.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="meson_build-allow_native_exec"></a>allow_native_exec |  Allow Meson to run compiled test binaries on the build host during feature detection. When False (default), Meson always uses compile-only checks, producing reproducible builds regardless of host. Set to True only if you need host-specific optimizations and don't require cross-host reproducibility.   | Boolean | optional |  `False`  |
 | <a id="meson_build-build_deps"></a>build_deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="meson_build-build_env"></a>build_env |  Environment variables passed to the sdist build. Values are subject to 'Make variable' and $(location) expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="meson_build-config_settings"></a>config_settings |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> List of strings</a> | optional |  `{}`  |

--- a/modules/backend_maturin/private/tools/maturin_builder.py
+++ b/modules/backend_maturin/private/tools/maturin_builder.py
@@ -41,7 +41,23 @@ def _get_cargo_dir() -> Path:
     return Path(".")
 
 
+def _disable_sbom() -> None:
+    """Disable maturin SBOM generation for reproducibility.
+
+    The generated CycloneDX SBOM contains non-reproducible data (random UUIDs,
+    timestamps, and absolute sandbox paths). Maturin only supports disabling
+    SBOM via pyproject.toml, so we patch it in the extracted sdist.
+    """
+    pyproject = Path("pyproject.toml")
+    if pyproject.exists():
+        content = pyproject.read_text()
+        if "[tool.maturin.sbom]" not in content:
+            content += "\n[tool.maturin.sbom]\nrust = false\nauditwheel = false\n"
+            pyproject.write_text(content)
+
+
 def pre_build(ctx):
+    _disable_sbom()
     cargo_dir = _get_cargo_dir()
     rust_common.configure_rust_env(ctx, cargo_dir, is_maturin=True)
 

--- a/modules/backend_maturin/private/tools/rust_common.py
+++ b/modules/backend_maturin/private/tools/rust_common.py
@@ -246,6 +246,18 @@ def configure_rust_env(ctx, cargo_dir: Path, is_maturin: bool = False):
 
     sysroot_dir_str = str(sysroot_dir.absolute())
 
+    # Compute a host-independent toolchain identifier for the metadata hash.
+    # The cross_repo_name contains the host triple (e.g. "rust_linux_x86_64__")
+    # which differs across hosts. We strip it, keeping only the target triple
+    # and version suffix (e.g. "aarch64-apple-darwin__nightly_toolchains__2025-01-02").
+    _toolchain_id = ""
+    if cross_repo_name:
+        parts = cross_repo_name.split(target_triple)
+        if len(parts) > 1:
+            _toolchain_id = target_triple + parts[-1]
+        else:
+            _toolchain_id = cross_repo_name
+
     wrapper_content = textwrap.dedent(f"""\
     #!/bin/sh
     "exec" "{ctx.exec_python.absolute()}" "-S" "$0" "$@"
@@ -308,7 +320,10 @@ def configure_rust_env(ctx, cargo_dir: Path, is_maturin: bool = False):
     if crate_name:
         cfg_flags.sort()
         crate_types.sort()
-        metadata_input = f"{{crate_name}}\\0{{target_triple}}\\0{{'|'.join(crate_types)}}\\0{{'|'.join(cfg_flags)}}"
+        # Include a toolchain version identifier so upgrades produce different
+        # hashes. We use the target triple + version suffix from the rules_rust
+        # repo name, which is host-independent.
+        metadata_input = f"{repr(_toolchain_id)}\\0{{crate_name}}\\0{{target_triple}}\\0{{'|'.join(crate_types)}}\\0{{'|'.join(cfg_flags)}}"
         stable_metadata = hashlib.sha256(metadata_input.encode()).hexdigest()[:16]
         i = 0
         while i < len(final_args):

--- a/modules/backend_maturin/private/tools/rust_common.py
+++ b/modules/backend_maturin/private/tools/rust_common.py
@@ -175,6 +175,10 @@ def configure_rust_env(ctx, cargo_dir: Path, is_maturin: bool = False):
     if is_maturin:
         # Prevent maturin from attempting to auto-bootstrap Rust via puccinialin
         ctx.build_env["MATURIN_NO_INSTALL_RUST"] = "1"
+        # Disable SBOM generation. The generated CycloneDX JSON contains
+        # non-reproducible data (random UUIDs, timestamps, and absolute
+        # sandbox paths), making wheels non-reproducible across builds.
+        ctx.build_env["MATURIN_PEP517_ARGS"] = "--no-sbom"
 
     ctx.build_env["CARGO_BUILD_TARGET"] = target_triple
 

--- a/modules/backend_maturin/private/tools/rust_common.py
+++ b/modules/backend_maturin/private/tools/rust_common.py
@@ -175,10 +175,6 @@ def configure_rust_env(ctx, cargo_dir: Path, is_maturin: bool = False):
     if is_maturin:
         # Prevent maturin from attempting to auto-bootstrap Rust via puccinialin
         ctx.build_env["MATURIN_NO_INSTALL_RUST"] = "1"
-        # Disable SBOM generation. The generated CycloneDX JSON contains
-        # non-reproducible data (random UUIDs, timestamps, and absolute
-        # sandbox paths), making wheels non-reproducible across builds.
-        ctx.build_env["MATURIN_PEP517_ARGS"] = "--no-sbom"
 
     ctx.build_env["CARGO_BUILD_TARGET"] = target_triple
 

--- a/modules/backend_maturin/private/tools/rust_common.py
+++ b/modules/backend_maturin/private/tools/rust_common.py
@@ -276,6 +276,11 @@ def configure_rust_env(ctx, cargo_dir: Path, is_maturin: bool = False):
         for link_arg in ldflags_args:
             final_args.extend(["-C", f"link-arg={{link_arg}}"])
 
+    # Remap sandbox paths for reproducible builds
+    prefix = {repr(str(ctx.prefix))}
+    final_args.extend(["--remap-path-prefix", f"{{prefix}}/="])
+    final_args.extend(["--remap-path-prefix", f"{{prefix}}="])
+
     os.execv(real_rustc, [real_rustc] + final_args)
     """)
 

--- a/modules/backend_maturin/private/tools/rust_common.py
+++ b/modules/backend_maturin/private/tools/rust_common.py
@@ -249,6 +249,7 @@ def configure_rust_env(ctx, cargo_dir: Path, is_maturin: bool = False):
     wrapper_content = textwrap.dedent(f"""\
     #!/bin/sh
     "exec" "{ctx.exec_python.absolute()}" "-S" "$0" "$@"
+    import hashlib
     import os
     import sys
 
@@ -280,6 +281,40 @@ def configure_rust_env(ctx, cargo_dir: Path, is_maturin: bool = False):
     prefix = {repr(str(ctx.prefix))}
     final_args.extend(["--remap-path-prefix", f"{{prefix}}/="])
     final_args.extend(["--remap-path-prefix", f"{{prefix}}="])
+
+    # Force single codegen unit for deterministic LLVM module IDs.
+    # With multiple CGUs, LLVM generates non-deterministic module ID suffixes
+    # (.llvm.NNNNN) in symbol names that can vary across build hosts.
+    if is_target:
+        final_args.extend(["-C", "codegen-units=1"])
+
+    # Normalize -C metadata for cross-host reproducibility.
+    # Cargo's metadata hash includes host-specific info (host triple from
+    # rustc --version -v, paths to host-compiled build scripts, etc.).
+    # We replace it with a deterministic hash derived from host-independent
+    # inputs so symbol hashes are identical regardless of build host.
+    # We leave -C extra-filename alone so Cargo can still find its files.
+    crate_name = None
+    crate_types = []
+    cfg_flags = []
+    for i, arg in enumerate(final_args):
+        if arg == "--crate-name" and i + 1 < len(final_args):
+            crate_name = final_args[i + 1]
+        elif arg == "--crate-type" and i + 1 < len(final_args):
+            crate_types.append(final_args[i + 1])
+        elif arg == "--cfg" and i + 1 < len(final_args):
+            cfg_flags.append(final_args[i + 1])
+
+    if crate_name:
+        cfg_flags.sort()
+        crate_types.sort()
+        metadata_input = f"{{crate_name}}\\0{{target_triple}}\\0{{'|'.join(crate_types)}}\\0{{'|'.join(cfg_flags)}}"
+        stable_metadata = hashlib.sha256(metadata_input.encode()).hexdigest()[:16]
+        i = 0
+        while i < len(final_args):
+            if final_args[i] == "-C" and i + 1 < len(final_args) and final_args[i + 1].startswith("metadata="):
+                final_args[i + 1] = f"metadata={{stable_metadata}}"
+            i += 1
 
     os.execv(real_rustc, [real_rustc] + final_args)
     """)

--- a/pycross/hooks/BUILD.bazel
+++ b/pycross/hooks/BUILD.bazel
@@ -8,3 +8,9 @@ alias(
     actual = "//pycross/private/build/tools:repair_wheel_hook",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "scrub_build_paths",
+    actual = "//pycross/private/build/tools:scrub_build_paths",
+    visibility = ["//visibility:public"],
+)

--- a/pycross/private/build/rules/meson_build.bzl
+++ b/pycross/private/build/rules/meson_build.bzl
@@ -35,12 +35,15 @@ def _meson_build_impl(ctx):
     tool_executables.extend(resolve_path_tools(ctx))
 
     # 2. Extract CC environment
+    meson_properties = dict(ctx.attr.meson_properties)
+    if ctx.attr.allow_native_exec:
+        meson_properties["_allow_native_exec"] = "true"
     cc_layer = extract_cc_layer(
         ctx,
         native_deps = ctx.attr.native_deps,
         copts = ctx.attr.copts,
         linkopts = ctx.attr.linkopts,
-        meson_properties = ctx.attr.meson_properties,
+        meson_properties = meson_properties,
     )
 
     additional_build_deps = []
@@ -92,6 +95,14 @@ meson_build = rule(
             cfg = pycross_exec_platform_transition,
         ),
         "meson_properties": attr.string_dict(),
+        "allow_native_exec": attr.bool(
+            doc = "Allow Meson to run compiled test binaries on the build host during " +
+                  "feature detection. When False (default), Meson always uses compile-only " +
+                  "checks, producing reproducible builds regardless of host. Set to True " +
+                  "only if you need host-specific optimizations and don't require " +
+                  "cross-host reproducibility.",
+            default = False,
+        ),
         "_builder": attr.label(
             default = "//pycross/private/build/tools:meson_builder",
             executable = True,

--- a/pycross/private/build/tools/BUILD.bazel
+++ b/pycross/private/build/tools/BUILD.bazel
@@ -87,3 +87,9 @@ py_binary(
         ":env_utils",
     ],
 )
+
+py_binary(
+    name = "scrub_build_paths",
+    srcs = ["scrub_build_paths.py"],
+    imports = ["../../../.."],
+)

--- a/pycross/private/build/tools/cmake_builder.py
+++ b/pycross/private/build/tools/cmake_builder.py
@@ -92,6 +92,11 @@ def generate_toolchain_file(ctx: BuildContext, cc_config: dict) -> None:
             "# strip utility cannot handle cross-compiled binaries (e.g. Mach-O).",
             "# Bazel/rules_pycross handles stripping separately if needed.",
             'set(CMAKE_STRIP "true" CACHE STRING "" FORCE)',
+            "",
+            "# Normalize shared library permissions across platforms. Without this,",
+            "# macOS builds install .so files with the execute bit (0755) while",
+            "# Linux/Debian builds strip it (0644), breaking wheel reproducibility.",
+            'set(CMAKE_INSTALL_SO_NO_EXE 1 CACHE BOOL "" FORCE)',
         ]
     )
 

--- a/pycross/private/build/tools/meson_utils.py
+++ b/pycross/private/build/tools/meson_utils.py
@@ -42,6 +42,17 @@ def generate_cross_ini(ctx: BuildContext, cc_config: Optional[Dict[str, Any]] = 
     c_args = shlex.split(cflags) if cflags else []
     cxx_args = shlex.split(cxxflags) if cxxflags else []
 
+    # Filter linker flags (-Wl,...) out of c_args/cxx_args into link args.
+    #
+    # Bazel's CC toolchain sometimes leaks linker flags (e.g. -Wl,-s) into
+    # CFLAGS. These are harmless during normal compilation but break Meson's
+    # compile-only feature detection, which uses -Werror internally. Clang
+    # reports "linker input unused" as an error under -Werror, causing feature
+    # checks (like NEON_VFPV4) to fail even when the compiler supports them.
+    leaked_link_args = [a for a in c_args if a.startswith("-Wl,")]
+    c_args = [a for a in c_args if not a.startswith("-Wl,")]
+    cxx_args = [a for a in cxx_args if not a.startswith("-Wl,")]
+
     # Use LDFLAGS (not LDSHAREDFLAGS) for Meson's c_link_args.
     #
     # LDSHAREDFLAGS comes from Bazel's cpp_link_dynamic_library action with
@@ -60,6 +71,7 @@ def generate_cross_ini(ctx: BuildContext, cc_config: Optional[Dict[str, Any]] = 
     # uses LDSHARED (CC + LDSHAREDFLAGS) directly and needs it.
     ldflags = get_var("LDFLAGS", "")
     c_link_args = shlex.split(ldflags) if ldflags else []
+    c_link_args.extend(leaked_link_args)
 
     # Add C++ static runtime libraries by full path, replicating Bazel's
     # static_link_cpp_runtimes behavior.
@@ -93,6 +105,22 @@ def generate_cross_ini(ctx: BuildContext, cc_config: Optional[Dict[str, Any]] = 
 
     target_system = cc_config["target_os"]
     target_cpu = cc_config["target_cpu"]
+
+    # Ensure consistent CPU feature baseline across different host compilers.
+    #
+    # The macOS-native clang binary (darwin-arm64) may default to a higher
+    # ARM feature level than the Linux cross-compiler (linux-amd64) when
+    # targeting aarch64-apple-darwin. This causes Meson's compile-only feature
+    # detection to produce different results on different build hosts.
+    #
+    # Explicitly setting -mcpu=apple-m1 (the minimum Apple Silicon baseline)
+    # makes both compiler binaries agree on the architecture features,
+    # producing identical feature detection and identical binaries.
+    if target_system == "darwin" and target_cpu == "aarch64":
+        has_mcpu = any(a.startswith("-mcpu=") or a == "-mcpu" for a in c_args)
+        if not has_mcpu:
+            c_args.append("-mcpu=apple-m1")
+            cxx_args.append("-mcpu=apple-m1")
 
     # Locate or create pkgconfig directory inside the build environment
     pkgconfig_dir = ctx.sdist_dir / "pkgconfig"

--- a/pycross/private/build/tools/meson_utils.py
+++ b/pycross/private/build/tools/meson_utils.py
@@ -112,6 +112,25 @@ def generate_cross_ini(ctx: BuildContext, cc_config: Optional[Dict[str, Any]] = 
 
     is_cross = ctx.exec_python != ctx.target_python
 
+    # By default, always tell Meson it needs an exe wrapper and should skip
+    # sanity checks. This prevents Meson from running compiled test binaries
+    # on the build host, which would make feature detection (e.g., SIMD
+    # capabilities) depend on the host rather than the hermetic toolchain.
+    # This is critical for reproducible cross-host builds.
+    #
+    # When allow_native_exec is set (via meson_properties), fall back to the
+    # old behavior of allowing native execution when exec == target platform.
+    allow_native_exec = False
+    if cc_config:
+        allow_native_exec = cc_config.get("meson_properties", {}).get("_allow_native_exec") == "true"
+
+    if allow_native_exec:
+        needs_exe_wrapper = is_cross
+        skip_sanity_check = is_cross
+    else:
+        needs_exe_wrapper = True
+        skip_sanity_check = True
+
     # Compute longdouble_format from target platform. Meson auto-detection
     # can't work in cross builds, so we always set this explicitly to keep
     # native and cross paths identical.
@@ -163,10 +182,14 @@ def generate_cross_ini(ctx: BuildContext, cc_config: Optional[Dict[str, Any]] = 
 
     binaries_section = "\n".join(binaries_lines)
 
-    # Build additional [properties] lines from meson_properties
+    # Build additional [properties] lines from meson_properties.
+    # Filter out internal properties (prefixed with _) that are used for
+    # framework configuration and should not appear in the cross.ini.
     extra_properties_lines = []
     if cc_config:
         for key, value in cc_config.get("meson_properties", {}).items():
+            if key.startswith("_"):
+                continue
             if "$$EXT_BUILD_ROOT$$" in value:
                 resolved = Path(replace_placeholder(ctx.prefix, value)).absolute().as_posix()
             else:
@@ -186,8 +209,8 @@ cpp_link_args = {format_meson_list(c_link_args)}
 pkg_config_path = '{abs_pkgconfig_dir}'
 
 [properties]
-needs_exe_wrapper = {str(is_cross).lower()}
-skip_sanity_check = {str(is_cross).lower()}
+needs_exe_wrapper = {str(needs_exe_wrapper).lower()}
+skip_sanity_check = {str(skip_sanity_check).lower()}
 longdouble_format = '{longdouble_format}'
 pkg_config_libdir = '{abs_pkgconfig_dir}'
 {extra_properties_str}

--- a/pycross/private/build/tools/meson_utils.py
+++ b/pycross/private/build/tools/meson_utils.py
@@ -113,14 +113,15 @@ def generate_cross_ini(ctx: BuildContext, cc_config: Optional[Dict[str, Any]] = 
     # targeting aarch64-apple-darwin. This causes Meson's compile-only feature
     # detection to produce different results on different build hosts.
     #
-    # Explicitly setting -mcpu=apple-m1 (the minimum Apple Silicon baseline)
-    # makes both compiler binaries agree on the architecture features,
-    # producing identical feature detection and identical binaries.
+    # We default to apple-m1 (the minimum Apple Silicon baseline, supporting
+    # all M1/M2/M3/M4 chips). Override via meson_properties _mcpu or by
+    # passing -mcpu=<value> in CFLAGS/copts.
     if target_system == "darwin" and target_cpu == "aarch64":
         has_mcpu = any(a.startswith("-mcpu=") or a == "-mcpu" for a in c_args)
         if not has_mcpu:
-            c_args.append("-mcpu=apple-m1")
-            cxx_args.append("-mcpu=apple-m1")
+            mcpu = cc_config.get("meson_properties", {}).get("_mcpu", "apple-m1")
+            c_args.append(f"-mcpu={mcpu}")
+            cxx_args.append(f"-mcpu={mcpu}")
 
     # Locate or create pkgconfig directory inside the build environment
     pkgconfig_dir = ctx.sdist_dir / "pkgconfig"

--- a/pycross/private/build/tools/meson_utils.py
+++ b/pycross/private/build/tools/meson_utils.py
@@ -197,6 +197,12 @@ system = '{target_system}'
 cpu_family = '{target_cpu}'
 cpu = '{target_cpu}'
 endian = 'little'
+
+[build_machine]
+system = '{target_system}'
+cpu_family = '{target_cpu}'
+cpu = '{target_cpu}'
+endian = 'little'
 """
 
     # Write the cross file into the cc_layer directory

--- a/pycross/private/build/tools/scrub_build_paths.py
+++ b/pycross/private/build/tools/scrub_build_paths.py
@@ -1,0 +1,63 @@
+"""Post-build hook to scrub sandbox paths from specific files inside a wheel.
+
+Usage: Set the following environment variables before invoking this hook:
+  PYCROSS_WHEEL_FILE       - Path to the wheel file to process.
+  PYCROSS_WHEEL_OUTPUT_DIR - Directory to write the modified wheel to.
+  PYCROSS_BAZEL_ROOT       - The sandbox prefix to strip.
+  PYCROSS_SCRUB_PATHS      - Comma-separated list of file paths within the wheel
+                             to scrub (e.g. "numpy/__config__.py,contourpy/util/_build_config.py").
+
+The hook strips absolute sandbox paths, Bazel output directory prefixes
+(bazel-out/<config>/bin/), and external/ prefixes from the specified files,
+making build metadata reproducible across different build hosts.
+"""
+
+import os
+import re
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+
+def main():
+    wheel_file = Path(os.environ["PYCROSS_WHEEL_FILE"])
+    output_dir = Path(os.environ["PYCROSS_WHEEL_OUTPUT_DIR"])
+    prefix = os.environ["PYCROSS_BAZEL_ROOT"]
+    scrub_paths_raw = os.environ.get("PYCROSS_SCRUB_PATHS", "")
+
+    if not scrub_paths_raw:
+        print("PYCROSS_SCRUB_PATHS not set, nothing to scrub", file=sys.stderr)
+        shutil.copy2(str(wheel_file), str(output_dir / wheel_file.name))
+        return
+
+    scrub_paths = {p.strip() for p in scrub_paths_raw.split(",") if p.strip()}
+    prefix_with_slash = prefix + "/"
+    bazel_out_re = re.compile(r"bazel-out/[^/]+/bin/")
+    external_re = re.compile(r"external/")
+
+    output_wheel = output_dir / wheel_file.name
+    modified = False
+
+    with zipfile.ZipFile(wheel_file, "r") as zin, zipfile.ZipFile(output_wheel, "w") as zout:
+        for info in zin.infolist():
+            data = zin.read(info.filename)
+            if info.filename in scrub_paths:
+                text = data.decode("utf-8")
+                text = text.replace(prefix_with_slash, "")
+                text = text.replace(prefix, "")
+                text = bazel_out_re.sub("", text)
+                text = external_re.sub("", text)
+                data = text.encode("utf-8")
+                modified = True
+                print(f"Scrubbed build paths from {info.filename}", file=sys.stderr)
+            zout.writestr(info, data)
+
+    if modified:
+        print(f"Wrote scrubbed wheel to {output_wheel}", file=sys.stderr)
+    else:
+        print(f"No matching files found to scrub in {wheel_file.name}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/pycross/private/build/tools/utils/cc_toolchain.py
+++ b/pycross/private/build/tools/utils/cc_toolchain.py
@@ -99,15 +99,6 @@ def wrap_compiler(lang: str, cc_exe: str, cflags: str, python_exe: Path, bin_dir
             linker_abs_path = str(linker_path.absolute())
             break
 
-    # Extract macOS deployment target from wrapper flags for platform_version.
-    # This is needed when using lld for Mach-O linking — lld requires an
-    # explicit -platform_version flag, unlike Apple's ld64.
-    macos_version = None
-    for flag in wrapper_flags:
-        if flag.startswith("-mmacosx-version-min="):
-            macos_version = flag.split("=", 1)[1]
-            break
-
     with open(wrapper_path, "w") as f:
         f.write(
             textwrap.dedent(
@@ -120,7 +111,6 @@ def wrap_compiler(lang: str, cc_exe: str, cflags: str, python_exe: Path, bin_dir
                 cc_exe = {repr(cc_exe)}
                 wrapper_flags = {repr(wrapper_flags)}
                 linker_abs_path = {repr(linker_abs_path)}
-                macos_version = {repr(macos_version)}
                 
                 filtered_args = []
                 is_link = True
@@ -134,10 +124,6 @@ def wrap_compiler(lang: str, cc_exe: str, cflags: str, python_exe: Path, bin_dir
                 extra_flags = []
                 if is_link and linker_abs_path:
                     extra_flags.append(f"-fuse-ld={{linker_abs_path}}")
-                    # Modern LLD requires explicit platform version for Mach-O target
-                    if macos_version and "aarch64-apple-darwin" in " ".join(wrapper_flags):
-                        v = macos_version + ".0" if macos_version.count(".") < 2 else macos_version
-                        extra_flags.append(f"-Wl,-platform_version,macos,{{v}},{{v}}")
 
                 os.execv(cc_exe, [cc_exe] + wrapper_flags + extra_flags + filtered_args)
                 """

--- a/pycross/private/build/tools/utils/cc_toolchain.py
+++ b/pycross/private/build/tools/utils/cc_toolchain.py
@@ -53,7 +53,7 @@ def parse_ar_and_guess_ranlib(ar: str | None) -> Tuple[List[str], Path | None]:
 
 def get_wrapper_flags(cflags: str) -> List[str]:
     """Extract target and sysroot flags to forward to compiler wrappers."""
-    possible_flags = ["-target", "--target", "--sysroot", "-isysroot"]
+    possible_flags = ["-target", "--target", "--sysroot", "-isysroot", "-mmacosx-version-min"]
     result = []
     split_cflags = shlex.split(cflags)
     for i, flag in enumerate(split_cflags):
@@ -88,6 +88,17 @@ def wrap_compiler(lang: str, cc_exe: str, cflags: str, python_exe: Path, bin_dir
     wrapper_flags = get_wrapper_flags(cflags)
     wrapper_path = bin_dir / wrapper_name
 
+    # Find the LLVM linker binary next to the compiler. This path is injected
+    # into the wrapper for link invocations so that Meson's feature detection
+    # link tests (compiler.links()) use the correct cross-linker instead of
+    # the system ld.bfd, which can't produce Mach-O for darwin targets.
+    linker_abs_path = None
+    for linker_candidate in ("ld64.lld", "ld.lld"):
+        linker_path = cc_path.parent / linker_candidate
+        if linker_path.exists():
+            linker_abs_path = str(linker_path.absolute())
+            break
+
     with open(wrapper_path, "w") as f:
         f.write(
             textwrap.dedent(
@@ -99,14 +110,25 @@ def wrap_compiler(lang: str, cc_exe: str, cflags: str, python_exe: Path, bin_dir
 
                 cc_exe = {repr(cc_exe)}
                 wrapper_flags = {repr(wrapper_flags)}
+                linker_abs_path = {repr(linker_abs_path)}
                 
                 filtered_args = []
+                is_link = True
                 for arg in sys.argv[1:]:
+                    if arg == "-c":
+                        is_link = False
                     if arg in ("-Wl,--start-group", "-Wl,--end-group", "-Wl,-start_group", "-Wl,-end_group", "-Wl,--as-needed", "-Wl,--allow-shlib-undefined", "-Wl,-O1"):
                         continue
                     filtered_args.append(arg)
 
-                os.execv(cc_exe, [cc_exe] + wrapper_flags + filtered_args)
+                extra_flags = []
+                if is_link and linker_abs_path:
+                    extra_flags.append(f"-fuse-ld={{linker_abs_path}}")
+                    # Modern LLD requires explicit platform version for Mach-O target
+                    if "aarch64-apple-darwin" in " ".join(wrapper_flags):
+                         extra_flags.append("-Wl,-platform_version,macos,14.0.0,14.0.0")
+
+                os.execv(cc_exe, [cc_exe] + wrapper_flags + extra_flags + filtered_args)
                 """
             )
         )

--- a/pycross/private/build/tools/utils/cc_toolchain.py
+++ b/pycross/private/build/tools/utils/cc_toolchain.py
@@ -99,6 +99,15 @@ def wrap_compiler(lang: str, cc_exe: str, cflags: str, python_exe: Path, bin_dir
             linker_abs_path = str(linker_path.absolute())
             break
 
+    # Extract macOS deployment target from wrapper flags for platform_version.
+    # This is needed when using lld for Mach-O linking — lld requires an
+    # explicit -platform_version flag, unlike Apple's ld64.
+    macos_version = None
+    for flag in wrapper_flags:
+        if flag.startswith("-mmacosx-version-min="):
+            macos_version = flag.split("=", 1)[1]
+            break
+
     with open(wrapper_path, "w") as f:
         f.write(
             textwrap.dedent(
@@ -111,6 +120,7 @@ def wrap_compiler(lang: str, cc_exe: str, cflags: str, python_exe: Path, bin_dir
                 cc_exe = {repr(cc_exe)}
                 wrapper_flags = {repr(wrapper_flags)}
                 linker_abs_path = {repr(linker_abs_path)}
+                macos_version = {repr(macos_version)}
                 
                 filtered_args = []
                 is_link = True
@@ -125,8 +135,9 @@ def wrap_compiler(lang: str, cc_exe: str, cflags: str, python_exe: Path, bin_dir
                 if is_link and linker_abs_path:
                     extra_flags.append(f"-fuse-ld={{linker_abs_path}}")
                     # Modern LLD requires explicit platform version for Mach-O target
-                    if "aarch64-apple-darwin" in " ".join(wrapper_flags):
-                         extra_flags.append("-Wl,-platform_version,macos,14.0.0,14.0.0")
+                    if macos_version and "aarch64-apple-darwin" in " ".join(wrapper_flags):
+                        v = macos_version + ".0" if macos_version.count(".") < 2 else macos_version
+                        extra_flags.append(f"-Wl,-platform_version,macos,{{v}},{{v}}")
 
                 os.execv(cc_exe, [cc_exe] + wrapper_flags + extra_flags + filtered_args)
                 """

--- a/pycross/private/build/tools/utils/lifecycle.py
+++ b/pycross/private/build/tools/utils/lifecycle.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
 from pycross.private.build.tools.utils.cc_toolchain import setup_cc_layer
@@ -40,6 +41,7 @@ class BackendStrategy:
     setup_venv: Callable[[BuildContext], None] = build_standard_venv
     pre_build: Callable[[BuildContext], None] = lambda ctx: None
     prepare_env: Callable[[BuildContext], None] = lambda ctx: None
+    post_build: Callable[["BuildContext", Path], Path] = lambda ctx, whl: whl
 
 
 def _apply_pre_build_patches(ctx: BuildContext) -> None:
@@ -104,5 +106,6 @@ def run_standard_build_lifecycle(config_path: str, strategy: BackendStrategy) ->
     strategy.prepare_env(ctx)
 
     wheel_file = run_pep517_build(ctx)
+    wheel_file = strategy.post_build(ctx, wheel_file)
     wheel_file = run_post_build_hooks(ctx, wheel_file)
     print(f"Successfully built wheel: {wheel_file}")

--- a/pycross/private/build/tools/utils/venv_utils.py
+++ b/pycross/private/build/tools/utils/venv_utils.py
@@ -51,6 +51,10 @@ def _link_merge_multiple(src_dirs: list[Path], dst_dir: Path):
                 _link_merge_multiple(items, target)
             else:
                 # Conflict: mixed file/dir or multiple files. First one wins.
+                print(
+                    f"WARNING: link merge conflict for '{name}': using {items[0]}, ignoring {items[1:]}",
+                    file=sys.stderr,
+                )
                 target.symlink_to(items[0])
 
 

--- a/pycross/private/build/tools/utils/venv_utils.py
+++ b/pycross/private/build/tools/utils/venv_utils.py
@@ -18,6 +18,42 @@ def find_site_dir(env_dir: Path) -> Path:
         raise ValueError(f"Cannot find site-packages under {env_dir}")
 
 
+def _link_merge_multiple(src_dirs: list[Path], dst_dir: Path):
+    """Merge contents of multiple src_dirs into dst_dir using symlinks.
+    
+    Link only as deeply as necessary. If a top-level directory/file is unique
+    across all sources, it is symlinked directly. If there are conflicts,
+    directories are merged recursively.
+    """
+    from collections import defaultdict
+    
+    entries = defaultdict(list)
+    for src in src_dirs:
+        if not src.exists():
+            continue
+        for item in src.iterdir():
+            entries[item.name].append(item)
+
+    for name, items in entries.items():
+        target = dst_dir / name
+        
+        # Handle pre-existing files in dst_dir (e.g. .pth files written before this)
+        if target.exists() or target.is_symlink():
+            if target.is_dir() and not target.is_symlink() and all(item.is_dir() for item in items):
+                _link_merge_multiple(items, target)
+            continue
+
+        if len(items) == 1:
+            target.symlink_to(items[0])
+        else:
+            if all(item.is_dir() for item in items):
+                target.mkdir()
+                _link_merge_multiple(items, target)
+            else:
+                # Conflict: mixed file/dir or multiple files. First one wins.
+                target.symlink_to(items[0])
+
+
 def write_base_prefix_pth(
     site_dir: Path, prefix: Path, base_prefix: Optional[Path], platbase_prefix: Optional[Path]
 ) -> None:
@@ -121,10 +157,7 @@ def build_standard_venv(ctx: BuildContext) -> None:
 
     write_base_prefix_pth(site_dir, ctx.prefix, base_prefix, platbase_prefix)
 
-    with open(site_dir / "deps.pth", "w") as f:
-        for dep_path in ctx.python_paths:
-            rel_dep_path = os.path.relpath(dep_path, site_dir)
-            f.write(f"import os, site; site.addsitedir(os.path.join(sitedir, {rel_dep_path!r}))\n")
+    _link_merge_multiple(ctx.python_paths, site_dir)
 
     # Write site_hooks to a file and .pth entry.
     # The hooks file is loaded by the python wrapper's -c handler and by
@@ -218,9 +251,8 @@ def inject_python_wrapper(ctx: BuildContext) -> None:
             import os, sys
 
             venv_site = {repr(str(site_dir.absolute()))}
-            dependency_paths = {repr(python_paths_list)}
             sdist_paths = {repr(sdist_paths)}
-            paths_to_add = [venv_site] + dependency_paths + sdist_paths
+            paths_to_add = [venv_site] + sdist_paths
             existing_pp = os.environ.get("PYTHONPATH")
             os.environ["PYTHONPATH"] = os.pathsep.join(paths_to_add) + (os.pathsep + existing_pp if existing_pp else "")
 

--- a/pycross/private/build/tools/utils/venv_utils.py
+++ b/pycross/private/build/tools/utils/venv_utils.py
@@ -20,13 +20,13 @@ def find_site_dir(env_dir: Path) -> Path:
 
 def _link_merge_multiple(src_dirs: list[Path], dst_dir: Path):
     """Merge contents of multiple src_dirs into dst_dir using symlinks.
-
+    
     Link only as deeply as necessary. If a top-level directory/file is unique
     across all sources, it is symlinked directly. If there are conflicts,
     directories are merged recursively.
     """
     from collections import defaultdict
-
+    
     entries = defaultdict(list)
     for src in src_dirs:
         if not src.exists():
@@ -218,6 +218,10 @@ def build_crossenv_venv(ctx: BuildContext) -> None:
         raise
 
     ctx.crossenv_active = True
+    
+    site_dir = find_site_dir(ctx.env_dir)
+    _link_merge_multiple(ctx.python_paths, site_dir)
+
     inject_python_wrapper(ctx)
 
 

--- a/pycross/private/build/tools/utils/venv_utils.py
+++ b/pycross/private/build/tools/utils/venv_utils.py
@@ -20,13 +20,13 @@ def find_site_dir(env_dir: Path) -> Path:
 
 def _link_merge_multiple(src_dirs: list[Path], dst_dir: Path):
     """Merge contents of multiple src_dirs into dst_dir using symlinks.
-    
+
     Link only as deeply as necessary. If a top-level directory/file is unique
     across all sources, it is symlinked directly. If there are conflicts,
     directories are merged recursively.
     """
     from collections import defaultdict
-    
+
     entries = defaultdict(list)
     for src in src_dirs:
         if not src.exists():
@@ -36,7 +36,7 @@ def _link_merge_multiple(src_dirs: list[Path], dst_dir: Path):
 
     for name, items in entries.items():
         target = dst_dir / name
-        
+
         # Handle pre-existing files in dst_dir (e.g. .pth files written before this)
         if target.exists() or target.is_symlink():
             if target.is_dir() and not target.is_symlink() and all(item.is_dir() for item in items):
@@ -234,7 +234,6 @@ def inject_python_wrapper(ctx: BuildContext) -> None:
         python_exe.unlink()
 
     site_dir = find_site_dir(ctx.env_dir)
-    python_paths_list = [str(p.absolute()) for p in ctx.python_paths]
     sdist_paths = [str(ctx.sdist_dir.absolute())]
 
     with open(python_exe, "w") as f:

--- a/pycross/private/build/tools/utils/venv_utils.py
+++ b/pycross/private/build/tools/utils/venv_utils.py
@@ -20,13 +20,13 @@ def find_site_dir(env_dir: Path) -> Path:
 
 def _link_merge_multiple(src_dirs: list[Path], dst_dir: Path):
     """Merge contents of multiple src_dirs into dst_dir using symlinks.
-    
+
     Link only as deeply as necessary. If a top-level directory/file is unique
     across all sources, it is symlinked directly. If there are conflicts,
     directories are merged recursively.
     """
     from collections import defaultdict
-    
+
     entries = defaultdict(list)
     for src in src_dirs:
         if not src.exists():
@@ -218,7 +218,7 @@ def build_crossenv_venv(ctx: BuildContext) -> None:
         raise
 
     ctx.crossenv_active = True
-    
+
     site_dir = find_site_dir(ctx.env_dir)
     _link_merge_multiple(ctx.python_paths, site_dir)
 

--- a/pycross/private/translator_common.bzl
+++ b/pycross/private/translator_common.bzl
@@ -310,10 +310,9 @@ def resolve_lock_graph(packages, pinned_package_specs, requires_python, strict_d
     lock_packages = {}
     for pkg in all_packages:
         if pkg.get("is_local", False):
-            # buildifier: disable=print
-            print("WARNING: Local package {} elided from pycross repo.".format(
-                _package_key_str(pkg["name"], pkg["version"]),
-            ))
+            # Local/editable/virtual packages are workspace members or path
+            # dependencies; they don't have downloadable artifacts so we skip
+            # them when building the pycross repo.
             continue
 
         pkg_key = _package_key_str(pkg["name"], pkg["version"])

--- a/tests/e2e/build_meson/deps/contourpy/BUILD.bazel
+++ b/tests/e2e/build_meson/deps/contourpy/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
 load("@uv//_backend:meson_build.bzl", "meson_build")
 
@@ -9,6 +10,11 @@ py_console_script_binary(
     script = "pybind11-config",
 )
 
+py_binary(
+    name = "scrub_contourpy",
+    srcs = ["scrub_contourpy.py"],
+)
+
 meson_build(
     name = "wheel",
     build_deps = [
@@ -17,9 +23,6 @@ meson_build(
         "@uv//pybind11:pkg",
         "@uv//numpy:pkg",
     ],
-    build_env = {
-        "PYCROSS_SCRUB_PATHS": "contourpy/util/_build_config.py",
-    },
     meson_properties = {
         "numpy-include-dir": "$(NUMPY_INCLUDE_DIR)",
     },
@@ -27,7 +30,7 @@ meson_build(
         "//deps/numpy:numpy_headers",
     ],
     path_tools = [":pybind11-config"],
-    post_build_hooks = ["@rules_pycross//pycross/hooks:scrub_build_paths"],
+    post_build_hooks = [":scrub_contourpy"],
     sdist = "@uv//contourpy:sdist",
     deps = [
         "@uv//numpy:pkg",

--- a/tests/e2e/build_meson/deps/contourpy/BUILD.bazel
+++ b/tests/e2e/build_meson/deps/contourpy/BUILD.bazel
@@ -17,6 +17,9 @@ meson_build(
         "@uv//pybind11:pkg",
         "@uv//numpy:pkg",
     ],
+    build_env = {
+        "PYCROSS_SCRUB_PATHS": "contourpy/util/_build_config.py",
+    },
     meson_properties = {
         "numpy-include-dir": "$(NUMPY_INCLUDE_DIR)",
     },
@@ -24,6 +27,7 @@ meson_build(
         "//deps/numpy:numpy_headers",
     ],
     path_tools = [":pybind11-config"],
+    post_build_hooks = ["@rules_pycross//pycross/hooks:scrub_build_paths"],
     sdist = "@uv//contourpy:sdist",
     deps = [
         "@uv//numpy:pkg",

--- a/tests/e2e/build_meson/deps/contourpy/scrub_contourpy.py
+++ b/tests/e2e/build_meson/deps/contourpy/scrub_contourpy.py
@@ -1,0 +1,61 @@
+"""Custom post-build hook to scrub contourpy build config.
+
+Scrubs paths and host CPU/OS metadata for reproducibility.
+"""
+
+import os
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+
+def main():
+    wheel_file = Path(os.environ["PYCROSS_WHEEL_FILE"])
+    output_dir = Path(os.environ["PYCROSS_WHEEL_OUTPUT_DIR"])
+    prefix = os.environ["PYCROSS_BAZEL_ROOT"]
+
+    prefix_with_slash = prefix + "/"
+    bazel_out_re = re.compile(r"bazel-out/[^/]+/bin/")
+    external_re = re.compile(r"external/")
+
+    # Regex to match build machine info
+    build_cpu_re = re.compile(r'(build_cpu=")[^"]+(")')
+    build_cpu_family_re = re.compile(r'(build_cpu_family=")[^"]+(")')
+    build_cpu_system_re = re.compile(r'(build_cpu_system=")[^"]+(")')
+
+    output_wheel = output_dir / wheel_file.name
+    modified = False
+
+    target_file = "contourpy/util/_build_config.py"
+
+    with zipfile.ZipFile(wheel_file, "r") as zin, zipfile.ZipFile(output_wheel, "w") as zout:
+        for info in zin.infolist():
+            data = zin.read(info.filename)
+            if info.filename == target_file:
+                text = data.decode("utf-8")
+
+                # Scrub paths
+                text = text.replace(prefix_with_slash, "")
+                text = text.replace(prefix, "")
+                text = bazel_out_re.sub("", text)
+                text = external_re.sub("", text)
+
+                # Scrub build machine metadata
+                text = build_cpu_re.sub(r"\1redacted\2", text)
+                text = build_cpu_family_re.sub(r"\1redacted\2", text)
+                text = build_cpu_system_re.sub(r"\1redacted\2", text)
+
+                data = text.encode("utf-8")
+                modified = True
+                print(f"Scrubbed build paths and metadata from {info.filename}", file=sys.stderr)
+            zout.writestr(info, data)
+
+    if modified:
+        print(f"Wrote scrubbed wheel to {output_wheel}", file=sys.stderr)
+    else:
+        print(f"No matching files found to scrub in {wheel_file.name}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/build_meson/deps/numpy/BUILD.bazel
+++ b/tests/e2e/build_meson/deps/numpy/BUILD.bazel
@@ -32,7 +32,14 @@ meson_build(
         "@uv//cython:pkg",
     ],
     config_settings = {
-        "setup-args": [],
+        "setup-args": [
+            # Explicitly set CPU feature baselines for reproducible builds.
+            # Without these, Meson's compile-only feature detection produces
+            # different results depending on the host clang binary (macOS-native
+            # vs Linux cross-compiler), even when both target the same arch.
+            "-Dcpu-baseline=neon",
+            "-Dcpu-dispatch=asimd,asimdhp,asimdfhm",
+        ],
         "compile-args": ["-v"],
     },
     copts = ["-Wl,-s"],

--- a/tests/e2e/build_meson/deps/numpy/BUILD.bazel
+++ b/tests/e2e/build_meson/deps/numpy/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_pycross//pycross:defs.bzl", "pycross_cc_pkg_config", "pycross_wheel_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
 load("@uv//_backend:meson_build.bzl", "meson_build")
 load(":numpy_headers.bzl", "numpy_cc_library")
@@ -18,6 +19,11 @@ py_console_script_binary(
     script = "cython",
 )
 
+py_binary(
+    name = "scrub_numpy",
+    srcs = ["scrub_numpy.py"],
+)
+
 meson_build(
     name = "wheel",
     build_deps = [
@@ -25,9 +31,6 @@ meson_build(
         "@uv//ninja:pkg",
         "@uv//cython:pkg",
     ],
-    build_env = {
-        "PYCROSS_SCRUB_PATHS": "numpy/__config__.py",
-    },
     config_settings = {
         "setup-args": [],
         "compile-args": ["-v"],
@@ -38,7 +41,7 @@ meson_build(
     ],
     path_tools = [":cython"],
     pkg_config_files = [":gen_openblas_pc_file"],
-    post_build_hooks = ["@rules_pycross//pycross/hooks:scrub_build_paths"],
+    post_build_hooks = [":scrub_numpy"],
     resource_size = "medium",
     sdist = "@uv//numpy:sdist",
 )

--- a/tests/e2e/build_meson/deps/numpy/BUILD.bazel
+++ b/tests/e2e/build_meson/deps/numpy/BUILD.bazel
@@ -25,6 +25,9 @@ meson_build(
         "@uv//ninja:pkg",
         "@uv//cython:pkg",
     ],
+    build_env = {
+        "PYCROSS_SCRUB_PATHS": "numpy/__config__.py",
+    },
     config_settings = {
         "setup-args": [],
         "compile-args": ["-v"],
@@ -35,6 +38,7 @@ meson_build(
     ],
     path_tools = [":cython"],
     pkg_config_files = [":gen_openblas_pc_file"],
+    post_build_hooks = ["@rules_pycross//pycross/hooks:scrub_build_paths"],
     resource_size = "medium",
     sdist = "@uv//numpy:sdist",
 )

--- a/tests/e2e/build_meson/deps/numpy/scrub_numpy.py
+++ b/tests/e2e/build_meson/deps/numpy/scrub_numpy.py
@@ -5,7 +5,6 @@ Scrubs paths and host CPU/OS metadata for reproducibility.
 
 import os
 import re
-import shutil
 import sys
 import zipfile
 from pathlib import Path
@@ -33,16 +32,16 @@ def main():
             data = zin.read(info.filename)
             if info.filename == target_file:
                 text = data.decode("utf-8")
-                
+
                 # Scrub paths
                 text = text.replace(prefix_with_slash, "")
                 text = text.replace(prefix, "")
                 text = bazel_out_re.sub("", text)
                 text = external_re.sub("", text)
-                
+
                 # Scrub specific toolchain path differences
                 text = toolchain_re.sub("llvm-toolchain-minimal-redacted", text)
-                
+
                 # Scrub build machine metadata
                 # We want to scrub ONLY the "build" block under "Machine Information"
                 # Simple state machine to find "build": { and scrub lines underneath
@@ -53,19 +52,19 @@ def main():
                         in_build_block = True
                         continue
                     if in_build_block:
-                        if '}' in line:
+                        if "}" in line:
                             in_build_block = False
                             continue
                         # Redact cpu, family, system
                         if '"cpu":' in line:
-                            lines[i] = re.sub(r'("cpu": ")[^"]+(")', r'\1redacted\2', line)
+                            lines[i] = re.sub(r'("cpu": ")[^"]+(")', r"\1redacted\2", line)
                         elif '"family":' in line:
-                            lines[i] = re.sub(r'("family": ")[^"]+(")', r'\1redacted\2', line)
+                            lines[i] = re.sub(r'("family": ")[^"]+(")', r"\1redacted\2", line)
                         elif '"system":' in line:
-                            lines[i] = re.sub(r'("system": ")[^"]+(")', r'\1redacted\2', line)
-                
+                            lines[i] = re.sub(r'("system": ")[^"]+(")', r"\1redacted\2", line)
+
                 text = "\n".join(lines) + "\n"
-                
+
                 data = text.encode("utf-8")
                 modified = True
                 print(f"Scrubbed build paths and metadata from {info.filename}", file=sys.stderr)

--- a/tests/e2e/build_meson/deps/numpy/scrub_numpy.py
+++ b/tests/e2e/build_meson/deps/numpy/scrub_numpy.py
@@ -1,0 +1,81 @@
+"""Custom post-build hook to scrub numpy build config.
+
+Scrubs paths and host CPU/OS metadata for reproducibility.
+"""
+
+import os
+import re
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+
+def main():
+    wheel_file = Path(os.environ["PYCROSS_WHEEL_FILE"])
+    output_dir = Path(os.environ["PYCROSS_WHEEL_OUTPUT_DIR"])
+    prefix = os.environ["PYCROSS_BAZEL_ROOT"]
+
+    prefix_with_slash = prefix + "/"
+    bazel_out_re = re.compile(r"bazel-out/[^/]+/bin/")
+    external_re = re.compile(r"external/")
+
+    # Regex to match toolchain minimal path in args
+    toolchain_re = re.compile(r"llvm-toolchain-minimal-[^/]+")
+
+    output_wheel = output_dir / wheel_file.name
+    modified = False
+
+    target_file = "numpy/__config__.py"
+
+    with zipfile.ZipFile(wheel_file, "r") as zin, zipfile.ZipFile(output_wheel, "w") as zout:
+        for info in zin.infolist():
+            data = zin.read(info.filename)
+            if info.filename == target_file:
+                text = data.decode("utf-8")
+                
+                # Scrub paths
+                text = text.replace(prefix_with_slash, "")
+                text = text.replace(prefix, "")
+                text = bazel_out_re.sub("", text)
+                text = external_re.sub("", text)
+                
+                # Scrub specific toolchain path differences
+                text = toolchain_re.sub("llvm-toolchain-minimal-redacted", text)
+                
+                # Scrub build machine metadata
+                # We want to scrub ONLY the "build" block under "Machine Information"
+                # Simple state machine to find "build": { and scrub lines underneath
+                lines = text.splitlines()
+                in_build_block = False
+                for i, line in enumerate(lines):
+                    if '"build": {' in line:
+                        in_build_block = True
+                        continue
+                    if in_build_block:
+                        if '}' in line:
+                            in_build_block = False
+                            continue
+                        # Redact cpu, family, system
+                        if '"cpu":' in line:
+                            lines[i] = re.sub(r'("cpu": ")[^"]+(")', r'\1redacted\2', line)
+                        elif '"family":' in line:
+                            lines[i] = re.sub(r'("family": ")[^"]+(")', r'\1redacted\2', line)
+                        elif '"system":' in line:
+                            lines[i] = re.sub(r'("system": ")[^"]+(")', r'\1redacted\2', line)
+                
+                text = "\n".join(lines) + "\n"
+                
+                data = text.encode("utf-8")
+                modified = True
+                print(f"Scrubbed build paths and metadata from {info.filename}", file=sys.stderr)
+            zout.writestr(info, data)
+
+    if modified:
+        print(f"Wrote scrubbed wheel to {output_wheel}", file=sys.stderr)
+    else:
+        print(f"No matching files found to scrub in {wheel_file.name}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/build_meson/third_party/openblas/BUILD.bazel
+++ b/tests/e2e/build_meson/third_party/openblas/BUILD.bazel
@@ -17,6 +17,11 @@ cmake(
             "TARGET": "HASWELL",
         },
         "@platforms//cpu:aarch64": {
+            "TARGET": "ARMV8",
+            "CMAKE_CROSSCOMPILING": "ON",
+            "CMAKE_SYSTEM_NAME": "Darwin",
+            "CMAKE_SYSTEM_PROCESSOR": "aarch64",
+            "BINARY": "64",
             "CMAKE_SIZEOF_VOID_P": "8",  # For some reason this is needed with later versions of zig
         },
         "//conditions:default": {},

--- a/tests/e2e/build_meson/third_party/openblas/BUILD.bazel
+++ b/tests/e2e/build_meson/third_party/openblas/BUILD.bazel
@@ -24,10 +24,14 @@ cmake(
             # Cross-compilation flags are required so OpenBLAS doesn't try to
             # detect the build host CPU (which would be x86_64 on Linux).
             "CMAKE_CROSSCOMPILING": "ON",
-            "CMAKE_SYSTEM_NAME": "Darwin",
             "CMAKE_SYSTEM_PROCESSOR": "aarch64",
             "BINARY": "64",
             "CMAKE_SIZEOF_VOID_P": "8",  # For some reason this is needed with later versions of zig
+        },
+        "//conditions:default": {},
+    }) | select({
+        "@platforms//os:macos": {
+            "CMAKE_SYSTEM_NAME": "Darwin",
         },
         "//conditions:default": {},
     }),

--- a/tests/e2e/build_meson/third_party/openblas/BUILD.bazel
+++ b/tests/e2e/build_meson/third_party/openblas/BUILD.bazel
@@ -17,7 +17,12 @@ cmake(
             "TARGET": "HASWELL",
         },
         "@platforms//cpu:aarch64": {
+            # ARMV8 is the generic ARMv8 baseline. For Apple Silicon specifically,
+            # VORTEX would provide better performance, but ARMV8 is the safe
+            # choice for reproducible cross-compilation.
             "TARGET": "ARMV8",
+            # Cross-compilation flags are required so OpenBLAS doesn't try to
+            # detect the build host CPU (which would be x86_64 on Linux).
             "CMAKE_CROSSCOMPILING": "ON",
             "CMAKE_SYSTEM_NAME": "Darwin",
             "CMAKE_SYSTEM_PROCESSOR": "aarch64",

--- a/tests/e2e/tools/compare_wheels.py
+++ b/tests/e2e/tools/compare_wheels.py
@@ -2,8 +2,8 @@
 """Compare wheels built on different hosts for reproducibility.
 
 For each target platform, finds matching .whl files from both build
-directories and compares them. Non-blocking: always exits 0, but
-prints detailed diagnostics when differences are found.
+directories and compares them. Exits with code 1 if any wheels differ,
+failing the CI check.
 """
 
 import difflib
@@ -125,7 +125,7 @@ def main():
         print("\n\U0001f389 All wheels are byte-identical across build hosts!")
     else:
         print("\n\u26a0\ufe0f  Some wheels differ. See details above.")
-        print("This is informational only \u2014 cross-host reproducibility is a goal, not a requirement.")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/meson_utils_test.py
+++ b/tests/unit/meson_utils_test.py
@@ -58,8 +58,10 @@ class MesonUtilsTest(unittest.TestCase):
         self.assertIn("c_args = ['-O2', '-fPIC']", content)
         self.assertIn("c_link_args = ['-Wl,-O1']", content)
 
+        # Even for native builds, default is needs_exe_wrapper=true for reproducibility
         self.assertIn("[properties]", content)
-        self.assertIn("needs_exe_wrapper = false", content)
+        self.assertIn("needs_exe_wrapper = true", content)
+        self.assertIn("skip_sanity_check = true", content)
 
     def test_generate_cross_ini_cross(self):
         # Make it a cross build by having target_python != exec_python
@@ -74,6 +76,40 @@ class MesonUtilsTest(unittest.TestCase):
         self.assertIn("system = 'linux'", content)
         self.assertIn("cpu_family = 'aarch64'", content)
         self.assertIn("needs_exe_wrapper = true", content)
+
+    def test_generate_cross_ini_allow_native_exec(self):
+        # With allow_native_exec, native builds should get needs_exe_wrapper=false
+        cc_config = {
+            "target_os": "linux",
+            "target_cpu": "x86_64",
+            "meson_properties": {"_allow_native_exec": "true"},
+        }
+        generate_cross_ini(self.ctx, cc_config)
+
+        cross_ini_path = self.temp_path / "cc_layer" / "cross.ini"
+        content = cross_ini_path.read_text()
+
+        self.assertIn("needs_exe_wrapper = false", content)
+        self.assertIn("skip_sanity_check = false", content)
+        # Internal property should not appear in the cross.ini output
+        self.assertNotIn("_allow_native_exec", content)
+
+    def test_generate_cross_ini_allow_native_exec_cross(self):
+        # With allow_native_exec but cross-compiling, should still be true
+        self.ctx.target_python = self.temp_path / "target_env" / "bin" / "python"
+
+        cc_config = {
+            "target_os": "linux",
+            "target_cpu": "aarch64",
+            "meson_properties": {"_allow_native_exec": "true"},
+        }
+        generate_cross_ini(self.ctx, cc_config)
+
+        cross_ini_path = self.temp_path / "cc_layer" / "cross.ini"
+        content = cross_ini_path.read_text()
+
+        self.assertIn("needs_exe_wrapper = true", content)
+        self.assertIn("skip_sanity_check = true", content)
 
 
 if __name__ == "__main__":

--- a/tests/unit/venv_utils_test.py
+++ b/tests/unit/venv_utils_test.py
@@ -46,7 +46,6 @@ class VenvUtilsTest(unittest.TestCase):
 
         # Assert PYTHONPATH
         self.assertIn('os.environ["PYTHONPATH"]', content)
-        self.assertIn("/mock/dep/path", content)
         self.assertIn("site-packages", content)
 
 


### PR DESCRIPTION
## Summary

Achieve byte-for-byte identical wheel builds across x86_64 Linux and aarch64 macOS build hosts. All wheels (Meson, CMake, Maturin/Rust) now produce identical artifacts regardless of which host architecture builds them.

## Changes by backend

### Meson (contourpy, numpy, pandas)

- **Force `needs_exe_wrapper = true`** by default — prevents Meson from running compiled test binaries on the build host, making feature detection depend on the hermetic toolchain rather than the host
- **Add `[build_machine]` section** to cross.ini matching `[host_machine]` — prevents Meson from sniffing the actual build host
- **Filter `-Wl,...` flags** from `c_args` into `c_link_args` — Bazel leaks linker flags into CFLAGS, which break Meson compile-only feature detection under `-Werror`
- **Set `-mcpu=apple-m1`** for darwin+aarch64 — ensures consistent ARM feature baseline across clang binaries (configurable via `_mcpu` meson property)
- **Inject `-fuse-ld=<lld>`** in CC wrapper for link invocations — ensures Meson link checks use the LLVM cross-linker
- **Add `post_build` callback** to `BackendStrategy` for backend-specific wheel post-processing
- **Add `scrub_build_paths` hook** (`//pycross/hooks:scrub_build_paths`) for stripping sandbox paths from wheel metadata
- **Custom numpy/contourpy scrub hooks** for package-specific build config files

### CMake (OpenBLAS)

- **Normalize `.so` permissions** in CMake builds
- **Force cross-compilation** for aarch64 with explicit `TARGET=ARMV8`, `CMAKE_CROSSCOMPILING=ON`
- **Separate CPU/OS selects** — `CMAKE_SYSTEM_NAME` now correctly selects on `@platforms//os:macos`

### Maturin/Rust (jiter)

- **`--remap-path-prefix`** — strips absolute sandbox paths from compiled binaries
- **`-C metadata=<deterministic hash>`** — replaces Cargo's host-tainted metadata with a hash over `(toolchain_version, crate_name, target_triple, crate_types, cfg_flags)`
- **`-C codegen-units=1`** — forces deterministic LLVM module ID generation
- **Disable SBOM generation** — maturin's CycloneDX SBOM contains random UUIDs and timestamps

### Shared infrastructure

- **Link-merge venv dependencies** — symlink dependency packages directly into site-packages instead of `.pth` files, improving compatibility with build systems
- **Enforce reproducibility in CI** — the repro check now fails the workflow on regression (`compare_wheels.py` exits 1 on mismatch)
