### PR TITLE
feat: merge wildcard backend overrides with package-specific overrides

### DIFF
--- a/pycross/private/lock_repo_creation.bzl
+++ b/pycross/private/lock_repo_creation.bzl
@@ -8,6 +8,7 @@ Used by both the legacy lock_repos extension and the unified locks extension.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@pycross_backends//:registry.bzl", "BACKEND_CONFIGS", "BACKEND_TO_RULE", "DEFAULT_BACKEND", "OVERRIDE_FILES")
 load("@pypackaging.bzl", "pypackaging")
+load("@rules_pycross//pycross/private:override_helpers.bzl", "merge_backend_overrides")
 load("@rules_pycross//pycross/private:sdist_repo.bzl", "pycross_sdist_repo")
 load("//pycross/private:package_repo.bzl", "package_repo")
 load("//pycross/private:pypi_file.bzl", "pypi_file")
@@ -223,11 +224,9 @@ def create_repos(
             def _apply_scope_overrides(src_key):
                 if src_key not in override_configs:
                     return
-                scope = override_configs[src_key]
-                source = scope.get(pkg_name, scope.get("*"))
-                if source:
-                    for b_name, b_attrs in source.items():
-                        pkg_overrides[b_name] = dict(b_attrs)
+                merged = merge_backend_overrides(override_configs[src_key], pkg_name)
+                for b_name, b_attrs in merged.items():
+                    pkg_overrides.setdefault(b_name, {}).update(b_attrs)
 
             ws_key = workspace_name
             _apply_scope_overrides(ws_key)

--- a/pycross/private/override_helpers.bzl
+++ b/pycross/private/override_helpers.bzl
@@ -11,6 +11,37 @@ Each backend extension follows the same pattern:
 
 load("@bazel_features//:features.bzl", "bazel_features")
 
+def merge_backend_overrides(scope, pkg_name):
+    """Merge wildcard and package-specific backend overrides.
+
+    Wildcard ("*") entries provide defaults. Package-specific entries override
+    individual fields. Fields are replaced, not merged (i.e. if both wildcard
+    and specific set copts, the specific value wins entirely).
+
+    Args:
+        scope: dict mapping package names (including "*") to
+            {backend_name: backend_attrs} dicts.
+        pkg_name: the normalized package name to look up.
+
+    Returns:
+        A merged dict of {backend_name: backend_attrs}, or empty dict.
+    """
+    result = {}
+    wildcard = scope.get("*")
+    specific = scope.get(pkg_name)
+
+    # Apply wildcard defaults first.
+    if wildcard:
+        for b_name, b_attrs in wildcard.items():
+            result.setdefault(b_name, {}).update(b_attrs)
+
+    # Overlay package-specific fields (individual attrs replace, not merge).
+    if specific:
+        for b_name, b_attrs in specific.items():
+            result.setdefault(b_name, {}).update(b_attrs)
+
+    return result
+
 def _overrides_repo_impl(rctx):
     """Simple repo that exports an overrides.json file."""
     rctx.file("overrides.json", rctx.attr.content)

--- a/tests/e2e/build_setuptools/MODULE.bazel
+++ b/tests/e2e/build_setuptools/MODULE.bazel
@@ -65,6 +65,17 @@ uv.package(
 )
 
 setuptools = use_extension("@rules_pycross//pycross/backends:setuptools.bzl", "setuptools")
+
+# Wildcard: default copts for all setuptools-built packages.
+# Tests wildcard+specific merging:
+#   - pyyaml inherits these copts alongside its specific build_env
+#   - zstandard's specific copts replace these
+#   - psycopg2 inherits these copts alongside its specific tool_deps
+setuptools.override(
+    name = "*",
+    copts = ["-O2"],
+    workspace = "uv",
+)
 setuptools.override(
     name = "psycopg2",
     tool_deps = {"pg_config": "@@//deps/psycopg2:pg_config"},
@@ -72,7 +83,10 @@ setuptools.override(
 )
 setuptools.override(
     name = "zstandard",
-    copts = ["-O2"],
+    copts = [
+        "-O2",
+        "-Wl,-s",
+    ],
     workspace = "uv",
 )
 setuptools.override(

--- a/tests/unit/test_override_helpers.bzl
+++ b/tests/unit/test_override_helpers.bzl
@@ -4,7 +4,7 @@ load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 load("@rules_testing//lib:util.bzl", "util")
 
 # buildifier: disable=bzl-visibility
-load("//pycross/private:override_helpers.bzl", "encode_build_system_attrs")
+load("//pycross/private:override_helpers.bzl", "encode_build_system_attrs", "merge_backend_overrides")
 
 # buildifier: disable=unused-variable
 def _test_encode_build_system_attrs_impl(env, target):
@@ -41,10 +41,177 @@ def _test_encode_build_system_attrs(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_encode_build_system_attrs_impl)
 
+# ---- merge_backend_overrides tests ----
+
+# buildifier: disable=unused-variable
+def _test_merge_wildcard_only_impl(env, target):
+    """Wildcard applies to all packages."""
+    scope = {
+        "*": {"setuptools_build": {"copts": json.encode(["-O2"])}},
+    }
+    result = merge_backend_overrides(scope, "numpy")
+    env.expect.that_dict(result).contains_exactly({
+        "setuptools_build": {"copts": json.encode(["-O2"])},
+    })
+
+def _test_merge_wildcard_only(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_merge_wildcard_only_impl)
+
+# buildifier: disable=unused-variable
+def _test_merge_specific_only_impl(env, target):
+    """Specific override with no wildcard."""
+    scope = {
+        "numpy": {"setuptools_build": {"native_deps": json.encode(["//openblas"])}},
+    }
+    result = merge_backend_overrides(scope, "numpy")
+    env.expect.that_dict(result).contains_exactly({
+        "setuptools_build": {"native_deps": json.encode(["//openblas"])},
+    })
+
+def _test_merge_specific_only(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_merge_specific_only_impl)
+
+# buildifier: disable=unused-variable
+def _test_merge_no_match_impl(env, target):
+    """Package not in scope and no wildcard returns empty."""
+    scope = {
+        "numpy": {"setuptools_build": {"copts": json.encode(["-O2"])}},
+    }
+    result = merge_backend_overrides(scope, "pandas")
+    env.expect.that_dict(result).keys().has_size(0)
+
+def _test_merge_no_match(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_merge_no_match_impl)
+
+# buildifier: disable=unused-variable
+def _test_merge_wildcard_and_specific_disjoint_fields_impl(env, target):
+    """Wildcard and specific with different fields: both are present."""
+    scope = {
+        "*": {"setuptools_build": {"copts": json.encode(["-O2"])}},
+        "numpy": {"setuptools_build": {"native_deps": json.encode(["//openblas"])}},
+    }
+    result = merge_backend_overrides(scope, "numpy")
+    env.expect.that_dict(result).contains_exactly({
+        "setuptools_build": {
+            "copts": json.encode(["-O2"]),
+            "native_deps": json.encode(["//openblas"]),
+        },
+    })
+
+def _test_merge_wildcard_and_specific_disjoint_fields(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_merge_wildcard_and_specific_disjoint_fields_impl)
+
+# buildifier: disable=unused-variable
+def _test_merge_specific_overrides_wildcard_field_impl(env, target):
+    """Specific value replaces wildcard for the same field (no list merge)."""
+    scope = {
+        "*": {"setuptools_build": {"copts": json.encode(["-O2"])}},
+        "numpy": {"setuptools_build": {"copts": json.encode(["-O3", "-mavx2"])}},
+    }
+    result = merge_backend_overrides(scope, "numpy")
+    env.expect.that_dict(result).contains_exactly({
+        "setuptools_build": {"copts": json.encode(["-O3", "-mavx2"])},
+    })
+
+def _test_merge_specific_overrides_wildcard_field(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_merge_specific_overrides_wildcard_field_impl)
+
+# buildifier: disable=unused-variable
+def _test_merge_unmatched_package_gets_wildcard_impl(env, target):
+    """A package without a specific override still gets the wildcard."""
+    scope = {
+        "*": {"setuptools_build": {"copts": json.encode(["-O2"])}},
+        "numpy": {"setuptools_build": {"native_deps": json.encode(["//openblas"])}},
+    }
+    result = merge_backend_overrides(scope, "pandas")
+    env.expect.that_dict(result).contains_exactly({
+        "setuptools_build": {"copts": json.encode(["-O2"])},
+    })
+
+def _test_merge_unmatched_package_gets_wildcard(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_merge_unmatched_package_gets_wildcard_impl)
+
+# buildifier: disable=unused-variable
+def _test_merge_multiple_backends_impl(env, target):
+    """Wildcard and specific can span different backends."""
+    scope = {
+        "*": {"setuptools_build": {"copts": json.encode(["-O2"])}},
+        "numpy": {"meson_build": {"native_deps": json.encode(["//openblas"])}},
+    }
+    result = merge_backend_overrides(scope, "numpy")
+
+    # Should have both backends.
+    env.expect.that_dict(result).keys().contains_exactly(["setuptools_build", "meson_build"])
+    env.expect.that_dict(result["setuptools_build"]).contains_exactly({
+        "copts": json.encode(["-O2"]),
+    })
+    env.expect.that_dict(result["meson_build"]).contains_exactly({
+        "native_deps": json.encode(["//openblas"]),
+    })
+
+def _test_merge_multiple_backends(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_merge_multiple_backends_impl)
+
+# buildifier: disable=unused-variable
+def _test_merge_multiple_backends_same_backend_merge_impl(env, target):
+    """Wildcard and specific both configure the same backend: attrs merge."""
+    scope = {
+        "*": {
+            "setuptools_build": {"copts": json.encode(["-O2"]), "linkopts": json.encode(["-lm"])},
+        },
+        "numpy": {
+            "setuptools_build": {"native_deps": json.encode(["//openblas"])},
+            "meson_build": {"copts": json.encode(["-O3"])},
+        },
+    }
+    result = merge_backend_overrides(scope, "numpy")
+
+    # setuptools_build should have wildcard copts+linkopts plus specific native_deps.
+    env.expect.that_dict(result["setuptools_build"]).contains_exactly({
+        "copts": json.encode(["-O2"]),
+        "linkopts": json.encode(["-lm"]),
+        "native_deps": json.encode(["//openblas"]),
+    })
+
+    # meson_build only from specific.
+    env.expect.that_dict(result["meson_build"]).contains_exactly({
+        "copts": json.encode(["-O3"]),
+    })
+
+def _test_merge_multiple_backends_same_backend_merge(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_merge_multiple_backends_same_backend_merge_impl)
+
+# buildifier: disable=unused-variable
+def _test_merge_empty_scope_impl(env, target):
+    """Empty scope returns empty dict."""
+    result = merge_backend_overrides({}, "numpy")
+    env.expect.that_dict(result).keys().has_size(0)
+
+def _test_merge_empty_scope(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_merge_empty_scope_impl)
+
 def override_helpers_test_suite(name):
     test_suite(
         name = name,
         tests = [
             _test_encode_build_system_attrs,
+            _test_merge_wildcard_only,
+            _test_merge_specific_only,
+            _test_merge_no_match,
+            _test_merge_wildcard_and_specific_disjoint_fields,
+            _test_merge_specific_overrides_wildcard_field,
+            _test_merge_unmatched_package_gets_wildcard,
+            _test_merge_multiple_backends,
+            _test_merge_multiple_backends_same_backend_merge,
+            _test_merge_empty_scope,
         ],
     )


### PR DESCRIPTION
Previously, setuptools.override(name="*", ...) and setuptools.override(name="numpy", ...) were mutually exclusive — the specific override completely replaced the wildcard. Now wildcard fields serve as defaults and package-specific fields override individual attrs (no list/dict merging).

Extract merge_backend_overrides() into override_helpers.bzl for testability and reuse.

- Add 9 unit tests for merge behavior
- Add wildcard override to build_setuptools e2e test