### PR TITLE
fix: rename pycross_wheel_headers wheel attr to wheel_library

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -219,7 +219,7 @@ Used in thin package repos when a uv_member specifies a target platform.
 <pre>
 load("@rules_pycross//pycross:defs.bzl", "pycross_wheel_headers")
 
-pycross_wheel_headers(<a href="#pycross_wheel_headers-name">name</a>, <a href="#pycross_wheel_headers-include_dir">include_dir</a>, <a href="#pycross_wheel_headers-make_variable">make_variable</a>, <a href="#pycross_wheel_headers-wheel">wheel</a>)
+pycross_wheel_headers(<a href="#pycross_wheel_headers-name">name</a>, <a href="#pycross_wheel_headers-include_dir">include_dir</a>, <a href="#pycross_wheel_headers-make_variable">make_variable</a>, <a href="#pycross_wheel_headers-wheel_library">wheel_library</a>)
 </pre>
 
 Extracts C/C++ headers from an installed wheel library.
@@ -238,7 +238,7 @@ configuration (e.g., Meson cross files).
 | <a id="pycross_wheel_headers-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="pycross_wheel_headers-include_dir"></a>include_dir |  Relative path within the wheel's site-packages to the include directory (e.g. 'numpy/_core/include').   | String | required |  |
 | <a id="pycross_wheel_headers-make_variable"></a>make_variable |  If set, export a TemplateVariableInfo with this name mapped to the absolutized include path.   | String | optional |  `""`  |
-| <a id="pycross_wheel_headers-wheel"></a>wheel |  A pycross_wheel_library target containing the headers.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="pycross_wheel_headers-wheel_library"></a>wheel_library |  A pycross_wheel_library target containing the headers.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 
 <a id="pycross_wheel_library"></a>

--- a/pycross/private/build/wheel_headers.bzl
+++ b/pycross/private/build/wheel_headers.bzl
@@ -9,9 +9,9 @@ load(
 )
 
 def _pycross_wheel_headers_impl(ctx):
-    unzipped_wheel = getattr(ctx.attr.wheel[PycrossExtractedWheelInfo], "site_packages", None)
+    unzipped_wheel = getattr(ctx.attr.wheel_library[PycrossExtractedWheelInfo], "site_packages", None)
     if not unzipped_wheel:
-        fail("The target provided to `wheel` does not provide an extracted site-packages directory. Make sure to use a `pycross_wheel_library` target.")
+        fail("The target provided to `wheel_library` does not provide an extracted site-packages directory. Make sure to use a `pycross_wheel_library` target.")
 
     include_dir_path = unzipped_wheel.path + "/site-packages/" + ctx.attr.include_dir
 
@@ -50,9 +50,10 @@ variable pointing to the absolute include path for use in build system
 configuration (e.g., Meson cross files).
 """,
     attrs = {
-        "wheel": attr.label(
+        "wheel_library": attr.label(
             doc = "A pycross_wheel_library target containing the headers.",
             mandatory = True,
+            providers = [PycrossExtractedWheelInfo],
         ),
         "include_dir": attr.string(
             doc = "Relative path within the wheel's site-packages to the include directory (e.g. 'numpy/_core/include').",

--- a/tests/analysis/pycross_wheel_headers_test.bzl
+++ b/tests/analysis/pycross_wheel_headers_test.bzl
@@ -34,7 +34,7 @@ def _test_pycross_wheel_headers_basic(name):
     util.helper_target(
         pycross_wheel_headers,
         name = name + "_subject",
-        wheel = name + "_wheel",
+        wheel_library = name + "_wheel",
         include_dir = "numpy/_core/include",
         make_variable = "NUMPY_INCLUDE",
     )
@@ -73,7 +73,7 @@ def _test_pycross_wheel_headers_no_make_variable(name):
     util.helper_target(
         pycross_wheel_headers,
         name = name + "_subject",
-        wheel = name + "_wheel",
+        wheel_library = name + "_wheel",
         include_dir = "numpy/_core/include",
     )
 

--- a/tests/e2e/build_meson/deps/numpy/numpy_headers.bzl
+++ b/tests/e2e/build_meson/deps/numpy/numpy_headers.bzl
@@ -6,7 +6,7 @@ def numpy_cc_library(name, numpy_wheel_dep, **kwargs):
     """Convenience macro for numpy headers."""
     pycross_wheel_headers(
         name = name,
-        wheel = numpy_wheel_dep,
+        wheel_library = numpy_wheel_dep,
         include_dir = "numpy/_core/include",
         make_variable = "NUMPY_INCLUDE_DIR",
         **kwargs


### PR DESCRIPTION
This rule doesn't take a `.whl` file, which one might expect with the
previous name. It takes a PycrossExtractedWheelInfo provider which is
returned by `pycross_wheel_library`.
