### PR TITLE
feat: add wheel_library_tags attribute to package annotations

### DIFF
--- a/pycross/private/format_extension.bzl
+++ b/pycross/private/format_extension.bzl
@@ -139,7 +139,38 @@ PACKAGE_ATTRS = dict(
     include_paths = attr.string_list(
         doc = "Override the auto-detected include paths.",
     ),
+    wheel_library_tags = attr.string_list(
+        doc = "Optional tags to apply to the generated pycross_wheel_library target.",
+    ),
 )
+
+def _tag_to_annotation_data(pkg, wildcard_pkg = None):
+    """Convert a normalized package tag struct to an annotation data dict.
+
+    Args:
+        pkg: A normalized package tag struct.
+        wildcard_pkg: Optional wildcard package tag struct for fallback values.
+
+    Returns:
+        A dict of annotation fields.
+    """
+    return json.decode(package_annotation(
+        always_build = pkg.always_build if pkg.always_build != None else (wildcard_pkg.always_build if wildcard_pkg else False),
+        extra_build_tools = pkg.extra_build_tools or (wildcard_pkg.extra_build_tools if wildcard_pkg else []),
+        build_tools_repo = pkg.build_tools_repo or (wildcard_pkg.build_tools_repo if wildcard_pkg else None),
+        build_target = str(pkg.build_target) if pkg.build_target else (str(wildcard_pkg.build_target) if wildcard_pkg and wildcard_pkg.build_target else None),
+        ignore_dependencies = pkg.ignore_dependencies or (wildcard_pkg.ignore_dependencies if wildcard_pkg else []),
+        install_exclude_globs = pkg.install_exclude_globs or (wildcard_pkg.install_exclude_globs if wildcard_pkg else []),
+        post_install_patches = pkg.post_install_patches or (wildcard_pkg.post_install_patches if wildcard_pkg else []),
+        pre_build_patches = pkg.pre_build_patches or (wildcard_pkg.pre_build_patches if wildcard_pkg else []),
+        site_hooks = pkg.site_hooks or (wildcard_pkg.site_hooks if wildcard_pkg else []),
+        build_backend = pkg.build_backend or (wildcard_pkg.build_backend if wildcard_pkg else None),
+        site_paths = pkg.site_paths or (wildcard_pkg.site_paths if wildcard_pkg else []),
+        bin_paths = pkg.bin_paths or (wildcard_pkg.bin_paths if wildcard_pkg else []),
+        data_paths = pkg.data_paths or (wildcard_pkg.data_paths if wildcard_pkg else []),
+        include_paths = pkg.include_paths or (wildcard_pkg.include_paths if wildcard_pkg else []),
+        wheel_library_tags = pkg.wheel_library_tags or (wildcard_pkg.wheel_library_tags if wildcard_pkg else []),
+    ))
 
 def _resolve_lock_inline(module_ctx, lock_info, serialized_lock_model, workspace_packages, repo_create_model_fn):
     """Run translator + resolver inline within module_ctx.
@@ -179,23 +210,10 @@ def _resolve_lock_inline(module_ctx, lock_info, serialized_lock_model, workspace
     wildcard_pkg = all_packages.pop("*", None)
 
     annotations_data = {}
+    if wildcard_pkg:
+        annotations_data["*"] = _tag_to_annotation_data(wildcard_pkg)
     for package_name, package in all_packages.items():
-        annotations_data[package_name] = json.decode(package_annotation(
-            always_build = package.always_build if package.always_build != None else (wildcard_pkg.always_build if wildcard_pkg else False),
-            extra_build_tools = package.extra_build_tools or (wildcard_pkg.extra_build_tools if wildcard_pkg else []),
-            build_tools_repo = package.build_tools_repo or (wildcard_pkg.build_tools_repo if wildcard_pkg else None),
-            build_target = str(package.build_target) if package.build_target else (str(wildcard_pkg.build_target) if wildcard_pkg and wildcard_pkg.build_target else None),
-            ignore_dependencies = package.ignore_dependencies or (wildcard_pkg.ignore_dependencies if wildcard_pkg else []),
-            install_exclude_globs = package.install_exclude_globs or (wildcard_pkg.install_exclude_globs if wildcard_pkg else []),
-            post_install_patches = package.post_install_patches or (wildcard_pkg.post_install_patches if wildcard_pkg else []),
-            pre_build_patches = package.pre_build_patches or (wildcard_pkg.pre_build_patches if wildcard_pkg else []),
-            site_hooks = package.site_hooks or (wildcard_pkg.site_hooks if wildcard_pkg else []),
-            build_backend = package.build_backend or (wildcard_pkg.build_backend if wildcard_pkg else None),
-            site_paths = package.site_paths or (wildcard_pkg.site_paths if wildcard_pkg else []),
-            bin_paths = package.bin_paths or (wildcard_pkg.bin_paths if wildcard_pkg else []),
-            data_paths = package.data_paths or (wildcard_pkg.data_paths if wildcard_pkg else []),
-            include_paths = package.include_paths or (wildcard_pkg.include_paths if wildcard_pkg else []),
-        ))
+        annotations_data[package_name] = _tag_to_annotation_data(package, wildcard_pkg)
 
     local_wheels = {}
     for w in lock_info.local_wheels:

--- a/pycross/private/lock_attrs.bzl
+++ b/pycross/private/lock_attrs.bzl
@@ -142,6 +142,9 @@ PACKAGE_ATTRS = dict(
     include_paths = attr.string_list(
         doc = "Override the auto-detected include paths.",
     ),
+    wheel_library_tags = attr.string_list(
+        doc = "Optional tags to apply to the generated pycross_wheel_library target.",
+    ),
 )
 
 # Attrs specific to build-system overrides (meson, setuptools, etc.).

--- a/pycross/private/lock_common.bzl
+++ b/pycross/private/lock_common.bzl
@@ -30,7 +30,8 @@ def package_annotation(
         site_paths = [],
         bin_paths = [],
         data_paths = [],
-        include_paths = []):
+        include_paths = [],
+        wheel_library_tags = []):
     """Annotations to apply to individual packages."""
     return json.encode(struct(
         always_build = always_build,
@@ -47,6 +48,7 @@ def package_annotation(
         bin_paths = bin_paths,
         data_paths = data_paths,
         include_paths = include_paths,
+        wheel_library_tags = wheel_library_tags,
     ))
 
 def check_unique_repo_name(owners, module_name, repo_name):
@@ -121,6 +123,7 @@ def normalize_package_tag(tag):
         bin_paths = tag.bin_paths,
         data_paths = tag.data_paths,
         include_paths = tag.include_paths,
+        wheel_library_tags = tag.wheel_library_tags,
     )
 
 def discover_uv_all_members(mctx, lock_file_label):

--- a/pycross/private/lock_repo_creation.bzl
+++ b/pycross/private/lock_repo_creation.bzl
@@ -18,7 +18,7 @@ load("//pycross/private:wheel_file.bzl", "pycross_wheel_file")
 load(":git_file.bzl", "pycross_git_file")
 
 # Annotation fields that affect pycross_wheel_library targets.
-_ANNOTATION_FIELDS = ["post_install_patches", "install_exclude_globs"]
+_ANNOTATION_FIELDS = ["post_install_patches", "install_exclude_globs", "wheel_library_tags"]
 
 def _disallowed_sdist_repo_impl(rctx):
     fail(

--- a/pycross/private/lock_resolver.bzl
+++ b/pycross/private/lock_resolver.bzl
@@ -80,6 +80,7 @@ def _apply_annotation(ann, versions_by_name, all_package_keys):
         bin_paths = ann.get("bin_paths", []),
         data_paths = ann.get("data_paths", []),
         include_paths = ann.get("include_paths", []),
+        wheel_library_tags = ann.get("wheel_library_tags", []),
     )
 
 def _collect_package_annotations(annotations_data, versions_by_name, all_package_keys):
@@ -254,6 +255,7 @@ def _create_package_resolver(pkg_key, pkg, ann, default_extra_build_tools, conte
         "bin_paths": ann.bin_paths if ann else [],
         "data_paths": ann.data_paths if ann else [],
         "include_paths": ann.include_paths if ann else [],
+        "wheel_library_tags": ann.wheel_library_tags if ann else [],
         "wheel_candidates": wheel_candidates,
         "uses_sdist": uses_sdist,
     }

--- a/pycross/private/package_repo.bzl
+++ b/pycross/private/package_repo.bzl
@@ -69,7 +69,7 @@ def _package_repo_impl(rctx):
     # Annotation fields that affect pycross_wheel_library targets.
     # If these differ between members for the same pkg_key, the package
     # is "conflicting" and gets per-member variant targets.
-    _ANNOTATION_FIELDS = ["post_install_patches", "install_exclude_globs"]
+    _ANNOTATION_FIELDS = ["post_install_patches", "install_exclude_globs", "wheel_library_tags"]
 
     # First pass: collect per-member package data, environment names, and cycle groups.
     member_packages = {}  # member_name -> {pkg_key -> pkg_data}

--- a/pycross/private/resolved_lock_renderer.bzl
+++ b/pycross/private/resolved_lock_renderer.bzl
@@ -525,6 +525,12 @@ def _render_marker_package(lines, pkg_key, pkg, packages, repo_map, sdist_map, r
             lines.append(_ind('"{}",'.format(patch), 3))
         lines.append(_ind("],", 2))
 
+    if pkg.get("wheel_library_tags"):
+        lines.append(_ind("tags = [", 2))
+        for tag in pkg["wheel_library_tags"]:
+            lines.append(_ind('"{}",'.format(tag), 3))
+        lines.append(_ind("],", 2))
+
     lines.extend([
         _ind(")"),
         "",

--- a/tests/unit/test_lock_resolver.bzl
+++ b/tests/unit/test_lock_resolver.bzl
@@ -1863,6 +1863,28 @@ def _test_wildcard_replace_semantics_exclude_globs_end_to_end(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_wildcard_replace_semantics_exclude_globs_end_to_end_impl)
 
+# buildifier: disable=unused-variable
+def _test_wheel_library_tags_impl(env, target):
+    lock_model_data = {
+        "packages": {
+            "foo@1.0": _make_pkg("foo", "1.0", [_make_file("foo-1.0-py3-none-any.whl")]),
+        },
+        "pins": {
+            "foo": "foo@1.0",
+        },
+    }
+    annotations_data = {
+        "foo": {"wheel_library_tags": ["no-remote"]},
+    }
+
+    res = resolve(lock_model_data, annotations_data = annotations_data)
+    foo_pkg = res.packages["foo@1.0"]
+    env.expect.that_collection(foo_pkg["wheel_library_tags"]).contains("no-remote")
+
+def _test_wheel_library_tags(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_wheel_library_tags_impl)
+
 def lock_resolver_test_suite(name):
     test_suite(
         name = name,
@@ -1926,5 +1948,6 @@ def lock_resolver_test_suite(name):
             _test_wildcard_build_tools_repo_flows_to_resolved_package,
             _test_wildcard_install_exclude_globs_end_to_end,
             _test_wildcard_replace_semantics_exclude_globs_end_to_end,
+            _test_wheel_library_tags,
         ],
     )

--- a/tests/unit/test_resolved_lock_renderer.bzl
+++ b/tests/unit/test_resolved_lock_renderer.bzl
@@ -672,6 +672,33 @@ def _test_resolution_marker_compound_rendering(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_resolution_marker_compound_rendering_impl)
 
+# buildifier: disable=unused-variable
+def _test_wheel_library_tags_rendering_impl(env, target):
+    """Verify that wheel_library_tags is rendered as tags on pycross_wheel_library."""
+    lock = {
+        "packages": {
+            "foo@1.0": {
+                "wheel_candidates": [
+                    {
+                        "filename": "foo-1.0-py3-none-any.whl",
+                        "file_reference": {"key": "foo_wheel"},
+                    },
+                ],
+                "wheel_library_tags": ["no-remote", "custom-tag"],
+            },
+        },
+    }
+    repo_map = {"foo_wheel": "@my_repo//foo:wheel"}
+    res = render_lock_bzl(lock, repo_map, "my_rctx")
+
+    env.expect.that_bool("tags = [" in res).equals(True)
+    env.expect.that_bool('"no-remote",' in res).equals(True)
+    env.expect.that_bool('"custom-tag",' in res).equals(True)
+
+def _test_wheel_library_tags_rendering(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_wheel_library_tags_rendering_impl)
+
 def resolved_lock_renderer_test_suite(name):
     test_suite(
         name = name,
@@ -688,5 +715,6 @@ def resolved_lock_renderer_test_suite(name):
             _test_no_available_when_all_have_sdist,
             _test_resolution_marker_evaluator_rendering,
             _test_resolution_marker_compound_rendering,
+            _test_wheel_library_tags_rendering,
         ],
     )


### PR DESCRIPTION
Add a new `wheel_library_tags` string list attribute to the `package`
tag, allowing users to apply custom Bazel tags (e.g. `no-remote`) to
generated `pycross_wheel_library` targets. This is useful for
controlling execution strategies in RBE builds.

The attribute flows through the full annotation pipeline:
- lock_attrs.bzl / format_extension.bzl: PACKAGE_ATTRS definition
- lock_common.bzl: package_annotation() and normalize_package_tag()
- lock_resolver.bzl: annotation parsing and propagation
- lock_repo_creation.bzl / package_repo.bzl: variant generation
- resolved_lock_renderer.bzl: tags rendered on pycross_wheel_library

Wildcards are supported: `package(name = "*", wheel_library_tags = [...])`
applies tags to all packages without explicit overrides.

Also refactored the annotation construction in format_extension.bzl:
extracted a `_tag_to_annotation_data` helper to eliminate two
near-identical field-by-field blocks, and fixed a pre-existing bug where
`annotations_data["*"]` was never populated in the bzlmod path,
preventing the resolver's wildcard logic from applying to packages
without explicit `package()` declarations.

Fixes https://github.com/jvolkman/rules_pycross/issues/215
