### PR TITLE
fix(v2): prioritize per-package lockfile index over workspace pypi_index

### DIFF
--- a/pycross/private/lock_repo_creation.bzl
+++ b/pycross/private/lock_repo_creation.bzl
@@ -140,10 +140,10 @@ def create_repos(
                     filename = file["name"],
                     sha256 = file["sha256"],
                 )
-                if pypi_index:
-                    pypi_file_attrs["index"] = pypi_index
-                elif file.get("index"):
+                if file.get("index"):
                     pypi_file_attrs["index"] = file["index"]
+                elif pypi_index:
+                    pypi_file_attrs["index"] = pypi_index
                 if file["name"].endswith(".whl"):
                     pycross_wheel_file(**pypi_file_attrs)
                 else:


### PR DESCRIPTION
This ensures that tools like Poetry and UV can still define per-package source index mappings in their locks, and rules_pycross will respect them rather than clobbering them with the workspace-level 'pypi_indexes' fallback. This fixes authentication to private package sources in lockfiles since pycross implicit netrc lookup will still work against the explicitly declared target server.
