### PR TITLE
fix: accept wheels with a local version segment

### DIFF
--- a/pycross/private/tools/wheel_installer.py
+++ b/pycross/private/tools/wheel_installer.py
@@ -93,7 +93,11 @@ def _validate_wheel_identity(
             f"but wheel filename has '{actual_name}'"
         )
 
-    if expected_version and actual_version != expected_version:
+    # A wheel filename may carry a local version segment (e.g. a CUDA
+    # build `3.0.0+cu130torch2110`) that the locked version (`3.0.0`) omits.
+    # Compare only the public version (everything before `+`) so such wheels
+    # are accepted while genuine version differences are still rejected.
+    if expected_version and actual_version.split("+", 1)[0] != expected_version.split("+", 1)[0]:
         raise SystemExit(
             f"error: wheel version mismatch for {wheel_path.name}: "
             f"expected version '{expected_version}' "

--- a/tests/unit/wheel_installer_test.py
+++ b/tests/unit/wheel_installer_test.py
@@ -161,6 +161,15 @@ class WheelInstallerValidationTest(unittest.TestCase):
             _validate_wheel_identity(whl, "six", "1.17.0")
         self.assertIn("wheel version mismatch", str(cm.exception))
 
+    def test_local_version_segment_passes(self):
+        from pycross.private.tools.wheel_installer import _validate_wheel_identity
+
+        # Wheel filename carries a PEP 440 local version segment (e.g. a CUDA
+        # build) that the locked version omits; only the public version is compared.
+        whl = self._create_wheel("foo-1.0+cu130-py3-none-any.whl", "foo", "1.0")
+        # Should not raise
+        _validate_wheel_identity(whl, "foo", "1.0")
+
     def test_none_expected_skips_check(self):
         from pycross.private.tools.wheel_installer import _validate_wheel_identity
 


### PR DESCRIPTION
Wheels may carry a local version segment (e.g. `3.0.0+cu130torch2110`) that the
lock's version (`3.0.0`) omits. Compare only the public version (before `+`) so
they install while genuine mismatches are still rejected.