### PR TITLE
Fix compatibility with repo contents cache

### DIFF
--- a/pycross/private/internal_repo.bzl
+++ b/pycross/private/internal_repo.bzl
@@ -112,6 +112,11 @@ def _resolve_python_interpreter(rctx):
         python_interpreter = rctx.path(rctx.attr.python_interpreter_target)
         if hasattr(rctx, "watch"):
             rctx.watch(python_interpreter)
+
+        # Keep the logical external-repository path. Resolving it can embed a
+        # transient repository contents-cache UUID in generated files.
+        return python_interpreter
+
     elif "/" not in python_interpreter:
         found_python_interpreter = rctx.which(python_interpreter)
         if not found_python_interpreter:


### PR DESCRIPTION
## Context
We recently experienced an incident at Canva where Bazel commands on some environments started failing with an error like this:

```
error loading package under directory 'tools': 
  error loading package 'tools/build/python/third_party':
    Encountered error while reading extension file 'requirements.bzl':
      no such package '@@rules_pycross++lock_repos+pypi//':
        no such package '@@rules_pycross++lock_import+pypi//':
          Unable to find the python executable
```

Inspecting the output base on these environments showed that the `rules_pycross_internal` bootstrapping venv contained a dangling symlink, pointing into an expired repo contents cache entry:
<img width="1809" height="248" alt="image" src="https://github.com/user-attachments/assets/5ea1ca5d-fccd-4262-9b1d-736644ab0c2f" />

This is because the repo rule `pycross_internal_repo` materialises the `realpath` of the interpreter target, rather than the logical external-repository path.

## Changes
Retain the logical path of the Python interpreter executable when rendering the `rules_pycross_internal` repo.

## Testing
I've boiled down the incident we had into a generic reproduction case, detailed below.

Set up a minimal Bzlmod workspace where:

- A Python interpreter is supplied by a reproducible external repository, so Bazel stores it in the repository-contents cache.
- `rules_pycross` is configured with `python_interpreter_target` pointing to that interpreter.
- A pycross environment repository is declared but has not yet been evaluated.

Then:

1. Use fresh output and cache directories, with deliberately tiny GC settings:

```text
--repo_contents_cache_gc_max_age=1ms
--repo_contents_cache_gc_idle_delay=1ms
```

2. Query only the canonical `rules_pycross_internal` repository. This creates its bootstrap virtualenv and records the interpreter path without evaluating the environment repository:

```sh
bazel query '@@rules_pycross++pycross+rules_pycross_internal//:*' \
  --repo_contents_cache="$CACHE" \
  --repo_contents_cache_gc_max_age=1ms \
  --repo_contents_cache_gc_idle_delay=1ms
```

3. Wait several seconds so the underlying interpreter’s cached contents are collected.

4. Query the previously untouched environment repository:

```sh
bazel query @pycross_environments//:environments \
  --repo_contents_cache="$CACHE" \
  --repo_contents_cache_gc_max_age=1ms \
  --repo_contents_cache_gc_idle_delay=1ms
```

Before the fix, this fails with:

```text
Unable to find the python executable
```

After the fix, the same query succeeds.
