### PR TITLE
Add repair exclude option

### DIFF
--- a/modules/backend_maturin/rules/maturin_build.bzl
+++ b/modules/backend_maturin/rules/maturin_build.bzl
@@ -109,6 +109,7 @@ def _maturin_build_impl(ctx):
         native_deps = ctx.attr.native_deps,
         repair_tool = ctx.executable._repair_tool,
         target_environment = target_environment,
+        repair_exclude = ctx.attr.repair_exclude,
         repair_deps = tool_deps.get("repairwheel", []),
         resource_set = resources.resource_set,
     )

--- a/modules/backend_maturin/rules/setuptools_rust_build.bzl
+++ b/modules/backend_maturin/rules/setuptools_rust_build.bzl
@@ -99,6 +99,7 @@ def _setuptools_rust_build_impl(ctx):
         native_deps = ctx.attr.native_deps,
         repair_tool = ctx.executable._repair_tool,
         target_environment = target_environment,
+        repair_exclude = ctx.attr.repair_exclude,
         repair_deps = tool_deps.get("repairwheel", []),
         resource_set = resources.resource_set,
     )

--- a/pycross/private/build/actions/repair_action.bzl
+++ b/pycross/private/build/actions/repair_action.bzl
@@ -10,6 +10,7 @@ def register_repair_action(
         repair_tool,
         native_deps = [],
         target_environment = None,
+        repair_exclude = [],
         repair_deps = [],
         resource_set = None):
     """Registers the repairwheel action to bundle native shared libs.
@@ -20,6 +21,7 @@ def register_repair_action(
         native_deps: list[Target], CcInfo deps whose shared libs to bundle.
         repair_tool: Target, the repair_wheel executable.
         target_environment: File (optional), the target environment JSON.
+        repair_exclude: list[str], Linux SONAME globs to leave unbundled.
         repair_deps: list[Target], optional PyInfo targets (e.g. user-provided
             repairwheel) whose site-packages are prepended to PYTHONPATH,
             shadowing the bundled version.
@@ -67,6 +69,9 @@ def register_repair_action(
 
     for d in depset(lib_dirs).to_list():
         args.add("--lib-dir", d)
+
+    for soname in repair_exclude:
+        args.add("--exclude", soname)
 
     if target_environment:
         args.add("--target-environment", target_environment.path)

--- a/pycross/private/build/repaired_wheel.bzl
+++ b/pycross/private/build/repaired_wheel.bzl
@@ -16,6 +16,7 @@ def _pycross_repaired_wheel_impl(ctx):
         native_deps = ctx.attr.native_deps,
         repair_tool = ctx.executable._repair_tool,
         target_environment = target_environment,
+        repair_exclude = ctx.attr.repair_exclude,
     )
 
     return [DefaultInfo(files = depset([repair_result.wheel_dir]))]
@@ -36,6 +37,9 @@ pycross_repaired_wheel = rule(
             doc = "The target environment mapping JSON (resolved dynamically via alias filegroup).",
             default = Label("@rules_pycross//pycross/private:default_target_platform"),
             allow_files = True,
+        ),
+        "repair_exclude": attr.string_list(
+            doc = "Linux SONAME globs to exclude from wheel repair; assumed provided at runtime.",
         ),
         "whldir_name": attr.string(
             doc = "Name for the output .whldir TreeArtifact directory. If empty, defaults to '{name}.whldir'.",

--- a/pycross/private/build/rules/cmake_build.bzl
+++ b/pycross/private/build/rules/cmake_build.bzl
@@ -83,6 +83,7 @@ def _cmake_build_impl(ctx):
         native_deps = ctx.attr.native_deps,
         repair_tool = ctx.executable._repair_tool,
         target_environment = target_environment,
+        repair_exclude = ctx.attr.repair_exclude,
         repair_deps = tool_deps.get("repairwheel", []),
         resource_set = resources.resource_set,
     )

--- a/pycross/private/build/rules/common_attrs.bzl
+++ b/pycross/private/build/rules/common_attrs.bzl
@@ -115,6 +115,9 @@ CC_BUILD_ATTRS = {
 }
 
 REPAIR_BUILD_ATTRS = {
+    "repair_exclude": attr.string_list(
+        doc = "Linux SONAME globs to exclude from wheel repair; assumed provided at runtime.",
+    ),
     "target_environment": attr.label(
         doc = "The target environment mapping JSON (resolved dynamically via alias filegroup).",
         default = Label("@rules_pycross//pycross/private:default_target_platform"),

--- a/pycross/private/build/rules/meson_build.bzl
+++ b/pycross/private/build/rules/meson_build.bzl
@@ -77,6 +77,7 @@ def _meson_build_impl(ctx):
         native_deps = ctx.attr.native_deps,
         repair_tool = ctx.executable._repair_tool,
         target_environment = target_environment,
+        repair_exclude = ctx.attr.repair_exclude,
         repair_deps = tool_deps.get("repairwheel", []),
         resource_set = resources.resource_set,
     )

--- a/pycross/private/build/rules/pep517_build.bzl
+++ b/pycross/private/build/rules/pep517_build.bzl
@@ -40,6 +40,7 @@ def _pep517_build_impl(ctx):
         input_wheel_dir = build_result.wheel_dir,
         repair_tool = ctx.executable._repair_tool,
         target_environment = target_environment,
+        repair_exclude = ctx.attr.repair_exclude,
         resource_set = resources.resource_set,
     )
 

--- a/pycross/private/build/rules/setuptools_build.bzl
+++ b/pycross/private/build/rules/setuptools_build.bzl
@@ -50,6 +50,7 @@ def _setuptools_build_impl(ctx):
         native_deps = ctx.attr.native_deps,
         repair_tool = ctx.executable._repair_tool,
         target_environment = target_environment,
+        repair_exclude = ctx.attr.repair_exclude,
         repair_deps = tool_deps.get("repairwheel", []),
         resource_set = resources.resource_set,
     )

--- a/pycross/private/build/tools/repair_wheel_hook.py
+++ b/pycross/private/build/tools/repair_wheel_hook.py
@@ -14,6 +14,9 @@ def main() -> None:
         "--lib-dir", action="append", default=[], help="Library directory for repairwheel (can be repeated)."
     )
     parser.add_argument("--target-environment", help="Path to target environment JSON for compatibility check.")
+    parser.add_argument(
+        "--exclude", action="append", default=[], help="Linux SONAME glob to exclude from repairwheel."
+    )
 
     args = parser.parse_args()
 
@@ -65,6 +68,9 @@ def main() -> None:
         cmd.extend(["--lib-dir", lp])
 
     from pycross.private.build.tools.utils.env import make_clean_env
+
+    for soname in args.exclude:
+        cmd.extend(["--exclude", soname])
 
     env = make_clean_env()
     python_path = list(sys.path)

--- a/tests/unit/BUILD.bazel
+++ b/tests/unit/BUILD.bazel
@@ -39,6 +39,15 @@ py_test(
     ],
 )
 
+py_test(
+    name = "repair_wheel_hook_test",
+    srcs = ["repair_wheel_hook_test.py"],
+    imports = ["../.."],
+    main = "repair_wheel_hook_test.py",
+    tags = ["unit"],
+    deps = ["//pycross/private/build/tools:repair_wheel_hook"],
+)
+
 common_attrs_test_suite(
     name = "test_common_attrs",
 )

--- a/tests/unit/repair_wheel_hook_test.py
+++ b/tests/unit/repair_wheel_hook_test.py
@@ -124,6 +124,45 @@ class RepairWheelHookArgsTest(unittest.TestCase):
         lib_dir_indices = [i for i, a in enumerate(call_args) if a == "--lib-dir"]
         self.assertEqual(len(lib_dir_indices), 2)
 
+    @patch("subprocess.check_call")
+    def test_excludes_passed_through(self, mock_check_call):
+        """--exclude arguments should be passed to repairwheel in order."""
+        self._create_dummy_wheel(self.wheel_dir)
+
+        def fake_repair(*args, **kwargs):
+            cmd = args[0]
+            for i, arg in enumerate(cmd):
+                if arg == "--output-dir":
+                    self._create_dummy_wheel(Path(cmd[i + 1]))
+                    break
+
+        mock_check_call.side_effect = fake_repair
+
+        from pycross.private.build.tools.repair_wheel_hook import main
+
+        with patch(
+            "sys.argv",
+            [
+                "repair_wheel_hook",
+                "--wheel-dir",
+                str(self.wheel_dir),
+                "--out-wheel-dir",
+                str(self.out_wheel_dir),
+                "--exclude",
+                "libtorch*.so",
+                "--exclude",
+                "libc10*.so",
+            ],
+        ):
+            main()
+
+        call_args = mock_check_call.call_args[0][0]
+        exclude_indices = [i for i, arg in enumerate(call_args) if arg == "--exclude"]
+        self.assertEqual(
+            [call_args[i + 1] for i in exclude_indices],
+            ["libtorch*.so", "libc10*.so"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add a `repair_exclude` attribute to all repair-capable wheel build rules.
- Forward each Linux SONAME glob as a repeatable `--exclude` argument to repairwheel.


## Dependency

This depends on https://github.com/jvolkman/repairwheel/pull/66, which adds repairwheel's `--exclude` option. The repairwheel dependency will need to be updated to a release containing that PR before this attribute is used.
