### PR TITLE
fix(uv): gate root marker dependencies

### DIFF
--- a/pycross/private/lock_resolver.bzl
+++ b/pycross/private/lock_resolver.bzl
@@ -252,6 +252,13 @@ def _create_package_resolver(pkg_key, pkg, ann, default_extra_build_tools, conte
     if always_build or build_target:
         wheel_candidates = []
 
+    # Markers under which the root projects request this exact pin; see
+    # _record_root_marker in uv_lock_model.bzl for the semantics.
+    root_pin_name = pkg_name
+    if pkg_extra:
+        root_pin_name = "{}[{}]".format(pkg_name, pkg_extra)
+    availability_markers = context.root_dependency_markers.get(root_pin_name, [])
+
     resolved_pkg = {
         "key": pkg_key,
         "name": pkg_name,
@@ -278,6 +285,7 @@ def _create_package_resolver(pkg_key, pkg, ann, default_extra_build_tools, conte
         "wheel_library_tags": ann.wheel_library_tags if ann else [],
         "wheel_candidates": wheel_candidates,
         "uses_sdist": uses_sdist,
+        "availability_markers": availability_markers,
     }
 
     return struct(
@@ -554,6 +562,7 @@ def resolve(
         local_wheels = local_wheels_by_pkg,
         remote_wheels = remote_wheels_by_pkg,
         always_include_sdist = always_include_sdist,
+        root_dependency_markers = lock_model_data.get("root_dependency_markers", {}),
     )
 
     lock_model_packages = lock_model_data.get("packages", {})

--- a/pycross/private/resolved_lock_renderer.bzl
+++ b/pycross/private/resolved_lock_renderer.bzl
@@ -90,6 +90,11 @@ def _collect_unique_markers(packages):
                 # We can share a single evaluator by setting extra to "".
                 effective_extra = extra if "extra" in marker else ""
                 markers[(marker, effective_extra)] = True
+
+        # Availability markers come from root project dependency edges, which
+        # never reference `extra`, so they share the extra-free evaluators.
+        for marker in pkg.get("availability_markers", []):
+            markers[(marker, "")] = True
     return markers.keys()
 
 def _marker_evaluator_name(marker_str, extra = ""):
@@ -280,10 +285,16 @@ def _render_marker_cycle_member_deps(lines, cycle_groups, packages):
             lines.append("")
 
 def _render_marker_wheel_chooser(lines, pkg_key, pkg, repo_map, sdist_map, rctx_name, sdist_target = None):
-    """Render a wheel chooser target and per-wheel config_settings + alias."""
+    """Render a wheel chooser target and per-wheel config_settings + alias.
+
+    Returns True when the wheel-based availability group was emitted under the
+    name _wheel_available_<pkg> because the package also carries availability
+    markers - the caller must then compose the two groups into the final
+    _available_<pkg> via _render_marker_availability(wheel_gated = True).
+    """
     candidates = pkg.get("wheel_candidates", [])
     if not candidates:
-        return
+        return False
 
     filenames = [c["filename"] for c in candidates]
     chooser_name = "_wheel_chooser_{}".format(pkg_key)
@@ -342,15 +353,19 @@ def _render_marker_wheel_chooser(lines, pkg_key, pkg, repo_map, sdist_map, rctx_
     # Availability config_setting_group: ORs all per-wheel config_settings.
     # Only emitted for packages that would fall to no_match_error (no sdist),
     # so that all_requirements can use select() to exclude them on incompatible
-    # platforms.
+    # platforms. When the package also carries availability markers, the group
+    # is named _wheel_available_ so _render_marker_availability can compose it
+    # with the marker-based group into the final _available_ group.
     if not sdist_target and resolved_candidates:
+        wheel_gated = bool(pkg.get("availability_markers"))
+        group_name = "_wheel_available_{}".format(pkg_key) if wheel_gated else "_available_{}".format(pkg_key)
         cs_names = []
         for candidate, _target in resolved_candidates:
             filename = candidate["filename"]
             cs_names.append(":_wheel_cs_{}_{}".format(pkg_key, _sanitize_name(filename)))
         lines.extend([
             _ind("selects.config_setting_group("),
-            _ind('name = "_available_{}",'.format(pkg_key), 2),
+            _ind('name = "{}",'.format(group_name), 2),
             _ind("match_any = [", 2),
         ])
         for cs in cs_names:
@@ -360,6 +375,8 @@ def _render_marker_wheel_chooser(lines, pkg_key, pkg, repo_map, sdist_map, rctx_
             _ind(")"),
             "",
         ])
+        return wheel_gated
+    return False
 
 def _render_marker_package_deps(lines, pkg_key, pkg_key_san, pkg, packages):
     """Render deps using marker-based select() instead of environment-based."""
@@ -399,6 +416,44 @@ def _render_marker_package_deps(lines, pkg_key, pkg_key_san, pkg, packages):
 
     lines.append("")
 
+def _render_marker_availability(lines, pkg_key, pkg, wheel_gated = False):
+    """Render an _available_<pkg> config_setting_group from availability markers.
+
+    No-op unless the package carries availability_markers. With wheel_gated,
+    the marker group is ANDed with the chooser's _wheel_available_<pkg> group;
+    otherwise the markers alone gate the package.
+    """
+    markers = pkg.get("availability_markers", [])
+    if not markers:
+        return
+    marker_group = "_available_{}".format(pkg_key)
+    if wheel_gated:
+        marker_group = "_marker_available_{}".format(pkg_key)
+    lines.extend([
+        _ind("selects.config_setting_group("),
+        _ind('name = "{}",'.format(marker_group), 2),
+        _ind("match_any = [", 2),
+    ])
+    for marker in markers:
+        eval_name = _marker_evaluator_name(marker, "")
+        lines.append(_ind('":{}_match",'.format(eval_name), 3))
+    lines.extend([
+        _ind("],", 2),
+        _ind(")"),
+        "",
+    ])
+    if wheel_gated:
+        lines.extend([
+            _ind("selects.config_setting_group("),
+            _ind('name = "_available_{}",'.format(pkg_key), 2),
+            _ind("match_all = [", 2),
+            _ind('":_wheel_available_{}",'.format(pkg_key), 3),
+            _ind('":{}",'.format(marker_group), 3),
+            _ind("],", 2),
+            _ind(")"),
+            "",
+        ])
+
 def _render_marker_package(lines, pkg_key, pkg, packages, repo_map, sdist_map, rctx_name):
     """Renders all targets for a single package using marker-based deps and wheel selection."""
     pkg_key_san = _sanitize_name(pkg_key)
@@ -425,6 +480,8 @@ def _render_marker_package(lines, pkg_key, pkg, packages, repo_map, sdist_map, r
         _render_marker_package_deps(lines, pkg_key, pkg_key_san, pkg, packages)
 
     if not has_wheel_candidates and extra:
+        _render_marker_availability(lines, pkg_key, pkg)
+
         # Extras packages wrap the base package plus their own deps.
         base_pkg_key = "{}@{}".format(package_name, package_version)
         lines.extend([
@@ -458,8 +515,9 @@ def _render_marker_package(lines, pkg_key, pkg, packages, repo_map, sdist_map, r
             sdist_target = "@@{}//:wheel".format(sdist_repo_name)
 
     # Wheel chooser
+    wheel_gated = False
     if has_wheel_candidates:
-        _render_marker_wheel_chooser(lines, pkg_key, pkg, repo_map, sdist_map, rctx_name, sdist_target = sdist_target)
+        wheel_gated = _render_marker_wheel_chooser(lines, pkg_key, pkg, repo_map, sdist_map, rctx_name, sdist_target = sdist_target)
     else:
         # No wheel candidates, alias directly to sdist_target or no_match_error
         target = sdist_target if sdist_target else "@rules_pycross//pycross/private:no_match_error"
@@ -470,6 +528,8 @@ def _render_marker_package(lines, pkg_key, pkg, packages, repo_map, sdist_map, r
             _ind(")"),
             "",
         ])
+
+    _render_marker_availability(lines, pkg_key, pkg, wheel_gated = wheel_gated)
 
     # Library
     lib_name = pkg_key
@@ -572,10 +632,13 @@ def render_lock_bzl(lock, repo_map, sdist_map = None, rctx_name = ""):
 
     # Check if selects.bzl is needed (for config_setting_group).
     # True for: packages with wheel candidates but no sdist fallback,
-    # or compound resolution-marker constraints.
+    # marker-restricted availability, or compound resolution-marker constraints.
     needs_selects = False
     for _pk, pkg_data in packages.items():
         if pkg_data.get("wheel_candidates") and not pkg_data.get("sdist_file") and not pkg_data.get("build_target"):
+            needs_selects = True
+            break
+        if pkg_data.get("availability_markers"):
             needs_selects = True
             break
     if not needs_selects:

--- a/pycross/private/thin_package_repo.bzl
+++ b/pycross/private/thin_package_repo.bzl
@@ -32,7 +32,9 @@ def requirement(pkg):
 """
 
 def _is_platform_specific(pkg):
-    """Check if a package is platform-specific (would be incompatible on some platforms)."""
+    """Check if a package is unavailable in some target environments."""
+    if pkg.get("availability_markers"):
+        return True
     has_wheels = bool(pkg.get("wheel_candidates"))
     has_sdist = bool(pkg.get("sdist_file")) or bool(pkg.get("build_target"))
     return has_wheels and not has_sdist
@@ -58,7 +60,10 @@ def _requirements_bzl(rctx, pins, packages):
 
         us_pin = underscore_name(pin_parts.name)
         if pin_parts.extra:
-            lines.append('    "@@{repo_name}//{pin}:[{extra}]",'.format(repo_name = rctx.name, pin = us_pin, extra = pin_parts.extra))
+            if is_conditional:
+                lines.append('    "@@{repo_name}//{pin}:[{extra}]_maybe",'.format(repo_name = rctx.name, pin = us_pin, extra = pin_parts.extra))
+            else:
+                lines.append('    "@@{repo_name}//{pin}:[{extra}]",'.format(repo_name = rctx.name, pin = us_pin, extra = pin_parts.extra))
         elif is_conditional:
             lines.append('    "@@{repo_name}//{pin}:{maybe}",'.format(repo_name = rctx.name, pin = us_pin, maybe = _safe_name(us_pin, "maybe")))
         else:
@@ -120,7 +125,7 @@ def _proxy_actual(actual_lines, target_dict, prefix, suffix, workspace_repo, ali
         return '"{}:{}",'.format(actual_pkg_ref, alias_name)
     return "{},".format(actual)
 
-def _pin_build(target_name, pin_target_dict, package, workspace_repo, workspace_lock_target_dict = None, has_aggregated_variant = False, extras_dict = None, default_variants = {}, target_platform = None, transition_bzl = None, maybe_available_key = None, testonly = False):
+def _pin_build(target_name, pin_target_dict, package, workspace_repo, workspace_lock_target_dict = None, has_aggregated_variant = False, extras_dict = None, default_variants = {}, target_platform = None, transition_bzl = None, maybe_available_key = None, extras_maybe_keys = None, testonly = False):
     """Generates the BUILD file for a pin directory, pointing to the workspace."""
     lock_target_dict = workspace_lock_target_dict if workspace_lock_target_dict else pin_target_dict
     lock_ref = "@{}//_lock:".format(workspace_repo)
@@ -248,6 +253,7 @@ def _pin_build(target_name, pin_target_dict, package, workspace_repo, workspace_
             ])
 
     extras_dict = extras_dict or {}
+    extras_maybe_keys = extras_maybe_keys or {}
     for extra_name, extra_target_dict in sorted(extras_dict.items()):
         actual_extra = _proxy_actual(actual_lines, extra_target_dict, lock_ref, "", workspace_repo, "extra_{}".format(extra_name), actual_pkg_ref, has_transition = has_transition, default_variants = default_variants)
         lines.extend([
@@ -263,6 +269,17 @@ def _pin_build(target_name, pin_target_dict, package, workspace_repo, workspace_
             ")",
             "",
         ])
+        if extra_name in extras_maybe_keys:
+            lines.extend([
+                "alias(",
+                '    name = "[{}]_maybe",'.format(extra_name),
+                "    actual = select({",
+                '        "@{}//_lock:_available_{}": ":[{}]",'.format(workspace_repo, extras_maybe_keys[extra_name], extra_name),
+                '        "//conditions:default": "//:_empty_library",',
+                "    }),",
+                ")",
+                "",
+            ])
 
     if maybe_available_key:
         lines.extend([
@@ -628,6 +645,14 @@ pycross_transitioning_file_proxy = rule(
                     maybe_available_key = pkg_key
                     break
 
+        extras_maybe_keys = {}
+        for extra_name, extra_target_dict in extras_dict.items():
+            for pkg_key in extra_target_dict.values():
+                pkg = packages.get(pkg_key, {})
+                if _is_platform_specific(pkg):
+                    extras_maybe_keys[extra_name] = pkg_key
+                    break
+
         result = _pin_build(
             us_name,
             base_target_dict,
@@ -640,6 +665,7 @@ pycross_transitioning_file_proxy = rule(
             target_platform = target_platform,
             transition_bzl = "//:_transition.bzl" if has_flags else None,
             maybe_available_key = maybe_available_key,
+            extras_maybe_keys = extras_maybe_keys,
             testonly = (base_pin_name in testonly_pins_set),
         )
         rctx.file(

--- a/pycross/private/translator_common.bzl
+++ b/pycross/private/translator_common.bzl
@@ -188,7 +188,7 @@ def _version_key(version_str):
     """Parse a version string into a comparable key tuple."""
     return pypackaging.version.parse(version_str).key
 
-def resolve_lock_graph(packages, pinned_package_specs, requires_python, strict_dependencies = True, variants = None, resolution_marker_exprs = None, testonly_pins = None):
+def resolve_lock_graph(packages, pinned_package_specs, requires_python, strict_dependencies = True, variants = None, resolution_marker_exprs = None, testonly_pins = None, root_dependency_markers = None):
     """Resolves a dependency graph of packages.
 
     Ports translator_utils.py resolve_lock_graph() to Starlark.
@@ -214,6 +214,10 @@ def resolve_lock_graph(packages, pinned_package_specs, requires_python, strict_d
         resolution_marker_exprs: Dict mapping constraint names to PEP 508
             marker expressions (optional). Used for resolution-marker forks.
         testonly_pins: List of pin names that are exclusively reachable from testonly groups.
+        root_dependency_markers: Dict mapping root pin names (including
+            extras) to the list of PEP 508 environment markers on the root
+            projects' dependency edges to them (optional). Only pins that are
+            exclusively requested under markers appear here.
 
     Returns:
         A dict in raw_lock.json format.
@@ -413,6 +417,9 @@ def resolve_lock_graph(packages, pinned_package_specs, requires_python, strict_d
 
     if resolution_marker_exprs:
         result["resolution_marker_exprs"] = resolution_marker_exprs
+
+    if root_dependency_markers:
+        result["root_dependency_markers"] = root_dependency_markers
 
     return result
 

--- a/pycross/private/uv_lock_model.bzl
+++ b/pycross/private/uv_lock_model.bzl
@@ -136,6 +136,21 @@ def _parse_uv_dependency(dep):
 
     return results
 
+def _record_root_marker(root_dependency_markers, name, marker):
+    """Accumulate the environment markers on a root project dependency.
+
+    A name maps to its root edges' markers, or to None once any unmarked
+    (i.e. unconditional) edge is seen.
+    """
+    if name in root_dependency_markers and root_dependency_markers[name] == None:
+        return
+    if not marker:
+        root_dependency_markers[name] = None
+        return
+    existing = root_dependency_markers.get(name, [])
+    if marker not in existing:
+        root_dependency_markers[name] = existing + [marker]
+
 def translate_uv(project_dict, lock_dict, lock_model):
     """Translates UV project and lock data to raw_lock_data dict.
 
@@ -273,6 +288,10 @@ def translate_uv(project_dict, lock_dict, lock_model):
     # Collect requirements
     requirements = []  # list of (req_name, specifier, constraint, is_testonly)
 
+    # Root dependency markers per exact pin; extras also record their implied
+    # base package marker. See _record_root_marker.
+    root_dependency_markers = {}
+
     for project_name in target_projects:
         project_info = workspace_members[project_name]
 
@@ -313,8 +332,13 @@ def translate_uv(project_dict, lock_dict, lock_model):
                 if dep_extras:
                     for extra in dep_extras:
                         pin_name = "{}[{}]".format(dep_name, canonicalize_name(extra))
+                        _record_root_marker(root_dependency_markers, pin_name, dep.get("marker", ""))
                         requirements.append((pin_name, specifier, fork_constraint, default_is_testonly))
-                else:
+
+                # An extras pin implies its base package, so the base records
+                # the same marker (an unmarked extras edge unlocks the base).
+                _record_root_marker(root_dependency_markers, base_dep_name, dep.get("marker", ""))
+                if not dep_extras:
                     requirements.append((dep_name, specifier, fork_constraint, default_is_testonly))
 
         for kind, groups_dict, constraint_dict in [("optional", optional_dependencies, extra_variant_values), ("group", development_dependencies, group_variant_values)]:
@@ -350,8 +374,12 @@ def translate_uv(project_dict, lock_dict, lock_model):
                     if dep_extras:
                         for extra in dep_extras:
                             pin_name = "{}[{}]".format(dep_name, canonicalize_name(extra))
+                            _record_root_marker(root_dependency_markers, pin_name, dep.get("marker", ""))
                             requirements.append((pin_name, specifier, effective_constraint, is_testonly))
-                    else:
+
+                    # See the default-dependencies loop: base shares the edge's marker.
+                    _record_root_marker(root_dependency_markers, base_dep_name, dep.get("marker", ""))
+                    if not dep_extras:
                         requirements.append((dep_name, specifier, effective_constraint, is_testonly))
 
     # End collect requirements
@@ -502,6 +530,11 @@ def translate_uv(project_dict, lock_dict, lock_model):
         variants = variant_sets,
         resolution_marker_exprs = resolution_marker_exprs,
         testonly_pins = testonly_pin_names,
+        root_dependency_markers = {
+            name: markers
+            for name, markers in root_dependency_markers.items()
+            if markers != None
+        },
     )
 
 def repo_create_uv_model(rctx, extra_project_files, lock_file, lock_model, output):

--- a/tests/unit/test_thin_package_repo.bzl
+++ b/tests/unit/test_thin_package_repo.bzl
@@ -337,6 +337,34 @@ def _test_pin_build_transition_bzl_variants(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_pin_build_transition_bzl_variants_impl)
 
+# ── Test: marked build targets and extras use maybe aliases ─────────
+
+# buildifier: disable=unused-variable
+def _test_requirements_bzl_root_marker_aliases_impl(env, target):
+    mock_rctx = struct(name = "my_repo")
+    pins = {
+        "foo": {"": "foo@1.0"},
+        "foo[linux-extra]": {"": "foo[linux-extra]@1.0"},
+    }
+    packages = {
+        "foo@1.0": {"build_target": "@//custom:foo"},
+        "foo[linux-extra]@1.0": {
+            "build_target": "@//custom:foo_extra",
+            "availability_markers": ["sys_platform == \"linux\""],
+        },
+    }
+    res = requirements_bzl_for_testing(mock_rctx, pins, packages)
+
+    # The unconditional base remains unconditional. Only the marked extra
+    # selects the empty library away on incompatible platforms.
+    env.expect.that_bool("@@my_repo//foo\"" in res).equals(True)
+    env.expect.that_bool("@@my_repo//foo:maybe" not in res).equals(True)
+    env.expect.that_bool("@@my_repo//foo:[linux-extra]_maybe" in res).equals(True)
+
+def _test_requirements_bzl_root_marker_aliases(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_requirements_bzl_root_marker_aliases_impl)
+
 # ── Test suite ─────────────────────────────────────────────────────
 
 # ── Test: _is_platform_specific ────────────────────────────────────
@@ -477,5 +505,6 @@ def thin_package_repo_test_suite(name):
             _test_requirements_bzl_maybe_aliases,
             _test_requirements_bzl_all_unconditional,
             _test_requirements_bzl_extra_pins,
+            _test_requirements_bzl_root_marker_aliases,
         ],
     )

--- a/tests/unit/test_uv_translator.bzl
+++ b/tests/unit/test_uv_translator.bzl
@@ -715,6 +715,34 @@ def _test_uv_testonly_wildcard_overrides_earlier(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_uv_testonly_wildcard_overrides_earlier_impl)
 
+# --- test_root_dependency_markers ---
+
+# buildifier: disable=unused-variable
+def _test_uv_root_dependency_markers_impl(env, target):
+    project = _project(deps = [
+        "foo==1.0",
+        "foo[linux-extra]==1.0 ; sys_platform == \"linux\"",
+    ])
+    lock = _lock([
+        _vpkg("my-app", deps = [
+            _dep("foo", "1.0"),
+            _dep("foo", "1.0", marker = "sys_platform == \"linux\"", extra = ["linux-extra"]),
+        ]),
+        _pkg("foo", "1.0", wheels = [_whl("foo-1.0-py3-none-any.whl", "foo")], opt_deps = {"linux-extra": []}),
+    ])
+    result = translate_uv(project, lock, _lock_model())
+
+    # The unmarked base pin is available everywhere. The marked extra remains
+    # separate so its marker cannot make the extra available on other platforms.
+    markers = result["root_dependency_markers"]
+    env.expect.that_collection(markers.keys()).contains("foo[linux-extra]")
+    env.expect.that_collection(markers.keys()).contains_none_of(["foo"])
+    env.expect.that_str(markers["foo[linux-extra]"][0]).equals("sys_platform == \"linux\"")
+
+def _test_uv_root_dependency_markers(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_uv_root_dependency_markers_impl)
+
 # --- Test suite ---
 
 def uv_translator_test_suite(name):
@@ -747,5 +775,6 @@ def uv_translator_test_suite(name):
             _test_uv_testonly_shared_dep_not_testonly,
             _test_uv_testonly_wildcard_with_override,
             _test_uv_testonly_wildcard_overrides_earlier,
+            _test_uv_root_dependency_markers,
         ],
     )


### PR DESCRIPTION
## Summary

Packages with an sdist or `build_target`, and extras pins, previously added unconditional entries to `all_requirements`. This happened even when the root project requested the package only under a marker such as `sys_platform == 'linux'`.

A consumer of `all_requirements`, such as a host venv on macOS, then analysed a Linux-only package and failed.

This change records root dependency markers during UV lock translation. It gates packages when all root dependency edges have markers:

- Base packages use `:maybe`.
- Extras pins use `[extra]_maybe`.
- On a platform where the marker does not match, the target resolves to an empty Python library.

Packages with an unmarked root edge, or a marker only on a transitive dependency, are unchanged.


## Example

Given:

```toml
dependencies = [
    "cuda-kernels ; sys_platform == 'linux'",
]
```

and a Linux-only `build_target`, `all_requirements` previously contained:
```
"@pypi//cuda_kernels"
```
A macOS build then failed during analysis:

```
ERROR: Target //tools:setup_venv is incompatible and cannot be built, but was explicitly requested.
Dependency chain:
    //tools:setup_venv
    @@rules_pycross++uv+pypi//cuda_kernels:cuda_kernels
    @@rules_pycross++uv+pypi//cuda_kernels:pkg
    @@rules_pycross++uv+pypi__pkgs//_lock:cuda-kernels@1.0.0
    @@rules_pycross++uv+pypi__pkgs//_lock:_wheel_cuda-kernels@1.0.0
    //third_party/cuda_kernels:cuda_kernels_wheel <-- target platform didn't satisfy constraint @platforms//:incompatible
```
Now the thin repository provides:
```starlark
alias(
    name = "maybe",
    actual = select({
        "@pypi__pkgs//_lock:_available_cuda-kernels@1.0.0": ":pkg",
        "//conditions:default": "//:_empty_library",
    }),
)
```
`all_requirements` uses `"@pypi//cuda_kernels:maybe"`. On macOS, it resolves to the empty library.

## Testing
Regression coverage verifies:
- Markers are recorded per exact pin, including extras.
- An unmarked base package stays unconditional when one extra is Linux-only.
- A marked custom-build extra uses its `[extra]_maybe` alias.