### PR TITLE
feat: gate root marker dependencies in pdm, poetry, and pylock translators

### DIFF
--- a/pycross/private/pdm_lock_model.bzl
+++ b/pycross/private/pdm_lock_model.bzl
@@ -11,6 +11,7 @@ load(
     "canonicalize_name",
     "compute_requested_dependency_groups",
     "parse_pep508_requirement",
+    "record_root_marker",
     "resolution_marker_constraint_name",
     "resolve_lock_graph",
     "select_project_file",
@@ -165,8 +166,14 @@ def translate_pdm(project_dict, lock_dict, lock_model):
     pinned_package_specs = {}
     testonly_reqs = {}
     non_testonly_reqs = {}
+    root_dependency_markers = {}
     for req, is_testonly in requirements:
         pinned_package_specs[req.name] = {"": req.specifier}
+        if req.extras:
+            for extra in req.extras:
+                pin_name = "{}[{}]".format(req.name, canonicalize_name(extra))
+                record_root_marker(root_dependency_markers, pin_name, req.marker)
+        record_root_marker(root_dependency_markers, req.name, req.marker)
         if is_testonly:
             testonly_reqs[req.name] = True
         else:
@@ -250,6 +257,11 @@ def translate_pdm(project_dict, lock_dict, lock_model):
         strict_dependencies = False,
         resolution_marker_exprs = resolution_marker_exprs,
         testonly_pins = testonly_pin_names,
+        root_dependency_markers = {
+            name: markers
+            for name, markers in root_dependency_markers.items()
+            if markers != None
+        },
     )
 
 def repo_create_pdm_model(rctx, extra_project_files, lock_file, lock_model, output):

--- a/pycross/private/poetry_lock_model.bzl
+++ b/pycross/private/poetry_lock_model.bzl
@@ -17,6 +17,7 @@ load(
     "canonicalize_name",
     "compute_requested_dependency_groups",
     "parse_pep508_requirement",
+    "record_root_marker",
     "resolution_marker_constraint_name",
     "resolve_lock_graph",
     "select_project_file",
@@ -258,6 +259,15 @@ def _get_files_for_package(files, package_name, package_version):
 
     return result
 
+def _extract_poetry_marker(info_dict):
+    if not info_dict:
+        return ""
+    if "markers" in info_dict:
+        return info_dict["markers"]
+    if "platform" in info_dict:
+        return 'sys_platform == "{}"'.format(info_dict["platform"])
+    return ""
+
 def _parse_poetry_pin(pin, pin_info, pinned_package_specs, track_pin, enrich_only = False):
     """Parse a Poetry dependency pin into pinned_package_specs.
 
@@ -278,18 +288,18 @@ def _parse_poetry_pin(pin, pin_info, pinned_package_specs, track_pin, enrich_onl
     # We don't propagate is_testonly here directly because pinned_package_specs
     # is now managed by the track_pin callback passed to us.
 
-    def track_spec(spec):
+    def track_spec(spec, marker = ""):
         # Do not overwrite a specific existing constraint with a wildcard if enrich_only is set.
         if enrich_only and existing_spec and not spec:
             return
-        track_pin(pin, spec)
+        track_pin(pin, spec, marker)
 
     if type(pin_info) == "string":
-        track_spec(_poetry_constraint_to_pep440(pin_info))
+        track_spec(_poetry_constraint_to_pep440(pin_info), "")
     elif type(pin_info) == "dict":
         if "path" in pin_info or pin_info.get("optional"):
             return
-        track_spec(_poetry_constraint_to_pep440(pin_info.get("version", "*")))
+        track_spec(_poetry_constraint_to_pep440(pin_info.get("version", "*")), _extract_poetry_marker(pin_info))
     elif type(pin_info) == "list":
         # List-of-dicts: each entry may have version, markers, url, python, etc.
         for entry in pin_info:
@@ -302,7 +312,7 @@ def _parse_poetry_pin(pin, pin_info, pinned_package_specs, track_pin, enrich_onl
 
             if enrich_only and existing_spec and not spec:
                 continue
-            track_pin(pin, spec)
+            track_spec(spec, _extract_poetry_marker(entry))
 
 def translate_poetry(project_dict, lock_dict, lock_model):
     """Translates Poetry project and lock data to raw_lock_data dict.
@@ -354,14 +364,16 @@ def translate_poetry(project_dict, lock_dict, lock_model):
 
     testonly_reqs = {}
     non_testonly_reqs = {}
+    root_dependency_markers = {}
 
-    def track_pin(pin_name, specifier, is_testonly):
+    def track_pin(pin_name, specifier, is_testonly, marker = ""):
         pinned_package_specs.setdefault(pin_name, {})
         pinned_package_specs[pin_name][""] = specifier
         if is_testonly:
             testonly_reqs[pin_name] = True
         else:
             non_testonly_reqs[pin_name] = True
+        record_root_marker(root_dependency_markers, pin_name, marker)
 
     project_optional_deps = project_dict.get("project", {}).get("optional-dependencies", {})
     pep735_groups = project_dict.get("dependency-groups", {})
@@ -390,7 +402,11 @@ def translate_poetry(project_dict, lock_dict, lock_model):
                 req = parse_pep508_requirement(dep_str)
                 if req.name == "python":
                     continue
-                track_pin(req.name, req.specifier, default_is_testonly)
+                if req.extras:
+                    for extra in req.extras:
+                        pin_name = "{}[{}]".format(req.name, canonicalize_name(extra))
+                        record_root_marker(root_dependency_markers, pin_name, req.marker)
+                track_pin(req.name, req.specifier, default_is_testonly, req.marker)
         if poetry_deps:
             # Also merge [tool.poetry.dependencies] if present
             for pin, pin_info in poetry_deps.items():
@@ -405,7 +421,7 @@ def translate_poetry(project_dict, lock_dict, lock_model):
                     pin,
                     pin_info,
                     pinned_package_specs,
-                    track_pin = lambda p, spec: track_pin(p, spec, default_is_testonly),
+                    track_pin = lambda p, spec, marker: track_pin(p, spec, default_is_testonly, marker),
                     enrich_only = has_project_deps,
                 )
 
@@ -417,7 +433,11 @@ def translate_poetry(project_dict, lock_dict, lock_model):
                 req = parse_pep508_requirement(dep_str)
                 if req.name == "python":
                     continue
-                track_pin(req.name, req.specifier, is_testonly)
+                if req.extras:
+                    for extra in req.extras:
+                        pin_name = "{}[{}]".format(req.name, canonicalize_name(extra))
+                        record_root_marker(root_dependency_markers, pin_name, req.marker)
+                track_pin(req.name, req.specifier, is_testonly, req.marker)
 
     for group_name in available_dev_groups:
         key = "group:{}".format(group_name)
@@ -430,7 +450,12 @@ def translate_poetry(project_dict, lock_dict, lock_model):
                     req = parse_pep508_requirement(dep_str)
                     if req.name == "python":
                         continue
-                    track_pin(canonicalize_name(req.name), req.specifier, is_testonly)
+                    canonical_name = canonicalize_name(req.name)
+                    if req.extras:
+                        for extra in req.extras:
+                            pin_name = "{}[{}]".format(canonical_name, canonicalize_name(extra))
+                            record_root_marker(root_dependency_markers, pin_name, req.marker)
+                    track_pin(canonical_name, req.specifier, is_testonly, req.marker)
 
             if group_name in poetry_groups:
                 g = poetry_groups[group_name]
@@ -442,7 +467,7 @@ def translate_poetry(project_dict, lock_dict, lock_model):
                         pin,
                         pin_info,
                         pinned_package_specs,
-                        track_pin = lambda p, spec: track_pin(p, spec, is_testonly),
+                        track_pin = lambda p, spec, marker: track_pin(p, spec, is_testonly, marker),
                     )
 
     testonly_pin_names = [name for name in testonly_reqs if name not in non_testonly_reqs]
@@ -605,6 +630,11 @@ def translate_poetry(project_dict, lock_dict, lock_model):
         strict_dependencies = True,
         resolution_marker_exprs = resolution_marker_exprs,
         testonly_pins = testonly_pin_names,
+        root_dependency_markers = {
+            name: markers
+            for name, markers in root_dependency_markers.items()
+            if markers != None
+        },
     )
 
 def repo_create_poetry_model(rctx, extra_project_files, lock_file, lock_model, output):

--- a/pycross/private/pylock_lock_model.bzl
+++ b/pycross/private/pylock_lock_model.bzl
@@ -6,8 +6,16 @@ lock_resolver.bzl.
 """
 
 load("@toml.bzl//toml:toml.bzl", "decode")
-load(":translator_common.bzl", "canonicalize_name", "compute_requested_dependency_groups", "resolution_marker_constraint_name", "select_project_file")
-load(":util.bzl", "extract_pep508_name", "parse_package_key")
+load(
+    ":translator_common.bzl",
+    "canonicalize_name",
+    "compute_requested_dependency_groups",
+    "parse_pep508_requirement",
+    "record_root_marker",
+    "resolution_marker_constraint_name",
+    "select_project_file",
+)
+load(":util.bzl", "parse_package_key")
 
 def _strip_selection_markers(marker):
     """Strip PDM selection markers (dependency_groups, extras) from a marker string.
@@ -192,10 +200,9 @@ def translate_pylock(lock_dict, project_dict, lock_model):
     pins = {}
 
     dependency_groups = getattr(lock_model, "dependency_groups", ["default"])
-    include_default = "default" in dependency_groups or "*" in dependency_groups
-    has_filter = not include_default or len([g for g in dependency_groups if g != "default"]) > 0
+    root_dependency_markers = {}
 
-    if project_dict and has_filter:
+    if project_dict:
         root_req_names = []
         testonly_root_req_names = []
         testonly_groups = getattr(lock_model, "testonly_groups", [])
@@ -222,13 +229,23 @@ def translate_pylock(lock_dict, project_dict, lock_model):
             fail_on_missing = False,  # Following precedent set by original print warning
         )
 
+        def handle_dep_str(dep_str, is_testonly):
+            req = parse_pep508_requirement(dep_str)
+            n = req.name
+            if is_testonly:
+                testonly_root_req_names.append(n)
+            else:
+                root_req_names.append(n)
+            if req.extras:
+                for extra in req.extras:
+                    pin_name = "{}[{}]".format(n, canonicalize_name(extra))
+                    record_root_marker(root_dependency_markers, pin_name, req.marker)
+            record_root_marker(root_dependency_markers, n, req.marker)
+
         if "default" in requested_groups_dict:
             is_testonly = requested_groups_dict["default"]
             for dep_str in project_section.get("dependencies", []):
-                if is_testonly:
-                    testonly_root_req_names.append(extract_pep508_name(dep_str))
-                else:
-                    root_req_names.append(extract_pep508_name(dep_str))
+                handle_dep_str(dep_str, is_testonly)
 
         for kind, groups_dict in [("optional", optional_deps), ("group", dev_deps)]:
             for target_name in groups_dict.keys():
@@ -239,21 +256,13 @@ def translate_pylock(lock_dict, project_dict, lock_model):
                 entries = groups_dict[target_name]
                 for entry in entries:
                     if type(entry) == "string":
-                        n = extract_pep508_name(entry)
-                        if is_testonly:
-                            testonly_root_req_names.append(n)
-                        else:
-                            root_req_names.append(n)
+                        handle_dep_str(entry, is_testonly)
                     elif type(entry) == "dict" and "include-group" in entry:
                         inc_group = entry["include-group"]
                         if inc_group in dev_deps:
                             for inc_dep in dev_deps[inc_group]:
                                 if type(inc_dep) == "string":
-                                    n = extract_pep508_name(inc_dep)
-                                    if is_testonly:
-                                        testonly_root_req_names.append(n)
-                                    else:
-                                        root_req_names.append(n)
+                                    handle_dep_str(inc_dep, is_testonly)
 
         # Deduplicate
         root_package_names = {n: True for n in root_req_names}
@@ -342,6 +351,13 @@ def translate_pylock(lock_dict, project_dict, lock_model):
     }
     if resolution_marker_exprs:
         result["resolution_marker_exprs"] = resolution_marker_exprs
+    filtered_root_markers = {
+        name: markers
+        for name, markers in root_dependency_markers.items()
+        if markers != None
+    }
+    if filtered_root_markers:
+        result["root_dependency_markers"] = filtered_root_markers
     return result
 
 def repo_create_pylock_model(rctx, extra_project_files, lock_file, lock_model, output):

--- a/pycross/private/translator_common.bzl
+++ b/pycross/private/translator_common.bzl
@@ -11,6 +11,26 @@ def canonicalize_name(name):
     """Canonicalize a Python package name per PEP 503."""
     return pypackaging.utils.canonicalize_name(name)
 
+def record_root_marker(root_dependency_markers, name, marker):
+    """Accumulate the environment markers on a root project dependency.
+
+    A name maps to its root edges' markers, or to None once any unmarked
+    (i.e. unconditional) edge is seen.
+
+    Args:
+        root_dependency_markers: Dict mapping pin names to list of marker strings or None.
+        name: Canonicalized package or extra pin name.
+        marker: PEP 508 environment marker string.
+    """
+    if name in root_dependency_markers and root_dependency_markers[name] == None:
+        return
+    if not marker:
+        root_dependency_markers[name] = None
+        return
+    existing = root_dependency_markers.get(name, [])
+    if marker not in existing:
+        root_dependency_markers[name] = existing + [marker]
+
 def resolution_marker_constraint_name(name, version):
     """Generate a deterministic constraint name for a resolution-marker fork.
 

--- a/pycross/private/uv_lock_model.bzl
+++ b/pycross/private/uv_lock_model.bzl
@@ -13,6 +13,7 @@ load(
     ":translator_common.bzl",
     "canonicalize_name",
     "compute_requested_dependency_groups",
+    "record_root_marker",
     "resolution_marker_constraint_name",
     "resolve_lock_graph",
     "select_project_file",
@@ -136,20 +137,7 @@ def _parse_uv_dependency(dep):
 
     return results
 
-def _record_root_marker(root_dependency_markers, name, marker):
-    """Accumulate the environment markers on a root project dependency.
-
-    A name maps to its root edges' markers, or to None once any unmarked
-    (i.e. unconditional) edge is seen.
-    """
-    if name in root_dependency_markers and root_dependency_markers[name] == None:
-        return
-    if not marker:
-        root_dependency_markers[name] = None
-        return
-    existing = root_dependency_markers.get(name, [])
-    if marker not in existing:
-        root_dependency_markers[name] = existing + [marker]
+_record_root_marker = record_root_marker
 
 def translate_uv(project_dict, lock_dict, lock_model):
     """Translates UV project and lock data to raw_lock_data dict.

--- a/tests/unit/test_pdm_translator.bzl
+++ b/tests/unit/test_pdm_translator.bzl
@@ -328,6 +328,37 @@ def _test_pdm_resolution_forks(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_pdm_resolution_forks_impl)
 
+# --- test_root_dependency_markers ---
+
+# buildifier: disable=unused-variable
+def _test_pdm_root_dependency_markers_impl(env, target):
+    project = _minimal_project(deps = [
+        "foo==1.0 ; sys_platform == \"linux\"",
+        "bar==2.0",
+    ])
+    lock = _minimal_lock([
+        {
+            "name": "foo",
+            "version": "1.0",
+            "files": [_whl("foo-1.0-py3-none-any.whl")],
+        },
+        {
+            "name": "bar",
+            "version": "2.0",
+            "files": [_whl("bar-2.0-py3-none-any.whl")],
+        },
+    ])
+    result = translate_pdm(project, lock, _lock_model())
+
+    markers = result["root_dependency_markers"]
+    env.expect.that_collection(markers.keys()).contains("foo")
+    env.expect.that_collection(markers.keys()).contains_none_of(["bar"])
+    env.expect.that_str(markers["foo"][0]).equals("sys_platform == \"linux\"")
+
+def _test_pdm_root_dependency_markers(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_pdm_root_dependency_markers_impl)
+
 # --- Test suite ---
 
 def pdm_translator_test_suite(name):
@@ -344,5 +375,6 @@ def pdm_translator_test_suite(name):
             _test_pdm_extras_in_markers,
             _test_pdm_extra_dependency,
             _test_pdm_resolution_forks,
+            _test_pdm_root_dependency_markers,
         ],
     )

--- a/tests/unit/test_pdm_translator.bzl
+++ b/tests/unit/test_pdm_translator.bzl
@@ -328,7 +328,7 @@ def _test_pdm_resolution_forks(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_pdm_resolution_forks_impl)
 
-# --- test_root_dependency_markers ---
+# --- test_pdm_root_dependency_markers ---
 
 # buildifier: disable=unused-variable
 def _test_pdm_root_dependency_markers_impl(env, target):

--- a/tests/unit/test_poetry_translator.bzl
+++ b/tests/unit/test_poetry_translator.bzl
@@ -446,6 +446,43 @@ def _test_poetry_or_constraint_translations(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_poetry_or_constraint_translations_impl)
 
+# --- test_root_dependency_markers ---
+
+# buildifier: disable=unused-variable
+def _test_poetry_root_dependency_markers_impl(env, target):
+    project = {
+        "tool": {"poetry": {
+            "name": "my-app",
+            "version": "0.1.0",
+            "dependencies": {
+                "python": "^3.8",
+                "foo": {"version": "1.0", "markers": "sys_platform == 'linux'"},
+                "bar": {"version": "2.0", "platform": "darwin"},
+                "baz": "3.0",
+            },
+        }},
+    }
+    lock = {
+        "metadata": {"lock-version": "2.1"},
+        "package": [
+            _pkg("foo", "1.0", files = [_whl("foo-1.0-py3-none-any.whl")]),
+            _pkg("bar", "2.0", files = [_whl("bar-2.0-py3-none-any.whl")]),
+            _pkg("baz", "3.0", files = [_whl("baz-3.0-py3-none-any.whl")]),
+        ],
+    }
+    result = translate_poetry(project, lock, _lock_model())
+
+    markers = result["root_dependency_markers"]
+    env.expect.that_collection(markers.keys()).contains("foo")
+    env.expect.that_collection(markers.keys()).contains("bar")
+    env.expect.that_collection(markers.keys()).contains_none_of(["baz"])
+    env.expect.that_str(markers["foo"][0]).equals("sys_platform == 'linux'")
+    env.expect.that_str(markers["bar"][0]).equals('sys_platform == "darwin"')
+
+def _test_poetry_root_dependency_markers(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_poetry_root_dependency_markers_impl)
+
 # --- Test suite ---
 
 def poetry_translator_test_suite(name):
@@ -466,5 +503,6 @@ def poetry_translator_test_suite(name):
             _test_poetry_issue_34,
             _test_poetry_issue_117,
             _test_poetry_or_constraint_translations,
+            _test_poetry_root_dependency_markers,
         ],
     )

--- a/tests/unit/test_poetry_translator.bzl
+++ b/tests/unit/test_poetry_translator.bzl
@@ -446,7 +446,7 @@ def _test_poetry_or_constraint_translations(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_poetry_or_constraint_translations_impl)
 
-# --- test_root_dependency_markers ---
+# --- test_poetry_root_dependency_markers ---
 
 # buildifier: disable=unused-variable
 def _test_poetry_root_dependency_markers_impl(env, target):

--- a/tests/unit/test_pylock_translator.bzl
+++ b/tests/unit/test_pylock_translator.bzl
@@ -500,6 +500,46 @@ def _test_pylock_resolution_forks(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_pylock_resolution_forks_impl)
 
+# --- test_root_dependency_markers ---
+
+# buildifier: disable=unused-variable
+def _test_pylock_root_dependency_markers_impl(env, target):
+    project = {
+        "project": {
+            "name": "my-project",
+            "dependencies": [
+                "foo==1.0 ; sys_platform == \"linux\"",
+                "bar==2.0",
+            ],
+        },
+    }
+    lock = {
+        "lock-version": "1.0",
+        "requires-python": ">=3.8",
+        "package": [
+            {
+                "name": "foo",
+                "version": "1.0",
+                "wheels": [_whl("foo-1.0-py3-none-any.whl", "foo")],
+            },
+            {
+                "name": "bar",
+                "version": "2.0",
+                "wheels": [_whl("bar-2.0-py3-none-any.whl", "bar")],
+            },
+        ],
+    }
+    result = translate_pylock(lock, project, _lock_model())
+
+    markers = result.get("root_dependency_markers", {})
+    env.expect.that_collection(markers.keys()).contains("foo")
+    env.expect.that_collection(markers.keys()).contains_none_of(["bar"])
+    env.expect.that_str(markers["foo"][0]).equals("sys_platform == \"linux\"")
+
+def _test_pylock_root_dependency_markers(name):
+    util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
+    analysis_test(name = name, target = name + "_subject", impl = _test_pylock_root_dependency_markers_impl)
+
 # --- Test suite ---
 
 def pylock_translator_test_suite(name):
@@ -521,5 +561,6 @@ def pylock_translator_test_suite(name):
             _test_pylock_sdist_parsing,
             _test_pylock_no_default_no_groups_empty,
             _test_pylock_resolution_forks,
+            _test_pylock_root_dependency_markers,
         ],
     )

--- a/tests/unit/test_pylock_translator.bzl
+++ b/tests/unit/test_pylock_translator.bzl
@@ -500,7 +500,7 @@ def _test_pylock_resolution_forks(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_pylock_resolution_forks_impl)
 
-# --- test_root_dependency_markers ---
+# --- test_pylock_root_dependency_markers ---
 
 # buildifier: disable=unused-variable
 def _test_pylock_root_dependency_markers_impl(env, target):

--- a/tests/unit/test_uv_translator.bzl
+++ b/tests/unit/test_uv_translator.bzl
@@ -715,7 +715,7 @@ def _test_uv_testonly_wildcard_overrides_earlier(name):
     util.helper_target(native.filegroup, name = name + "_subject", srcs = [])
     analysis_test(name = name, target = name + "_subject", impl = _test_uv_testonly_wildcard_overrides_earlier_impl)
 
-# --- test_root_dependency_markers ---
+# --- test_uv_root_dependency_markers ---
 
 # buildifier: disable=unused-variable
 def _test_uv_root_dependency_markers_impl(env, target):


### PR DESCRIPTION
Extract root dependency environment markers in PDM, Poetry, and Pylock
lock model translators so that platform-specific root dependencies are
properly gated via availability_markers in all_requirements and :maybe aliases.

- Move record_root_marker helper to translator_common.bzl
- Extract markers and extras markers in pdm_lock_model.bzl
- Extract markers (including platform shorthand) in poetry_lock_model.bzl
- Extract markers via parse_pep508_requirement in pylock_lock_model.bzl
- Add unit tests for PDM, Poetry, and Pylock translators
